### PR TITLE
Update `JunitReporter` to parse parallel tests

### DIFF
--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -21,31 +21,24 @@ public final class JunitReporter {
         switch line {
             // Capture standard output
             case Matcher.failingTestMatcher:
-                components.append(.failingTest(generateFailingTest(line: line,
-                                                                   regex: Matcher.failingTestMatcher)))
+                components.append(.failingTest(generateFailingTest(line: line)))
             case Matcher.testCasePassedMatcher:
-                components.append(.testCasePassed(generatePassingTest(line: line,
-                                                                      regex: Matcher.testCasePassedMatcher)))
+                components.append(.testCasePassed(generatePassingTest(line: line)))
             case Matcher.testSuiteStartMatcher:
-                components.append(.testSuiteStart(generateSuiteStart(line: line,
-                                                                     regex: Matcher.testSuiteStartMatcher)))
+                components.append(.testSuiteStart(generateSuiteStart(line: line)))
             // Capture parallel output
             case Matcher.parallelTestCaseFailedMatcher:
-                parallelComponents.append(
-                  .failingTest(generateFailingTest(line: line,
-                                                   regex: Matcher.parallelTestCaseFailedMatcher)))
+                parallelComponents.append(.failingTest(generateParallelFailingTest(line: line)))
             case Matcher.parallelTestCasePassedMatcher:
-                parallelComponents.append(
-                  .testCasePassed(generatePassingTest(line: line,
-                                                      regex: Matcher.parallelTestCasePassedMatcher)))
+                parallelComponents.append(.testCasePassed(generatePassingParallelTest(line: line)))
             default:
                 // Not needed for generating a junit report
                 break
         }
     }
 
