### PR TITLE
display a banner and warning or error in the quiet mode

### DIFF
--- a/Sources/XcbeautifyLib/Constants.swift
+++ b/Sources/XcbeautifyLib/Constants.swift
@@ -13,3 +13,11 @@ enum Symbol: String {
     case warning = "⚠️"
     case asciiWarning = "[!]"
 }
+
+public enum OutputType {
+    case undefined
+    case task
+    case warning
+    case error
+    case result
+}

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -1,156 +1,226 @@
+public enum OutputType {
+    case UNDEFINED
+    case TASK
+    case WARN_ERR
+    case RESULT
+}
+
 public class Parser {
     public init() {}
 
-    public var quiet: Bool = false
-
     public var summary: TestSummary? = nil
 
+    public var outputType: OutputType = .UNDEFINED
+
     public func parse(line: String, colored: Bool = true) -> String? {
-        if !quiet {
-            switch line {
+        switch line {
             case Matcher.analyzeMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .analyze, colored: colored)
             case Matcher.buildTargetMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .buildTarget, colored: colored)
             case Matcher.aggregateTargetMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .aggregateTarget, colored: colored)
             case Matcher.analyzeTargetMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .analyzeTarget, colored: colored)
             case Matcher.checkDependenciesMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .checkDependencies, colored: colored)
             case Matcher.shellCommandMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .shellCommand, colored: colored)
             case Matcher.cleanRemoveMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .cleanRemove, colored: colored)
             case Matcher.cleanTargetMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .cleanTarget, colored: colored)
             case Matcher.codesignFrameworkMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .codesignFramework, colored: colored)
             case Matcher.codesignMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .codesign, colored: colored)
             case Matcher.compileMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .compile, colored: colored)
             case Matcher.compileCommandMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .compileCommand, colored: colored)
             case Matcher.compileXibMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .compileXib, colored: colored)
             case Matcher.compileStoryboardMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .compileStoryboard, colored: colored)
             case Matcher.copyHeaderMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .copyHeader, colored: colored)
             case Matcher.copyPlistMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .copyPlist, colored: colored)
             case Matcher.copyStringsMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .copyStrings, colored: colored)
             case Matcher.cpresourceMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .cpresource, colored: colored)
             case Matcher.executedMatcher:
+                outputType = .TASK
                 parseSummary(line: line, colored: colored)
                 return nil
             case Matcher.failingTestMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .failingTest, colored: colored)
             case Matcher.uiFailingTestMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .uiFailingTest, colored: colored)
             case Matcher.restartingTestsMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .restartingTests, colored: colored)
             case Matcher.generateDsymMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .generateDsym, colored: colored)
             case Matcher.libtoolMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .libtool, colored: colored)
             case Matcher.linkingMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .linking, colored: colored)
             case Matcher.testCasePassedMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .testCasePassed, colored: colored)
             case Matcher.testCaseStartedMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .testCaseStarted, colored: colored)
             case Matcher.testCasePendingMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .testCasePending, colored: colored)
             case Matcher.testCaseMeasuredMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .testCaseMeasured, colored: colored)
             case Matcher.phaseSuccessMatcher:
+                outputType = .RESULT
                 return line.beautify(pattern: .phaseSuccess, colored: colored)
             case Matcher.phaseScriptExecutionMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .phaseScriptExecution, colored: colored)
             case Matcher.processPchMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .processPch, colored: colored)
             case Matcher.processPchCommandMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .processPchCommand, colored: colored)
             case Matcher.preprocessMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .preprocess, colored: colored)
             case Matcher.pbxcpMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .pbxcp, colored: colored)
             case Matcher.processInfoPlistMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .processInfoPlist, colored: colored)
             case Matcher.testsRunCompletionMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .testsRunCompletion, colored: colored)
             case Matcher.testSuiteStartedMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .testSuiteStarted, colored: colored)
             case Matcher.testSuiteStartMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .testSuiteStart, colored: colored)
             case Matcher.tiffutilMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .tiffutil, colored: colored)
             case Matcher.touchMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .touch, colored: colored)
             case Matcher.writeFileMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .writeFile, colored: colored)
             case Matcher.writeAuxiliaryFilesMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .writeAuxiliaryFiles, colored: colored)
             case Matcher.parallelTestCasePassedMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .parallelTestCasePassed, colored: colored)
             case Matcher.parallelTestCaseAppKitPassedMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .parallelTestCaseAppKitPassed, colored: colored)
             case Matcher.parallelTestingStartedMatcher:
+                outputType = .TASK
                 return line.beautify(pattern: .parallelTestingStarted, colored: colored)
