### PR TITLE
Add Swift Package Manager support into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,7 @@ let package = Package(
 
 Enter this command to execute.  
 ```
-$ cd BuildTools
-$ swift run -c release --package-path {package-path} xcbeautify
+swift run -c release --package-path {package-path} xcbeautify
 ```
 
 ### Build from source

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ The `xcbeautify` binary will be installed at `Pods/xcbeautify/xcbeautify`
 
 ### Swift Package Manager
 
+Create a directory in the same location as the `xcodeproj` file, for example `Example`.  
+In that directory, create a `Package.swift` file with the following contents.  
+In addition, add an empty file named `Empty.swift` to the same location.
+
 ```swift
 // swift-tools-version: 5.6
 import PackageDescription
@@ -78,6 +82,12 @@ let package = Package(
       .target(name: "Example", path: "")
     ]
 )
+```
+
+Enter this command to execute.  
+```
+$ cd Example
+$ swift run -c release --package-path {package-path} xcbeautify
 ```
 
 ### Build from source

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The `xcbeautify` binary will be installed at `Pods/xcbeautify/xcbeautify`
 
 ### Swift Package Manager
 
-Create a directory in the same location as the `xcodeproj` file, for example `Example`.  
+Create a directory in the same location as the `xcodeproj` file, for example `BuildTools`.  
 In that directory, create a `Package.swift` file with the following contents.  
 In addition, add an empty file named `Empty.swift` to the same location.
 
@@ -73,20 +73,20 @@ In addition, add an empty file named `Empty.swift` to the same location.
 import PackageDescription
 
 let package = Package(
-    name: "Example",
+    name: "BuildTools",
     platforms: [.macOS(.v10_11)],
     dependencies: [
       .package(url: "https://github.com/tuist/xcbeautify", from: "0.13.0"),
     ],
     targets: [
-      .target(name: "Example", path: "")
+      .target(name: "BuildTools", path: "")
     ]
 )
 ```
 
 Enter this command to execute.  
 ```
-$ cd Example
+$ cd BuildTools
 $ swift run -c release --package-path {package-path} xcbeautify
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,25 @@ pod 'xcbeautify'
 
 The `xcbeautify` binary will be installed at `Pods/xcbeautify/xcbeautify`
 
+
+### Swift Package Manager
+
+```swift
+// swift-tools-version: 5.6
+import PackageDescription
+
+let package = Package(
+    name: "Example",
+    platforms: [.macOS(.v10_11)],
+    dependencies: [
+      .package(url: "https://github.com/tuist/xcbeautify", from: "0.13.0"),
+    ],
+    targets: [
+      .target(name: "Example", path: "")
+    ]
+)
+```
+
 ### Build from source
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ let package = Package(
 
 Enter this command to execute.  
 ```
-swift run -c release --package-path {package-path} xcbeautify
+swift run -c release --package-path ./BuildTools xcbeautify
 ```
 
 ### Build from source


### PR DESCRIPTION
I was able to install it using the `Swift Package Manager` and have added instructions to `Readme.md`.  

How to use it:  
`swift run -c release --package-path {package-path} xcbeautify`

This will allow you to run `xcbeautify` without having to set up `HomeBrew` , `Mint` , `CocoaPods`, etc., making it easier to run CI.

I used `SwiftFormat` as a reference for this method.  
https://github.com/nicklockwood/SwiftFormat#using-swift-package-manager