### PR TITLE
Print test results under quiet/quieter flag

### DIFF
--- a/Sources/XcbeautifyLib/Constants.swift
+++ b/Sources/XcbeautifyLib/Constants.swift
@@ -17,7 +17,27 @@ enum Symbol: String {
 public enum OutputType {
     case undefined
     case task
+    case test
     case warning
     case error
     case result
+}
+
+extension OutputType: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .undefined:
+            return "undefined"
+        case .task:
+            return "task"
+        case .test:
+            return "test"
+        case .warning:
+            return "warning"
+        case .error:
+            return "error"
+        case .result:
+            return "result"
+        }
+    }
 }

--- a/Sources/XcbeautifyLib/OutputHandler.swift
+++ b/Sources/XcbeautifyLib/OutputHandler.swift
@@ -1,37 +1,39 @@
 import Foundation
 
-
 public class OutputHandler {
     let quiet: Bool
     let quieter: Bool
     let isCI: Bool
     let writer: (String) -> Void
-    
-    /// In quiet mode, lastFormatted will record last output and whether it will be printed is determined by the current output type. In this way, if we encounter warnings or errors, we get a chance to print last output as their banner. So now the output is in following form:
+
+    /// In quiet mode, lastFormatted will record last output and whether it will be
+    /// printed is determined by the current output type. In this way, if we encounter
+    /// warnings or errors, we get a chance to print last output as their banner. So now
+    /// the output is in following form:
     /// [Target] Doing Something
     /// warnings or errors
     ///
     /// Ref: https://github.com/thii/xcbeautify/pull/15
     private var lastFormatted: String? = nil
-    
+
     public init(quiet: Bool, quieter: Bool, isCI: Bool = false, _ writer: @escaping (String) -> Void) {
         self.quiet = quiet
         self.quieter = quieter
         self.isCI = isCI
         self.writer = writer
     }
-    
+
     public func write(_ type: OutputType, _ content: String?) {
         guard let content = content else { return }
-        
-        if !quiet && !quieter {
+
+        if !quiet, !quieter {
             writer(content)
             return
         }
-        
+
         switch type {
         case OutputType.warning:
-            if quieter {return}
+            if quieter { return }
             fallthrough
         case OutputType.error:
             if let last = lastFormatted {

--- a/Sources/XcbeautifyLib/OutputHandler.swift
+++ b/Sources/XcbeautifyLib/OutputHandler.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+
+public class OutputHandler {
+    let quiet: Bool
+    let quieter: Bool
+    let isCI: Bool
+    let writer: (String) -> Void
+    
+    /// In quiet mode, lastFormatted will record last output and whether it will be printed is determined by the current output type. In this way, if we encounter warnings or errors, we get a chance to print last output as their banner. So now the output is in following form:
+    /// [Target] Doing Something
+    /// warnings or errors
+    ///
+    /// Ref: https://github.com/thii/xcbeautify/pull/15
+    private var lastFormatted: String? = nil
+    
+    public init(quiet: Bool, quieter: Bool, isCI: Bool = false, _ writer: @escaping (String) -> Void) {
+        self.quiet = quiet
+        self.quieter = quieter
+        self.isCI = isCI
+        self.writer = writer
+    }
+    
+    public func write(_ type: OutputType, _ content: String?) {
+        guard let content = content else { return }
+        
+        if !quiet && !quieter {
+            writer(content)
+            return
+        }
+        
+        switch type {
+        case OutputType.warning:
+            if quieter {return}
+            fallthrough
+        case OutputType.error:
+            if let last = lastFormatted {
+                writer(last)
+                lastFormatted = nil
+            }
+            writer(content)
+        case OutputType.result:
+            writer(content)
+        case OutputType.test:
+            if isCI {
+                writer(content)
+            } else {
+                fallthrough
+            }
+        default:
+            lastFormatted = content
+        }
+    }
+}

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -69,7 +69,7 @@ public class Parser {
                 outputType = OutputType.error
                 return line.beautify(pattern: .uiFailingTest, colored: colored)
             case Matcher.restartingTestsMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .restartingTests, colored: colored)
             case Matcher.generateCoverageDataMatcher:
                 outputType = OutputType.task
@@ -87,16 +87,16 @@ public class Parser {
                 outputType = OutputType.task
                 return line.beautify(pattern: .linking, colored: colored)
             case Matcher.testCasePassedMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .testCasePassed, colored: colored)
             case Matcher.testCaseStartedMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .testCaseStarted, colored: colored)
             case Matcher.testCasePendingMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .testCasePending, colored: colored)
             case Matcher.testCaseMeasuredMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .testCaseMeasured, colored: colored)
             case Matcher.phaseSuccessMatcher:
                 outputType = OutputType.result
@@ -120,13 +120,13 @@ public class Parser {
                 outputType = OutputType.task
                 return line.beautify(pattern: .processInfoPlist, colored: colored)
             case Matcher.testsRunCompletionMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .testsRunCompletion, colored: colored)
             case Matcher.testSuiteStartedMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .testSuiteStarted, colored: colored)
             case Matcher.testSuiteStartMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .testSuiteStart, colored: colored)
             case Matcher.tiffutilMatcher:
                 outputType = OutputType.task