+            
+            // WARNING + ERROR = WARN_ERR
+            case Matcher.compileWarningMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .compileWarning, colored: colored)
+            case Matcher.ldWarningMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .ldWarning, colored: colored)
+            case Matcher.genericWarningMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .genericWarning, colored: colored)
+            case Matcher.willNotBeCodeSignedMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .willNotBeCodeSigned, colored: colored)
+            case Matcher.clangErrorMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .clangError, colored: colored)
+            case Matcher.checkDependenciesErrorsMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .checkDependenciesErrors, colored: colored)
+            case Matcher.provisioningProfileRequiredMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .provisioningProfileRequired, colored: colored)
+            case Matcher.noCertificateMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .noCertificate, colored: colored)
+            case Matcher.compileErrorMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .compileError, colored: colored)
+            case Matcher.cursorMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .cursor, colored: colored)
+            case Matcher.fatalErrorMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .fatalError, colored: colored)
+            case Matcher.fileMissingErrorMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .fileMissingError, colored: colored)
+            case Matcher.ldErrorMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .ldError, colored: colored)
+            case Matcher.linkerDuplicateSymbolsLocationMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .linkerDuplicateSymbolsLocation, colored: colored)
+            case Matcher.linkerDuplicateSymbolsMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .linkerDuplicateSymbols, colored: colored)
+            case Matcher.linkerUndefinedSymbolLocationMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .linkerUndefinedSymbolLocation, colored: colored)
+            case Matcher.linkerUndefinedSymbolsMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .linkerUndefinedSymbols, colored: colored)
+            case Matcher.podsErrorMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .podsError, colored: colored)
+            case Matcher.symbolReferencedFromMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .symbolReferencedFrom, colored: colored)
+            case Matcher.moduleIncludesErrorMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .moduleIncludesError, colored: colored)
+            case Matcher.parallelTestCaseFailedMatcher:
+                outputType = .WARN_ERR
+                return line.beautify(pattern: .parallelTestCaseFailed, colored: colored)
             default:
