### PR TITLE
Make JUnit file name changeable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Similar to `xcpretty`, but faster.
   bring anywhere. This also means less Ruby-dependant in your development
   environment and CI.
 
-**Note:** `xcbeautify` does not support generating JUnit or HTML test reports.
+**Note:** `xcbeautify` support generating JUnit reports. 
 In fact, you shouldn't rely on `xcodebuild`'s output to generate test reports.
 We suggest using [trainer](https://github.com/KrauseFx/trainer) or
 [XCTestHTMLReport](https://github.com/TitouanVanBelle/XCTestHTMLReport) to

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -30,7 +30,7 @@ struct Xcbeautify: ParsableCommand {
     var reportPath = "build/reports"
 
 	@Option(help: "The the name of JUnit report file name")
-	var junitReportFileName = "junit.xml"
+	var junitReportFilename = "junit.xml"
 
     func run() throws {
         let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCi, { print($0) })
@@ -69,7 +69,7 @@ struct Xcbeautify: ParsableCommand {
             for reportType in Set(report) {
                 switch reportType {
                 case .junit:
-                    let junitOutputPath = outputPath.appendingPathComponent(junitReportFileName)
+                    let junitOutputPath = outputPath.appendingPathComponent(junitReportFilename)
                     let report = try junitReporter.generateReport()
                     try report.write(to: junitOutputPath)
                 }

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -29,8 +29,8 @@ struct Xcbeautify: ParsableCommand {
     @Option(help: "The path to use when generating reports")
     var reportPath = "build/reports"
 
-	@Option(help: "The the name of JUnit report file name")
-	var junitReportFilename = "junit.xml"
+    @Option(help: "The the name of JUnit report file name")
+    var junitReportFilename = "junit.xml"
 
     func run() throws {
         let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCi, { print($0) })

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -29,6 +29,9 @@ struct Xcbeautify: ParsableCommand {
     @Option(help: "The path to use when generating reports")
     var reportPath = "build/reports"
 
+	@Option(help: "The the name of JUnit report file name")
+	var junitReportFileName = "junit.xml"
+
     func run() throws {
         let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCi, { print($0) })
         let junitReporter = JunitReporter()
@@ -66,7 +69,7 @@ struct Xcbeautify: ParsableCommand {
             for reportType in Set(report) {
                 switch reportType {
                 case .junit:
-                    let junitOutputPath = outputPath.appendingPathComponent("junit.xml")
+                    let junitOutputPath = outputPath.appendingPathComponent(junitReportFileName)
                     let report = try junitReporter.generateReport()
                     try report.write(to: junitOutputPath)
                 }

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -29,7 +29,7 @@ struct Xcbeautify: ParsableCommand {
     @Option(help: "The path to use when generating reports")
     var reportPath = "build/reports"
 
-    @Option(help: "The the name of JUnit report file name")
+    @Option(help: "The name of JUnit report file name")
     var junitReportFilename = "junit.xml"
 
     func run() throws {


### PR DESCRIPTION
Motivation - some services require a specific file name.

I thought it would be great if `xcbeautify` becomes more flexible.

Peace and goodness to all!