@@ -141,19 +141,19 @@ public class Parser {
                 outputType = OutputType.task
                 return line.beautify(pattern: .writeAuxiliaryFiles, colored: colored)
             case Matcher.parallelTestCasePassedMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .parallelTestCasePassed, colored: colored)
             case Matcher.parallelTestCaseAppKitPassedMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .parallelTestCaseAppKitPassed, colored: colored)
             case Matcher.parallelTestingStartedMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .parallelTestingStarted, colored: colored)
             case Matcher.parallelTestingPassedMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .parallelTestingPassed, colored: colored)
             case Matcher.parallelTestSuiteStartedMatcher:
-                outputType = OutputType.task
+                outputType = OutputType.test
                 return line.beautify(pattern: .parallelTestSuiteStarted, colored: colored)
             
             case Matcher.compileWarningMatcher:

--- a/Sources/xcbeautify/root.swift
+++ b/Sources/xcbeautify/root.swift
@@ -14,68 +14,56 @@ private func configuration(command: Command) {
               value: false,
               description: "Only print tasks that have warnings or errors.",
               inheritable: true)
-        ])
+    ])
     
     command.add(flags: [
         .init(longName: "quieter",
               value: false,
               description: "Only print tasks that have errors.",
               inheritable: true)
-        ])
-
+    ])
+    
+    command.add(flags: [
+        .init(longName: "isCI",
+              value: false,
+              description: "Print test result too under quiet/quiter flag")
+    ])
+    
     command.add(flags: [
         .init(shortName: "v",
               longName: "version",
               value: false,
               description: "Prints the version",
               inheritable: true)
-        ])
-
+    ])
+    
     command.inheritablePreRun = { flags, args in
         if let versionFlag = flags.getBool(name: "version"), versionFlag == true {
-            print(version)
+            print("Version: \(version)")
             return false
         }
-
+        
         return true
     }
-
+    
     command.example = """
-      $ xcodebuild test -project MyApp.xcodeproj -scheme MyApp -destination 'platform=iOS Simulator,OS=12.0,name=iPhone X' | xcbeautify
+    $ xcodebuild test -project MyApp.xcodeproj -scheme MyApp -destination 'platform=iOS Simulator,OS=12.0,name=iPhone X' | xcbeautify
     """
 }
 
 private func execute(flags: Flags, args: [String]) {
+    
     let parser = Parser()
     let quiet = flags.getBool(name: "quiet") == true
     let quieter = flags.getBool(name: "quieter") == true
-    var lastFormatted: String? = nil
-
+    let isCI = flags.getBool(name: "isCI") == true
+    let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCI, { print($0) })
+    
     while let line = readLine() {
         guard let formatted = parser.parse(line: line) else { continue }
-
-        if !quiet && !quieter {
-            print(formatted)
-            continue
-        }
-
-        switch parser.outputType {
-            case OutputType.warning:
-                if quieter {continue}
-            fallthrough
-            case OutputType.error:
-                if let last = lastFormatted {
-                    print(last)
-                    lastFormatted = nil
-                }
-                print(formatted)
-            case OutputType.result:
-                print(formatted)
-            default:
-                lastFormatted = formatted
-        }
+        output.write(parser.outputType, formatted)
     }