-                print("", terminator: "") // Fallthrough
-            }
-        }
-
-        switch line {
-        case Matcher.compileWarningMatcher:
-            return line.beautify(pattern: .compileWarning, colored: colored)
-        case Matcher.ldWarningMatcher:
-            return line.beautify(pattern: .ldWarning, colored: colored)
-        case Matcher.genericWarningMatcher:
-            return line.beautify(pattern: .genericWarning, colored: colored)
-        case Matcher.willNotBeCodeSignedMatcher:
-            return line.beautify(pattern: .willNotBeCodeSigned, colored: colored)
-        case Matcher.clangErrorMatcher:
-            return line.beautify(pattern: .clangError, colored: colored)
-        case Matcher.checkDependenciesErrorsMatcher:
-            return line.beautify(pattern: .checkDependenciesErrors, colored: colored)
-        case Matcher.provisioningProfileRequiredMatcher:
-            return line.beautify(pattern: .provisioningProfileRequired, colored: colored)
-        case Matcher.noCertificateMatcher:
-            return line.beautify(pattern: .noCertificate, colored: colored)
-        case Matcher.compileErrorMatcher:
-            return line.beautify(pattern: .compileError, colored: colored)
-        case Matcher.cursorMatcher:
-            return line.beautify(pattern: .cursor, colored: colored)
-        case Matcher.fatalErrorMatcher:
-            return line.beautify(pattern: .fatalError, colored: colored)
-        case Matcher.fileMissingErrorMatcher:
-            return line.beautify(pattern: .fileMissingError, colored: colored)
-        case Matcher.ldErrorMatcher:
-            return line.beautify(pattern: .ldError, colored: colored)
-        case Matcher.linkerDuplicateSymbolsLocationMatcher:
-            return line.beautify(pattern: .linkerDuplicateSymbolsLocation, colored: colored)
-        case Matcher.linkerDuplicateSymbolsMatcher:
-            return line.beautify(pattern: .linkerDuplicateSymbols, colored: colored)
-        case Matcher.linkerUndefinedSymbolLocationMatcher:
-            return line.beautify(pattern: .linkerUndefinedSymbolLocation, colored: colored)
-        case Matcher.linkerUndefinedSymbolsMatcher:
-            return line.beautify(pattern: .linkerUndefinedSymbols, colored: colored)
-        case Matcher.podsErrorMatcher:
-            return line.beautify(pattern: .podsError, colored: colored)
-        case Matcher.symbolReferencedFromMatcher:
-            return line.beautify(pattern: .symbolReferencedFrom, colored: colored)
-        case Matcher.moduleIncludesErrorMatcher:
-            return line.beautify(pattern: .moduleIncludesError, colored: colored)
-        case Matcher.parallelTestCaseFailedMatcher:
-            return line.beautify(pattern: .parallelTestCaseFailed, colored: colored)
-        default:
-            return nil
+                outputType = .UNDEFINED
+                return nil
         }
     }
 

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -1,225 +1,217 @@
-public enum OutputType {
-    case UNDEFINED
-    case TASK
-    case WARN_ERR
-    case RESULT
-}
-
 public class Parser {
     public init() {}
 
     public var summary: TestSummary? = nil
 
-    public var outputType: OutputType = .UNDEFINED
+    public var outputType: OutputType = OutputType.undefined
 
     public func parse(line: String, colored: Bool = true) -> String? {
         switch line {
             case Matcher.analyzeMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .analyze, colored: colored)
             case Matcher.buildTargetMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .buildTarget, colored: colored)
             case Matcher.aggregateTargetMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .aggregateTarget, colored: colored)
             case Matcher.analyzeTargetMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .analyzeTarget, colored: colored)
             case Matcher.checkDependenciesMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .checkDependencies, colored: colored)
             case Matcher.shellCommandMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .shellCommand, colored: colored)
             case Matcher.cleanRemoveMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .cleanRemove, colored: colored)
             case Matcher.cleanTargetMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .cleanTarget, colored: colored)
             case Matcher.codesignFrameworkMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .codesignFramework, colored: colored)
             case Matcher.codesignMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .codesign, colored: colored)
             case Matcher.compileMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .compile, colored: colored)
             case Matcher.compileCommandMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .compileCommand, colored: colored)
             case Matcher.compileXibMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .compileXib, colored: colored)
             case Matcher.compileStoryboardMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .compileStoryboard, colored: colored)
             case Matcher.copyHeaderMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .copyHeader, colored: colored)
             case Matcher.copyPlistMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .copyPlist, colored: colored)
             case Matcher.copyStringsMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .copyStrings, colored: colored)
             case Matcher.cpresourceMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .cpresource, colored: colored)
             case Matcher.executedMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 parseSummary(line: line, colored: colored)
                 return nil
             case Matcher.failingTestMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .failingTest, colored: colored)
             case Matcher.uiFailingTestMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .uiFailingTest, colored: colored)
             case Matcher.restartingTestsMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .restartingTests, colored: colored)
             case Matcher.generateDsymMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .generateDsym, colored: colored)
             case Matcher.libtoolMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .libtool, colored: colored)
             case Matcher.linkingMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .linking, colored: colored)
             case Matcher.testCasePassedMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .testCasePassed, colored: colored)
             case Matcher.testCaseStartedMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .testCaseStarted, colored: colored)
             case Matcher.testCasePendingMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .testCasePending, colored: colored)
             case Matcher.testCaseMeasuredMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .testCaseMeasured, colored: colored)
             case Matcher.phaseSuccessMatcher:
-                outputType = .RESULT
+                outputType = OutputType.result
                 return line.beautify(pattern: .phaseSuccess, colored: colored)
             case Matcher.phaseScriptExecutionMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .phaseScriptExecution, colored: colored)
             case Matcher.processPchMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .processPch, colored: colored)
             case Matcher.processPchCommandMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .processPchCommand, colored: colored)
             case Matcher.preprocessMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .preprocess, colored: colored)
             case Matcher.pbxcpMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .pbxcp, colored: colored)
             case Matcher.processInfoPlistMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .processInfoPlist, colored: colored)
             case Matcher.testsRunCompletionMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .testsRunCompletion, colored: colored)
             case Matcher.testSuiteStartedMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .testSuiteStarted, colored: colored)
             case Matcher.testSuiteStartMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .testSuiteStart, colored: colored)
             case Matcher.tiffutilMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .tiffutil, colored: colored)
             case Matcher.touchMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .touch, colored: colored)
             case Matcher.writeFileMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .writeFile, colored: colored)
             case Matcher.writeAuxiliaryFilesMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .writeAuxiliaryFiles, colored: colored)
             case Matcher.parallelTestCasePassedMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .parallelTestCasePassed, colored: colored)
             case Matcher.parallelTestCaseAppKitPassedMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .parallelTestCaseAppKitPassed, colored: colored)
             case Matcher.parallelTestingStartedMatcher:
-                outputType = .TASK
+                outputType = OutputType.task
                 return line.beautify(pattern: .parallelTestingStarted, colored: colored)
             
