### PR TITLE
Match parallel tests for AppKit projects

### DIFF
--- a/Sources/XcbeautifyLib/Matcher.swift
+++ b/Sources/XcbeautifyLib/Matcher.swift
@@ -39,6 +39,7 @@ struct Matcher {
     static let noCertificateMatcher = Regex(pattern: .noCertificate)
     static let parallelTestCaseFailedMatcher = Regex(pattern: .parallelTestCaseFailed)
     static let parallelTestCasePassedMatcher = Regex(pattern: .parallelTestCasePassed)
+    static let parallelTestCaseAppKitPassedMatcher = Regex(pattern: .parallelTestCaseAppKitPassed)
     static let parallelTestingStartedMatcher = Regex(pattern: .parallelTestingStarted)
     static let pbxcpMatcher = Regex(pattern: .pbxcp)
     static let phaseScriptExecutionMatcher = Regex(pattern: .phaseScriptExecution)

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -134,6 +134,8 @@ public class Parser {
             return line.beautify(pattern: .moduleIncludesError)
         case Matcher.parallelTestCasePassedMatcher:
             return line.beautify(pattern: .parallelTestCasePassed)
+        case Matcher.parallelTestCaseAppKitPassedMatcher:
+            return line.beautify(pattern: .parallelTestCaseAppKitPassed)
         case Matcher.parallelTestCaseFailedMatcher:
             return line.beautify(pattern: .parallelTestCaseFailed)
         case Matcher.parallelTestingStartedMatcher:

--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -157,6 +157,12 @@ enum Pattern: String {
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = test case
+    /// $3 = time
+    case parallelTestCaseAppKitPassed = "\\s*Test case\\s'-\\[(.*)\\s(.*)\\]'\\spassed\\son\\s'.*'\\s\\((\\d*\\.\\d{3})\\sseconds\\)"
+
+    /// Regular expression captured groups:
+    /// $1 = suite
+    /// $2 = test case
     /// $3 = device
     /// $4 = installed app file and ID (e.g. MyApp.app (12345))
     /// $5 = time

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -37,6 +37,7 @@ extension String {
              .testCaseMeasured,
              .testsRunCompletion,
              .parallelTestCasePassed,
+             .parallelTestCaseAppKitPassed,
              .parallelTestCaseFailed:
             return formatTest(pattern: pattern)
         case .codesign,
@@ -260,6 +261,10 @@ extension String {
             let device = groups[2]
             let time = groups[4]
             return indent + TestStatus.pass.rawValue.foreground.Green + " " + testCase + " on '\(device)' (\(time.coloredTime()) seconds)"
+        case .parallelTestCaseAppKitPassed:
+            let testCase = groups[1]
+            let time = groups[2]
+            return indent + TestStatus.pass.rawValue.foreground.Green + " " + testCase + " (\(time.coloredTime()) seconds)"
         case .parallelTestCaseFailed:
             let testCase = groups[1]
             let device = groups[2]

--- a/Tests/XcbeautifyLibTests/XCTestManifests.swift
+++ b/Tests/XcbeautifyLibTests/XCTestManifests.swift
@@ -42,6 +42,7 @@ extension XcbeautifyLibTests {
         ("testNoCertificate", testNoCertificate),
         ("testParallelTestCaseFailed", testParallelTestCaseFailed),
         ("testParallelTestCasePassed", testParallelTestCasePassed),
+        ("testParallelTestCaseAppKitPassed", testParallelTestCaseAppKitPassed),
         ("testParallelTestingStarted", testParallelTestingStarted),
         ("testPbxcp", testPbxcp),
         ("testPhaseScriptExecution", testPhaseScriptExecution),

--- a/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
+++ b/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
@@ -157,6 +157,17 @@ final class XcbeautifyLibTests: XCTestCase {
         XCTAssertTrue(formatted.contains("0.131"))
     }
 
+    func testParallelTestCaseAppKitPassed() {
+        let original = "Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed on 'xctest (49438)' (0.131 seconds)."
+        guard let formatted = Parser().parse(line: original) else {
+            XCTFail()
+            return
+        }
+        XCTAssertTrue(formatted.contains(TestStatus.pass.rawValue))
+        XCTAssertTrue(formatted.contains("testBuildTarget"))
+        XCTAssertTrue(formatted.contains("0.131"))
+    }
+
     func testParallelTestingStarted() {
     }
 


### PR DESCRIPTION
Closes #4 

## What has been done

As parallel tests cases for iOS seem to have a wildly different pattern than parallel test cases for AppKit, I opted to copy the parallel test case pattern. Now there are 2 cases for passed parallel tests: AppKit and non-AppKit. That's maybe not ideal architecturally, but it scratches my itch.

A test was added for this new case.

## What has not been done

Everything else for AppKit. I've tested `xcbeautify` with other AppKit tests of the same product and the result is not fully matched. The passed test cases were the most important for me, but I'd also need to print anything that doesn't match (which I don't think `xcbeautify` does at the moment).