-
+    
     if let summary = parser.summary {
         print(summary.format())
     }

--- a/Sources/xcbeautify/root.swift
+++ b/Sources/xcbeautify/root.swift
@@ -13,57 +13,56 @@ private func configuration(command: Command) {
               longName: "quiet",
               value: false,
               description: "Only print tasks that have warnings or errors.",
-              inheritable: true)
+              inheritable: true),
     ])
-    
+
     command.add(flags: [
         .init(longName: "quieter",
               value: false,
               description: "Only print tasks that have errors.",
-              inheritable: true)
+              inheritable: true),
     ])
-    
+
     command.add(flags: [
         .init(longName: "isCI",
               value: false,
-              description: "Print test result too under quiet/quiter flag")
+              description: "Print test result too under quiet/quiter flag"),
     ])
-    
+
     command.add(flags: [
         .init(shortName: "v",
               longName: "version",
               value: false,
               description: "Prints the version",
-              inheritable: true)
+              inheritable: true),
     ])
-    
+
     command.inheritablePreRun = { flags, args in
         if let versionFlag = flags.getBool(name: "version"), versionFlag == true {
             print("Version: \(version)")
             return false
         }
-        
+
         return true
     }
-    
+
     command.example = """
-    $ xcodebuild test -project MyApp.xcodeproj -scheme MyApp -destination 'platform=iOS Simulator,OS=12.0,name=iPhone X' | xcbeautify
+      $ xcodebuild test -project MyApp.xcodeproj -scheme MyApp -destination 'platform=iOS Simulator,OS=12.0,name=iPhone X' | xcbeautify
     """
 }
 
 private func execute(flags: Flags, args: [String]) {
-    
     let parser = Parser()
     let quiet = flags.getBool(name: "quiet") == true
     let quieter = flags.getBool(name: "quieter") == true
-    let isCI = flags.getBool(name: "isCI") == true
+    let isCI = flags.getBool(name: "is-CI") == true
     let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCI, { print($0) })
-    
+
     while let line = readLine() {
         guard let formatted = parser.parse(line: line) else { continue }
         output.write(parser.outputType, formatted)
     }
-    
+
     if let summary = parser.summary {
         print(summary.format())
     }