-            // WARNING + ERROR = WARN_ERR
             case Matcher.compileWarningMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.warning
                 return line.beautify(pattern: .compileWarning, colored: colored)
             case Matcher.ldWarningMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.warning
                 return line.beautify(pattern: .ldWarning, colored: colored)
             case Matcher.genericWarningMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.warning
                 return line.beautify(pattern: .genericWarning, colored: colored)
             case Matcher.willNotBeCodeSignedMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.warning
                 return line.beautify(pattern: .willNotBeCodeSigned, colored: colored)
             case Matcher.clangErrorMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .clangError, colored: colored)
             case Matcher.checkDependenciesErrorsMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .checkDependenciesErrors, colored: colored)
             case Matcher.provisioningProfileRequiredMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.warning
                 return line.beautify(pattern: .provisioningProfileRequired, colored: colored)
             case Matcher.noCertificateMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.warning
                 return line.beautify(pattern: .noCertificate, colored: colored)
             case Matcher.compileErrorMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .compileError, colored: colored)
             case Matcher.cursorMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.warning
                 return line.beautify(pattern: .cursor, colored: colored)
             case Matcher.fatalErrorMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .fatalError, colored: colored)
             case Matcher.fileMissingErrorMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .fileMissingError, colored: colored)
             case Matcher.ldErrorMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .ldError, colored: colored)
             case Matcher.linkerDuplicateSymbolsLocationMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .linkerDuplicateSymbolsLocation, colored: colored)
             case Matcher.linkerDuplicateSymbolsMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .linkerDuplicateSymbols, colored: colored)
             case Matcher.linkerUndefinedSymbolLocationMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .linkerUndefinedSymbolLocation, colored: colored)
             case Matcher.linkerUndefinedSymbolsMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .linkerUndefinedSymbols, colored: colored)
             case Matcher.podsErrorMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .podsError, colored: colored)
             case Matcher.symbolReferencedFromMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.warning
                 return line.beautify(pattern: .symbolReferencedFrom, colored: colored)
             case Matcher.moduleIncludesErrorMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .moduleIncludesError, colored: colored)
             case Matcher.parallelTestCaseFailedMatcher:
-                outputType = .WARN_ERR
+                outputType = OutputType.error
                 return line.beautify(pattern: .parallelTestCaseFailed, colored: colored)
             default:
-                outputType = .UNDEFINED
+                outputType = OutputType.undefined
                 return nil
         }
     }

--- a/Sources/xcbeautify/root.swift
+++ b/Sources/xcbeautify/root.swift
@@ -12,7 +12,7 @@ private func configuration(command: Command) {
         .init(shortName: "q",
               longName: "quiet",
               value: false,
-              description: "Do not print any output except for warnings and errors.",
+              description: "Only print tasks that have warnings or errors.",
               inheritable: true)
         ])
 
@@ -40,11 +40,29 @@ private func configuration(command: Command) {
 
 private func execute(flags: Flags, args: [String]) {
     let parser = Parser()
-    parser.quiet = flags.getBool(name: "quiet") == true
+    let quiet = flags.getBool(name: "quiet") == true
+    var lastFormatted: String? = nil
 
     while let line = readLine() {
         guard let formatted = parser.parse(line: line) else { continue }
-        print(formatted)
+
+        if !quiet {
+            print(formatted)
+            continue
+        }
+
+        switch parser.outputType {
+            case OutputType.WARN_ERR:
+                if let last = lastFormatted {
+                    print(last)
+                    lastFormatted = nil
+                }
+                print(formatted)
+            case OutputType.RESULT:
+                print(formatted)
+            default:
+                lastFormatted = formatted
+        }
     }
 
     if let summary = parser.summary {

--- a/Sources/xcbeautify/root.swift
+++ b/Sources/xcbeautify/root.swift
@@ -52,13 +52,13 @@ private func execute(flags: Flags, args: [String]) {
         }
 
         switch parser.outputType {
-            case OutputType.WARN_ERR:
+            case OutputType.warning, OutputType.error:
                 if let last = lastFormatted {
                     print(last)
                     lastFormatted = nil
                 }
                 print(formatted)
-            case OutputType.RESULT:
+            case OutputType.result:
                 print(formatted)
             default:
                 lastFormatted = formatted


### PR DESCRIPTION
### Abstract
In this submission, `xcbeautify` will display a Banner and warnings or errors in the `quiet` mode.

Parser now would not only parse a line, but also keep track of the type of the current line. TASK means it's a general message; WARN_ERR means it's a warning or an error; RESULT means it's build result or test result; and UNDEFINED otherwise.

In `quiet` mode, lastFormatted will record last output and whether it will be printed is determined by the current output type. In this way, if we encounter warnings or errors, we get a chance to print last output as their banner. So now the output is in following form:

[Target] Doing Something
warnings or errors

This makes everything clear, and we won't miss Target information in the quiet mode.

### Test performed
`make test`, all tests pass.
Manual test on a large project, the output is as expected.
