### PR TITLE
Fixes Restarting Tests validation

### DIFF
--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -120,7 +120,7 @@ enum Pattern: String {
     case uiFailingTest = #"\s{4}t = \s+\d+\.\d+s\s+Assertion Failure: (.*:\d+): (.*)$"#
 
     /// Regular expression captured groups:
-    case restartingTests = #"Restarting after unexpected exit or crash in.+$"#
+    case restartingTests = #"Restarting after unexpected exit.+$"#
 
     /// Nothing returned here for now.
     case generateCoverageData = #"generating\s+coverage\s+data\.*"#

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -335,7 +335,7 @@ extension String {
             let failingReason = groups[1]
             return _colored ? indent + TestStatus.fail.rawValue.foreground.Red + " "  + file + ", " + failingReason : indent + TestStatus.fail.rawValue + " "  + file + ", " + failingReason
         case .restartingTests:
-            return self
+            return _colored ? indent + TestStatus.fail.rawValue.foreground.Red + " "  + self : indent + TestStatus.fail.rawValue + " "  + self
         case .testCasePending:
             let testCase = groups[1]
             return _colored ? indent + TestStatus.pending.rawValue.foreground.Yellow + " "  + testCase + " [PENDING]" : indent + TestStatus.pending.rawValue + " "  + testCase + " [PENDING]"

--- a/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
+++ b/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
@@ -260,6 +260,8 @@ final class XcbeautifyLibTests: XCTestCase {
     }
 
     func testRestartingTests() {
+        let formatted = noColoredFormatted( "Restarting after unexpected exit, crash, or test timeout in HomePresenterTest.testIsCellPresented(); summary will include totals from previous launches.")
+        XCTAssertEqual(formatted, "    ✖ Restarting after unexpected exit, crash, or test timeout in HomePresenterTest.testIsCellPresented(); summary will include totals from previous launches.")
     }
 
     func testShellCommand() {


### PR DESCRIPTION
I don't know since which Xcode version but now when a test crashes it shows this message:
Restarting after unexpected exit, crash, or test timeout
instead of:
Restarting after unexpected exit or crash in

This pull request simplifies the regex so it covers both cases, formats the message similar to failing tests and I added a test for it.