### PR TITLE
Add a command-line option to allow preserving unbeautified output lines

### DIFF
--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -8,6 +8,8 @@ public class Parser {
 
     public var needToRecordSummary = false
 
+    public var preserveUnbeautifiedLines = false
+
     public var outputType: OutputType = OutputType.undefined
     
     private lazy var innerParsers: [InnerParser] = [
@@ -90,8 +92,13 @@ public class Parser {
     
     // MARK: - Init
     
-    public init(colored: Bool = true, additionalLines: @escaping () -> (String?)) {
+    public init(
+        colored: Bool = true,
+        preserveUnbeautifiedLines: Bool = false,
+        additionalLines: @escaping () -> (String?)
+    ) {
         self.colored = colored
+        self.preserveUnbeautifiedLines = preserveUnbeautifiedLines
         self.additionalLines = additionalLines
     }
     public func parse(line: String) -> String? {
@@ -125,7 +132,7 @@ public class Parser {
             
             // Nothing found?
             outputType = OutputType.undefined
-            return nil
+            return preserveUnbeautifiedLines ? line : nil
         }
         
         let parser = innerParsers[idx]

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -14,6 +14,9 @@ struct Xcbeautify: ParsableCommand {
     @Flag(name: [.long, .customLong("qq", withSingleDash: true)], help: "Only print tasks that have errors.")
     var quieter = false
     
+    @Flag(name: [.long], help: "Preserves unbeautified output lines.")
+    var preserveUnbeautified = false
+
     @Flag(name: .long, help: "Print test result too under quiet/quieter flag.")
     var isCi = false
 
@@ -40,7 +43,11 @@ struct Xcbeautify: ParsableCommand {
             return line
         }
         
-        let parser = Parser(colored: !disableColoredOutput, additionalLines: { readLine() })
+        let parser = Parser(
+            colored: !disableColoredOutput,
+            preserveUnbeautifiedLines: preserveUnbeautified,
+            additionalLines: { readLine() }
+        )
 
         while let line = readLine() {
             guard let formatted = parser.parse(line: line) else { continue }


### PR DESCRIPTION
This PR adds a command-line option to allow preserving unbeautified (raw) output lines.

Some large-scale projects may involve a large number of customized scripts in build phases. Outputs of the script are not generally recognized by `xcbeautify`. By adding a command-line option to allow preserving unbeautified outputs, these projects can utilize `xcbeautify` to beautify parts of the logs without losing potentially useful outputs.