--- a/Sources/xcbeautify/root.swift
+++ b/Sources/xcbeautify/root.swift
@@ -24,7 +24,7 @@ private func configuration(command: Command) {
     ])
 
     command.add(flags: [
-        .init(longName: "isCI",
+        .init(longName: "is-ci",
               value: false,
               description: "Print test result too under quiet/quiter flag"),
     ])
@@ -55,7 +55,7 @@ private func execute(flags: Flags, args: [String]) {
     let parser = Parser()
     let quiet = flags.getBool(name: "quiet") == true
     let quieter = flags.getBool(name: "quieter") == true
-    let isCI = flags.getBool(name: "is-CI") == true
+    let isCI = flags.getBool(name: "is-ci") == true
     let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCI, { print($0) })
 
     while let line = readLine() {

--- a/Tests/XcbeautifyLibTests/OutputHandlerTests.swift
+++ b/Tests/XcbeautifyLibTests/OutputHandlerTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import XCTest
+import XcbeautifyLib
+
+class OutputHandlerTests: XCTestCase {
+    
+    override func setUpWithError() throws {
+    }
+
+    override func tearDownWithError() throws {
+    }
+    
+    func testEarlyReturnIfEmptyString() throws {
+        var collector: [String] = []
+        let sut = OutputHandler(quiet: false, quieter: false, isCI: false) { (content) in
+            collector.append(content)
+        }
+        
+        sut.write(.error, nil)
+        
+        XCTAssertEqual(collector, [])
+    }
+
+    func testPrintAllOutputTypeByDefault() throws {
+        var collector: [String] = []
+        let sut = OutputHandler(quiet: false, quieter: false, isCI: false) { (content) in
+            collector.append(content)
+        }
+        
+        sut.write(.task, "task 1")
+        sut.write(.error, "error")
+        sut.write(.task, "task 2")
+        sut.write(.warning, "warning")
+        sut.write(.result, "result")
+        sut.write(.undefined, "undefined")
+        
+        XCTAssertEqual(collector, ["task 1", "error", "task 2", "warning", "result", "undefined"])
+    }
+    
+    
+    func testPrintOnlyTasksWithWarningOrError() throws { // quiet
+        var collector: [String] = []
+        let sut = OutputHandler(quiet: true, quieter: false, isCI: false) { (content) in
+            collector.append(content)
+        }
+        
+        sut.write(.error, "error")
+        sut.write(.task, "task 1")
+        sut.write(.task, "task 2")
+        sut.write(.warning, "warning")
+        sut.write(.result, "result")
+        sut.write(.undefined, "undefined")
+        
+        // NOTE: task 2 appear in result is because of "warning"
+        XCTAssertEqual(collector, ["error", "task 2", "warning", "result"])
+        
+        collector.removeAll()
+        
+        sut.write(.task, "task 1")
+        sut.write(.task, "task 2")
+        sut.write(.warning, "warning")
+        sut.write(.result, "result")
+        sut.write(.error, "error")
+        sut.write(.undefined, "undefined")
+        
+        // NOTE: task 2 appear in result is because of "warning"
+        XCTAssertEqual(collector, ["task 2", "warning", "result", "error"])
+    }
+    
+    func testPrintOnlyTasksWithError() throws { // quieter
+        var collector: [String] = []
+        let sut = OutputHandler(quiet: true, quieter: true, isCI: false) { (content) in
+            collector.append(content)
+        }
+        
+        sut.write(.result, "result")
+        sut.write(.error, "error")
+        sut.write(.task, "task 1")
+        sut.write(.task, "task 2")
+        sut.write(.warning, "warning")
+        sut.write(.undefined, "undefined")
+        
+        XCTAssertEqual(collector, ["result", "error"])
+    }
+    
+    func testPrintTestResultTooIfIsCIAndQuiet() throws { // on quiet/quiter , print test task too
+        var collector: [String] = []
+        let sut = OutputHandler(quiet: true, quieter: false, isCI: true) { (content) in
+            collector.append(content)
+        }
+        
+        sut.write(.warning, "warning")
+        sut.write(.undefined, "undefined")
+        sut.write(.test, "test started")
+        sut.write(.test, "test completed")
+        sut.write(.result, "result")
+        
+        
+        XCTAssertEqual(collector, ["warning", "test started", "test completed", "result"])
+    }
+    
+    func testPrintTestResultTooIfIsCIAndQuieter() throws { // on quiet/quiter , print test task too
+        var collector: [String] = []
+        let sut = OutputHandler(quiet: true, quieter: true, isCI: true) { (content) in
+            collector.append(content)
+        }
+        
+        sut.write(.error, "error")
+        sut.write(.warning, "warning")
+        sut.write(.test, "test started")
+        sut.write(.test, "test completed")
+        sut.write(.result, "result")
+        
+        XCTAssertEqual(collector, ["error", "test started", "test completed", "result"])
+        
+        collector.removeAll()
+        
+        sut.write(.warning, "warning")
+        sut.write(.test, "test started")
+        sut.write(.error, "error")
+        sut.write(.test, "test completed")
+        sut.write(.result, "result")
+        
+        XCTAssertEqual(collector, ["test started", "error", "test completed", "result"])
+    }
+    
+}
+
+/*
+ sut.write(.result, "Clean Succeeded")
+ sut.write(.error, "❌ error: unable to resolve product type 'com.apple.product-type.tool' for platform 'iphonesimulator' (in target 'xcbeautify' from project 'xcbeautify')")
+ sut.write(.task, "[XCUITestKit] Processing XCUITestKit-Info.plist")
+ sut.write(.warning, "Multiple targets match implicit dependency for linker flags '-framework XCUITestLiveReset'. Consider adding an explicit dependency on the intended target to resolve this ambiguity. (in target 'XCUITestKit_Example' from project 'XCUITestKit')")
+ */


### PR DESCRIPTION
Quiet or quieter flag print only warning + error message type.
In some cases, like running in CI machine, I want to also see the test task and result in the log. 

This PR introduces a new flag `--isCI` and new OutputType.test. 
xcbeautify will print test task/result too if `--isCI` flag is set and `-q` is flag is set