-    private func generateFailingTest(line: String, regex: Regex) -> Testcase {
-        let groups = line.capturedGroups(with: regex.pattern)
+    private func generateFailingTest(line: String) -> Testcase {
+        let groups = line.capturedGroups(with: Matcher.failingTestMatcher.pattern)
         return Testcase(
             classname: groups[1],
             name: groups[2],
@@ -54,13 +47,29 @@ public final class JunitReporter {
         )
     }
 
-    private func generatePassingTest(line: String, regex: Regex) -> Testcase {
-        let groups = line.capturedGroups(with: regex.pattern)
+    private func generateParallelFailingTest(line: String) -> Testcase {
+        // Parallel tests do not provide meaningful failure messages
+        let groups = line.capturedGroups(with: Matcher.parallelTestCaseFailedMatcher.pattern)
+        return Testcase(
+            classname: groups[0],
+            name: groups[1],
+            time: nil,
+            failure: .init(message: "Parallel test failed")
+        )
+    }
+
+    private func generatePassingTest(line: String) -> Testcase {
+        let groups = line.capturedGroups(with: Matcher.testCasePassedMatcher.pattern)
         return Testcase(classname: groups[0], name: groups[1], time: groups[2], failure: nil)
     }
 
-    private func generateSuiteStart(line: String, regex: Regex) -> String {
-        let groups = line.capturedGroups(with: regex.pattern)
+    private func generatePassingParallelTest(line: String) -> Testcase {
+      let groups = line.capturedGroups(with: Matcher.parallelTestCasePassedMatcher.pattern)
+      return Testcase(classname: groups[0], name: groups[1], time: groups[3], failure: nil)
+    }
+  
+    private func generateSuiteStart(line: String) -> String {
+        let groups = line.capturedGroups(with: Matcher.testSuiteStartMatcher.pattern)
         return groups[0]
     }
     

--- a/Tests/XcbeautifyLibTests/JunitReporterTests.swift
+++ b/Tests/XcbeautifyLibTests/JunitReporterTests.swift
@@ -399,6 +399,7 @@ class JunitReporterTests: XCTestCase {
       Test suite 'Event_EmailTests' started on 'Clone 1 of iPhone 13 mini - xctest (32505)'
       Test case 'Event_EmailTests.test_path_isCorrectValue()' passed on 'Clone 1 of iPhone 13 mini - xctest (32505)' (0.001 seconds)
       Test case 'UserCoordinatorTests.test_loginWithEmailPasswordAndSSO_callsAuthenticationService_thenCallsCompletion()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.015 seconds)
+      Test case 'BuildFlagTests.test_failIntentionally()' failed on 'Clone 1 of iPhone 13 mini - xctest (59522)' (0.278 seconds)
       Test case 'UserCoordinatorTests.test_refreshLoginToken_failure_completionIsCalled()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.012 seconds)
       Test case 'UserCoordinatorTests.test_refreshLoginToken_failure_recordsError()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.014 seconds)
       Test case 'UserCoordinatorTests.test_refreshLoginToken_success_completionIsCalled()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.008 seconds)
@@ -412,40 +413,43 @@ class JunitReporterTests: XCTestCase {
     """
 
   private let expectedParallelXml = """
-      <testsuites name="PARALLEL_TESTS" tests="20" failures="0">
+      <testsuites name="PARALLEL_TESTS" tests="21" failures="1">
           <testsuite name="URL_OutgoingEmailTests" tests="2" failures="0">
-              <testcase classname="URL_OutgoingEmailTests" name="test_outgoingEmailLinkName_urlContainsQueryItem_valueIsReturned" time="Clone 1 of iPhone 13 mini - xctest (32506)" />
-              <testcase classname="URL_OutgoingEmailTests" name="test_outgoingEmailToken_urlContainsQueryItem_valueIsReturned" time="Clone 1 of iPhone 13 mini - xctest (32506)" />
+              <testcase classname="URL_OutgoingEmailTests" name="test_outgoingEmailLinkName_urlContainsQueryItem_valueIsReturned" time="0.002" />
+              <testcase classname="URL_OutgoingEmailTests" name="test_outgoingEmailToken_urlContainsQueryItem_valueIsReturned" time="0.003" />
           </testsuite>
           <testsuite name="MobileWebURLRouteTest" tests="2" failures="0">
-              <testcase classname="MobileWebURLRouteTest" name="testReportingDescriptionContainsUrl" time="Clone 1 of iPhone 13 mini - xctest (32505)" />
-              <testcase classname="MobileWebURLRouteTest" name="testRouteContainsUrl" time="Clone 1 of iPhone 13 mini - xctest (32505)" />
+              <testcase classname="MobileWebURLRouteTest" name="testReportingDescriptionContainsUrl" time="0.003" />
+              <testcase classname="MobileWebURLRouteTest" name="testRouteContainsUrl" time="0.002" />
           </testsuite>
           <testsuite name="URLRoutingComponentsTests" tests="1" failures="0">
-              <testcase classname="URLRoutingComponentsTests" name="test_init_urlWithQueryItems_queryItemsReturnsCorrectly" time="Clone 1 of iPhone 13 mini - xctest (32504)" />
+              <testcase classname="URLRoutingComponentsTests" name="test_init_urlWithQueryItems_queryItemsReturnsCorrectly" time="0.004" />
           </testsuite>
-          <testsuite name="BuildFlagTests" tests="2" failures="0">
-              <testcase classname="BuildFlagTests" name="test_logClicksToConsole_isFalse" time="Clone 1 of iPhone 13 mini - xctest (32507)" />
-              <testcase classname="BuildFlagTests" name="test_logEventsToConsole_isFalse" time="Clone 1 of iPhone 13 mini - xctest (32507)" />
+          <testsuite name="BuildFlagTests" tests="3" failures="1">
+              <testcase classname="BuildFlagTests" name="test_logClicksToConsole_isFalse" time="0.003" />
+              <testcase classname="BuildFlagTests" name="test_logEventsToConsole_isFalse" time="0.002" />
+              <testcase classname="BuildFlagTests" name="test_failIntentionally">
+                  <failure message="Parallel test failed" />
+              </testcase>
           </testsuite>
           <testsuite name="GeneratedTestingFlagTests" tests="1" failures="0">
-              <testcase classname="GeneratedTestingFlagTests" name="test_generatedTesting_expectedValue" time="Clone 1 of iPhone 13 mini - xctest (32504)" />
+              <testcase classname="GeneratedTestingFlagTests" name="test_generatedTesting_expectedValue" time="0.001" />
           </testsuite>
           <testsuite name="Event_EmailTests" tests="1" failures="0">
-              <testcase classname="Event_EmailTests" name="test_path_isCorrectValue" time="Clone 1 of iPhone 13 mini - xctest (32505)" />
+              <testcase classname="Event_EmailTests" name="test_path_isCorrectValue" time="0.001" />
           </testsuite>
           <testsuite name="UserCoordinatorTests" tests="11" failures="0">
-              <testcase classname="UserCoordinatorTests" name="test_loginWithEmailPasswordAndSSO_callsAuthenticationService_thenCallsCompletion" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
-              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_failure_completionIsCalled" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
-              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_failure_recordsError" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
-              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_success_completionIsCalled" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
-              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_success_storesLoginToken" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
-              <testcase classname="UserCoordinatorTests" name="test_refreshUser_failure_completionIsCalled" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
-              <testcase classname="UserCoordinatorTests" name="test_refreshUser_failure_logsError" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
-              <testcase classname="UserCoordinatorTests" name="test_refreshUser_success_completionIsCalled" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
-              <testcase classname="UserCoordinatorTests" name="test_refreshUser_success_userIsStoredInUserDefaults" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
-              <testcase classname="UserCoordinatorTests" name="test_refreshUser_success_userPropertyIsUpdated" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
-              <testcase classname="UserCoordinatorTests" name="test_resetPassword_requestSucceeds_completionCalledWithSuccess" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_loginWithEmailPasswordAndSSO_callsAuthenticationService_thenCallsCompletion" time="0.015" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_failure_completionIsCalled" time="0.012" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_failure_recordsError" time="0.014" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_success_completionIsCalled" time="0.008" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_success_storesLoginToken" time="0.006" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshUser_failure_completionIsCalled" time="0.005" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshUser_failure_logsError" time="0.005" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshUser_success_completionIsCalled" time="0.005" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshUser_success_userIsStoredInUserDefaults" time="0.006" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshUser_success_userPropertyIsUpdated" time="0.032" />
+              <testcase classname="UserCoordinatorTests" name="test_resetPassword_requestSucceeds_completionCalledWithSuccess" time="0.005" />
           </testsuite>
       </testsuites>
       """

--- a/Tests/XcbeautifyLibTests/JunitReporterTests.swift
+++ b/Tests/XcbeautifyLibTests/JunitReporterTests.swift
@@ -383,4 +383,81 @@ class JunitReporterTests: XCTestCase {
         #endif
         XCTAssertEqual(xml, expectedXml)
     }
+
+    private let parallelTests = """
+      Test suite 'MobileWebURLRouteTest' started on 'Clone 1 of iPhone 13 mini - xctest (32505)'
+      Test suite 'BuildFlagTests' started on 'Clone 1 of iPhone 13 mini - xctest (32507)'
+      Test case 'URL_OutgoingEmailTests.test_outgoingEmailLinkName_urlContainsQueryItem_valueIsReturned()' passed on 'Clone 1 of iPhone 13 mini - xctest (32506)' (0.002 seconds)
+      Test case 'MobileWebURLRouteTest.testReportingDescriptionContainsUrl()' passed on 'Clone 1 of iPhone 13 mini - xctest (32505)' (0.003 seconds)
+      Test case 'URLRoutingComponentsTests.test_init_urlWithQueryItems_queryItemsReturnsCorrectly()' passed on 'Clone 1 of iPhone 13 mini - xctest (32504)' (0.004 seconds)
+      Test case 'BuildFlagTests.test_logClicksToConsole_isFalse()' passed on 'Clone 1 of iPhone 13 mini - xctest (32507)' (0.003 seconds)
+      Test case 'URL_OutgoingEmailTests.test_outgoingEmailToken_urlContainsQueryItem_valueIsReturned()' passed on 'Clone 1 of iPhone 13 mini - xctest (32506)' (0.003 seconds)
+      Test case 'MobileWebURLRouteTest.testRouteContainsUrl()' passed on 'Clone 1 of iPhone 13 mini - xctest (32505)' (0.002 seconds)
+      Test suite 'GeneratedTestingFlagTests' started on 'Clone 1 of iPhone 13 mini - xctest (32504)'
+      Test case 'BuildFlagTests.test_logEventsToConsole_isFalse()' passed on 'Clone 1 of iPhone 13 mini - xctest (32507)' (0.002 seconds)
+      Test case 'GeneratedTestingFlagTests.test_generatedTesting_expectedValue()' passed on 'Clone 1 of iPhone 13 mini - xctest (32504)' (0.001 seconds)
+      Test suite 'Event_EmailTests' started on 'Clone 1 of iPhone 13 mini - xctest (32505)'
+      Test case 'Event_EmailTests.test_path_isCorrectValue()' passed on 'Clone 1 of iPhone 13 mini - xctest (32505)' (0.001 seconds)
+      Test case 'UserCoordinatorTests.test_loginWithEmailPasswordAndSSO_callsAuthenticationService_thenCallsCompletion()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.015 seconds)
+      Test case 'UserCoordinatorTests.test_refreshLoginToken_failure_completionIsCalled()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.012 seconds)
+      Test case 'UserCoordinatorTests.test_refreshLoginToken_failure_recordsError()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.014 seconds)
+      Test case 'UserCoordinatorTests.test_refreshLoginToken_success_completionIsCalled()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.008 seconds)
+      Test case 'UserCoordinatorTests.test_refreshLoginToken_success_storesLoginToken()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.006 seconds)
+      Test case 'UserCoordinatorTests.test_refreshUser_failure_completionIsCalled()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.005 seconds)
+      Test case 'UserCoordinatorTests.test_refreshUser_failure_logsError()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.005 seconds)
+      Test case 'UserCoordinatorTests.test_refreshUser_success_completionIsCalled()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.005 seconds)
+      Test case 'UserCoordinatorTests.test_refreshUser_success_userIsStoredInUserDefaults()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.006 seconds)
+      Test case 'UserCoordinatorTests.test_refreshUser_success_userPropertyIsUpdated()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.032 seconds)
+      Test case 'UserCoordinatorTests.test_resetPassword_requestSucceeds_completionCalledWithSuccess()' passed on 'Clone 1 of iPhone 13 mini - xctest (32503)' (0.005 seconds)
+    """
+
+  private let expectedParallelXml = """
+      <testsuites name="PARALLEL_TESTS" tests="20" failures="0">
+          <testsuite name="URL_OutgoingEmailTests" tests="2" failures="0">
+              <testcase classname="URL_OutgoingEmailTests" name="test_outgoingEmailLinkName_urlContainsQueryItem_valueIsReturned" time="Clone 1 of iPhone 13 mini - xctest (32506)" />
+              <testcase classname="URL_OutgoingEmailTests" name="test_outgoingEmailToken_urlContainsQueryItem_valueIsReturned" time="Clone 1 of iPhone 13 mini - xctest (32506)" />
+          </testsuite>
+          <testsuite name="MobileWebURLRouteTest" tests="2" failures="0">
+              <testcase classname="MobileWebURLRouteTest" name="testReportingDescriptionContainsUrl" time="Clone 1 of iPhone 13 mini - xctest (32505)" />
+              <testcase classname="MobileWebURLRouteTest" name="testRouteContainsUrl" time="Clone 1 of iPhone 13 mini - xctest (32505)" />
+          </testsuite>
+          <testsuite name="URLRoutingComponentsTests" tests="1" failures="0">
+              <testcase classname="URLRoutingComponentsTests" name="test_init_urlWithQueryItems_queryItemsReturnsCorrectly" time="Clone 1 of iPhone 13 mini - xctest (32504)" />
+          </testsuite>
+          <testsuite name="BuildFlagTests" tests="2" failures="0">
+              <testcase classname="BuildFlagTests" name="test_logClicksToConsole_isFalse" time="Clone 1 of iPhone 13 mini - xctest (32507)" />
+              <testcase classname="BuildFlagTests" name="test_logEventsToConsole_isFalse" time="Clone 1 of iPhone 13 mini - xctest (32507)" />
+          </testsuite>
+          <testsuite name="GeneratedTestingFlagTests" tests="1" failures="0">
+              <testcase classname="GeneratedTestingFlagTests" name="test_generatedTesting_expectedValue" time="Clone 1 of iPhone 13 mini - xctest (32504)" />
+          </testsuite>
+          <testsuite name="Event_EmailTests" tests="1" failures="0">
+              <testcase classname="Event_EmailTests" name="test_path_isCorrectValue" time="Clone 1 of iPhone 13 mini - xctest (32505)" />
+          </testsuite>
+          <testsuite name="UserCoordinatorTests" tests="11" failures="0">
+              <testcase classname="UserCoordinatorTests" name="test_loginWithEmailPasswordAndSSO_callsAuthenticationService_thenCallsCompletion" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_failure_completionIsCalled" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_failure_recordsError" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_success_completionIsCalled" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshLoginToken_success_storesLoginToken" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshUser_failure_completionIsCalled" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshUser_failure_logsError" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshUser_success_completionIsCalled" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshUser_success_userIsStoredInUserDefaults" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_refreshUser_success_userPropertyIsUpdated" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+              <testcase classname="UserCoordinatorTests" name="test_resetPassword_requestSucceeds_completionCalledWithSuccess" time="Clone 1 of iPhone 13 mini - xctest (32503)" />
+          </testsuite>
+      </testsuites>
+      """
+
+
+
+  func testParallelJunitReport() throws {
+      let reporter = JunitReporter()
+      parallelTests.components(separatedBy: .newlines).forEach { reporter.add(line: $0) }
+      let data = try reporter.generateReport()
+      let xml = String(data: data, encoding: .utf8)!
+      let expectedXml = expectedParallelXml
+      XCTAssertEqual(xml, expectedXml)
+  }
 }


### PR DESCRIPTION
- Change `JunitComponent` to capture the Regex used to create the component
- Relies on capture groups being consistent between parallel and non-parallel output
- Add unit test