### PR TITLE
Fix hang for complex output

### DIFF
--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -311,7 +311,7 @@ enum Pattern: String {
     /// $1 = file path
     /// $2 = filename
     /// $3 = reason
-    case compileWarning = #"((.*):.*:.*):\swarning:\s(.*)$"#
+    case compileWarning = #"(([^:]*):\d*:\d*):\swarning:\s(.*)$"#
 
     /// Regular expression captured groups:
     /// $1 = ld prefix
@@ -348,7 +348,7 @@ enum Pattern: String {
     /// $1 = file path (could be a relative path if you build with Bazel)
     /// $2 = is fatal error
     /// $3 = reason
-    case compileError = #"((.*):.*:.*):\s(?:fatal\s)?error:\s(.*)$"#
+    case compileError = #"(([^:]*):\d*:\d*):\s(?:fatal\s)?error:\s(.*)$"#
 
     /// Regular expression captured groups:
     /// $1 = cursor (with whitespaces and tildes)

--- a/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
+++ b/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
@@ -75,6 +75,13 @@ final class XcbeautifyLibTests: XCTestCase {
     }
 
     func testCompileError() {
+        let inputError = "/path/file.swift:64:69: error: cannot find 'input' in scope"
+        let outputError = "[x] /path/file.swift:64:69: cannot find \'input\' in scope\n\n"
+        XCTAssertEqual(noColoredFormatted(inputError), outputError)
+
+        let inputFatal = "/path/file.swift:64:69: fatal error: cannot find 'input' in scope"
+        let outputFatal = "[x] /path/file.swift:64:69: cannot find 'input' in scope\n\n"
+        XCTAssertEqual(noColoredFormatted(inputFatal), outputFatal)
     }
 
     func testCompile() {
@@ -95,6 +102,9 @@ final class XcbeautifyLibTests: XCTestCase {
     }
 
     func testCompileWarning() {
+        let input = "/path/file.swift:64:69: warning: 'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value"
+        let output = "[!]  /path/file.swift:64:69: 'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value\n\n"
+        XCTAssertEqual(noColoredFormatted(input), output)
     }
 
     func testCompileXib() {


### PR DESCRIPTION
This may be related to #68

It has been found that some of the regex are not optimised, and in the case of large outputs (like a print statement) will result in an exponential usage of CPU and memory.