### PR TITLE
Speedup regex by reducing backtracking

### DIFF
--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -2,106 +2,106 @@ enum Pattern: String {
     /// Regular expression captured groups:
     /// $1 = file path
     /// $2 = filename
-    case analyze = #"Analyze(?:Shallow)?\s(.*\/(.*\.(?:m|mm|cc|cpp|c|cxx)))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case analyze = #"^Analyze(?:Shallow)?\s(.*\/(.*\.(?:m|mm|cc|cpp|c|cxx)))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 = target
     /// $2 = project
     /// $3 = configuration
-    case buildTarget = #"=== BUILD TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#
+    case buildTarget = #"^=== BUILD TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#
 
     /// Regular expression captured groups:
     /// $1 = target
     /// $2 = project
     /// $3 = configuration
-    case aggregateTarget = #"=== BUILD AGGREGATE TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#
+    case aggregateTarget = #"^=== BUILD AGGREGATE TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#
 
     /// Regular expression captured groups:
     /// $1 = target
     /// $2 = project
     /// $3 = configuration
-    case analyzeTarget = #"=== ANALYZE TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#
+    case analyzeTarget = #"^=== ANALYZE TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#
 
     /// Nothing returned here for now
-    case checkDependencies = #"Check dependencies"#
+    case checkDependencies = #"^Check dependencies"#
 
     /// Regular expression captured groups:
     /// $1 = command path
     /// $2 = arguments
-    case shellCommand = #"\s{4}(cd|setenv|(?:[\w\/:\s\-.]+?\/)?[\w\-]+)\s(.*)$"#
+    case shellCommand = #"^\s{4}(cd|setenv|(?:[\w\/:\s\-.]+?\/)?[\w\-]+)\s(.*)$"#
 
     /// Nothing returned here for now
-    case cleanRemove = #"Clean.Remove(.*)"#
+    case cleanRemove = #"^Clean.Remove(.*)"#
 
     /// Regular expression captured groups:
     /// $1 = target
     /// $2 = project
     /// $3 = configuration
-    case cleanTarget = #"=== CLEAN TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH CONFIGURATION\s(.*)\s==="#
+    case cleanTarget = #"^=== CLEAN TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH CONFIGURATION\s(.*)\s==="#
 
     /// Regular expression captured groups:
     /// $1 = file
-    case codesign = #"CodeSign\s(((?!.framework/Versions/A)(?:\ |[^ ]))*)$"#
+    case codesign = #"^CodeSign\s(((?!.framework/Versions/A)(?:\ |[^ ]))*)$"#
 
     /// Regular expression captured groups:
     /// $1 = file
-    case codesignFramework = #"CodeSign\s((?:\ |[^ ])*.framework)\/Versions/A"#
+    case codesignFramework = #"^CodeSign\s((?:\ |[^ ])*.framework)\/Versions/A"#
 
     #if os(Linux)
     /// Regular expression captured groups:
     /// $1 = filename (e.g. KWNull.m)
     /// $2 = target
-    case compile = #"\[\d+\/\d+\]\sCompiling\s([^ ]+)\s([^ \.]+\.(?:m|mm|c|cc|cpp|cxx|swift))"#
+    case compile = #"^\[\d+\/\d+\]\sCompiling\s([^ ]+)\s([^ \.]+\.(?:m|mm|c|cc|cpp|cxx|swift))"#
     #else
     /// Regular expression captured groups:
     /// $1 = file path
     /// $2 = filename (e.g. KWNull.m)
     /// $3 = target
-    case compile = #"Compile[\w]+\s.+?\s((?:\.|[^ ])+\/((?:\.|[^ ])+\.(?:m|mm|c|cc|cpp|cxx|swift)))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case compile = #"^Compile[\w]+\s.+?\s((?:\.|[^ ])+\/((?:\.|[^ ])+\.(?:m|mm|c|cc|cpp|cxx|swift)))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#
     #endif
 
     /// Regular expression captured groups:
     /// $1 = compiler command
     /// $2 = file path
-    case compileCommand = #"\s*(.*clang\s.*\s\-c\s(.*\.(?:m|mm|c|cc|cpp|cxx))\s.*\.o)$"#
+    case compileCommand = #"^\s*(.*clang\s.*\s\-c\s(.*\.(?:m|mm|c|cc|cpp|cxx))\s.*\.o)$"#
 
     /// Regular expression captured groups:
     /// $1 = file path
     /// $2 = filename (e.g. MainMenu.xib)
     /// $3 = target
-    case compileXib = #"CompileXIB\s(.*\/(.*\.xib))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case compileXib = #"^CompileXIB\s(.*\/(.*\.xib))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 = file path
     /// $2 = filename (e.g. Main.storyboard)
     /// $3 = target
-    case compileStoryboard = #"CompileStoryboard\s(.*\/([^\/].*\.storyboard))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case compileStoryboard = #"^CompileStoryboard\s(.*\/([^\/].*\.storyboard))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 = source file
     /// $2 = target file
     /// $3 = target
-    case copyHeader = #"CpHeader\s(.*\.h)\s(.*\.h) \((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case copyHeader = #"^CpHeader\s(.*\.h)\s(.*\.h) \((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 = source file
     /// $2 = target file
-    case copyPlist = #"CopyPlistFile\s(.*\.plist)\s(.*\.plist) \((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case copyPlist = #"^CopyPlistFile\s(.*\.plist)\s(.*\.plist) \((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 = file
-    case copyStrings = #"CopyStringsFile\s(.*\.strings)\s(.*\.strings) \((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case copyStrings = #"^CopyStringsFile\s(.*\.strings)\s(.*\.strings) \((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 = resource
-    case cpresource = #"CpResource\s(.*)\s\/(.*) \((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case cpresource = #"^CpResource\s(.*)\s\/(.*) \((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 = number of tests
     /// $2 = number of failures
     /// $3 = number of unexpected failures
     /// $4 = wall clock time in seconds (e.g. 0.295)
-    case executed = #"\s*Executed\s(\d+)\stest[s]?,\swith\s(\d+)\sfailure[s]?\s\((\d+)\sunexpected\)\sin\s\d+\.\d{3}\s\((\d+\.\d{3})\)\sseconds"#
+    case executed = #"^\s*Executed\s(\d+)\stest[s]?,\swith\s(\d+)\sfailure[s]?\s\((\d+)\sunexpected\)\sin\s\d+\.\d{3}\s\((\d+\.\d{3})\)\sseconds"#
     
     /// Regular expression captured groups:
     /// $1 = number of tests
@@ -109,7 +109,7 @@ enum Pattern: String {
     /// $3 = number of failures
     /// $4 = number of unexpected failures
     /// $5 = wall clock time in seconds (e.g. 0.295)
-    case executedWithSkipped = #"\s*Executed\s(\d+)\stest[s]?,\swith\s(\d+)\stest[s]?\sskipped\sand\s(\d+)\sfailure[s]?\s\((\d+)\sunexpected\)\sin\s\d+\.\d{3}\s\((\d+\.\d{3})\)\sseconds"#
+    case executedWithSkipped = #"^\s*Executed\s(\d+)\stest[s]?,\swith\s(\d+)\stest[s]?\sskipped\sand\s(\d+)\sfailure[s]?\s\((\d+)\sunexpected\)\sin\s\d+\.\d{3}\s\((\d+\.\d{3})\)\sseconds"#
 
     /// Regular expression captured groups:
     /// $1 = file
@@ -117,45 +117,45 @@ enum Pattern: String {
     /// $3 = test case
     /// $4 = reason
     #if os(Linux)
-    case failingTest = #"\s*(.+:\d+):\serror:\s(.*)\.(.*)\s:(?:\s'.*'\s\[failed\],)?\s(.*)"#
+    case failingTest = #"^\s*(.+:\d+):\serror:\s(.*)\.(.*)\s:(?:\s'.*'\s\[failed\],)?\s(.*)"#
     #else
-    case failingTest = #"\s*(.+:\d+):\serror:\s[\+\-]\[(.*)\s(.*)\]\s:(?:\s'.*'\s\[FAILED\],)?\s(.*)"#
+    case failingTest = #"^\s*(.+:\d+):\serror:\s[\+\-]\[(.*)\s(.*)\]\s:(?:\s'.*'\s\[FAILED\],)?\s(.*)"#
     #endif
 
     /// Regular expression captured groups:
     /// $1 = file
     /// $2 = reason
-    case uiFailingTest = #"\s{4}t = \s+\d+\.\d+s\s+Assertion Failure: (.*:\d+): (.*)$"#
+    case uiFailingTest = #"^\s{4}t = \s+\d+\.\d+s\s+Assertion Failure: (.*:\d+): (.*)$"#
 
     /// Regular expression captured groups:
-    case restartingTests = #"Restarting after unexpected exit.+$"#
+    case restartingTests = #"^Restarting after unexpected exit.+$"#
 
     /// Nothing returned here for now.
-    case generateCoverageData = #"generating\s+coverage\s+data\.*"#
+    case generateCoverageData = #"^generating\s+coverage\s+data\.*"#
 
     /// Regular expression captured groups:
     /// $1 = coverage report file path
-    case generatedCoverageReport = #"generated\s+coverage\s+report:\s+(.+)"#
+    case generatedCoverageReport = #"^generated\s+coverage\s+report:\s+(.+)"#
 
     /// Regular expression captured groups:
     /// $1 = dsym
     /// $2 = target
-    case generateDsym = #"GenerateDSYMFile \/.*\/(.*\.dSYM) \/.* \((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case generateDsym = #"^GenerateDSYMFile \/.*\/(.*\.dSYM) \/.* \((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 = library
     /// $2 = target
-    case libtool = #"Libtool.*\/(.*) .* .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case libtool = #"^Libtool.*\/(.*) .* .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     #if os(Linux)
     /// Regular expression captured groups:
     /// $1 = target
-    case linking = #"\[\d+\/\d+\]\sLinking\s([^ ]+)"#
+    case linking = #"^\[\d+\/\d+\]\sLinking\s([^ ]+)"#
     #else
     /// Regular expression captured groups:
     /// $1 = binary filename
     /// $2 = target
-    case linking = #"Ld \/?.*\/(.*?) normal .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case linking = #"^Ld \/?.*\/(.*?) normal .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#
     #endif
 
     /// Regular expression captured groups:
@@ -163,32 +163,32 @@ enum Pattern: String {
     /// $2 = test case
     /// $3 = time
     #if os(Linux)
-    case testCasePassed = #"\s*Test Case\s'(.*)\.(.*)'\spassed\s\((\d*\.\d{1,3})\sseconds\)"#
+    case testCasePassed = #"^\s*Test Case\s'(.*)\.(.*)'\spassed\s\((\d*\.\d{1,3})\sseconds\)"#
     #else
-    case testCasePassed = #"\s*Test Case\s'-\[(.*)\s(.*)\]'\spassed\s\((\d*\.\d{3})\sseconds\)."#
+    case testCasePassed = #"^\s*Test Case\s'-\[(.*)\s(.*)\]'\spassed\s\((\d*\.\d{3})\sseconds\)."#
     #endif
 
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = test case
     #if os(Linux)
-    case testCaseStarted = #"Test Case '(.*)\.(.*)' started at"#
+    case testCaseStarted = #"^Test Case '(.*)\.(.*)' started at"#
     #else
-    case testCaseStarted = #"Test Case '-\[(.*) (.*)\]' started.$"#
+    case testCaseStarted = #"^Test Case '-\[(.*) (.*)\]' started.$"#
     #endif
 
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = test case
-    case testCasePending = #"Test Case\s'-\[(.*)\s(.*)PENDING\]'\spassed"#
+    case testCasePending = #"^Test Case\s'-\[(.*)\s(.*)PENDING\]'\spassed"#
 
     /// $1 = suite
     /// $2 = test case
     /// $3 = time
     #if os(Linux)
-    case testCaseMeasured = #"[^:]*:[^:]*:\sTest Case\s'(.*)\.(.*)'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#
+    case testCaseMeasured = #"^[^:]*:[^:]*:\sTest Case\s'(.*)\.(.*)'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#
     #else
-    case testCaseMeasured = #"[^:]*:[^:]*:\sTest Case\s'-\[(.*)\s(.*)\]'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#
+    case testCaseMeasured = #"^[^:]*:[^:]*:\sTest Case\s'-\[(.*)\s(.*)\]'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#
     #endif
 
     /// Regular expression captured groups:
@@ -196,114 +196,114 @@ enum Pattern: String {
     /// $2 = test case
     /// $3 = installed app file and ID (e.g. "MyApp.app (12345)"), process (e.g. "xctest (12345)"), or device (e.g. "iPhone X")
     /// $4 = time
-     case parallelTestCasePassed = #"Test\s+case\s+'(.*)\.(.*)\(\)'\s+passed\s+on\s+'(.*)'\s+\((\d*\.(.*){3})\s+seconds\)"#
+     case parallelTestCasePassed = #"^Test\s+case\s+'(.*)\.(.*)\(\)'\s+passed\s+on\s+'(.*)'\s+\((\d*\.(.*){3})\s+seconds\)"#
 
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = test case
     /// $3 = time
-    case parallelTestCaseAppKitPassed = #"\s*Test case\s'-\[(.*)\s(.*)\]'\spassed\son\s'.*'\s\((\d*\.\d{3})\sseconds\)"#
+    case parallelTestCaseAppKitPassed = #"^\s*Test case\s'-\[(.*)\s(.*)\]'\spassed\son\s'.*'\s\((\d*\.\d{3})\sseconds\)"#
 
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = test case
     /// $3 = installed app file and ID (e.g. "MyApp.app (12345)"), process (e.g. "xctest (12345)"), or device (e.g. "iPhone X")
     /// $4 = time
-    case parallelTestCaseFailed = #"Test\s+case\s+'(.*)\.(.*)\(\)'\s+failed\s+on\s+'(.*)'\s+\((\d*\.(.*){3})\s+seconds\)"#
+    case parallelTestCaseFailed = #"^Test\s+case\s+'(.*)\.(.*)\(\)'\s+failed\s+on\s+'(.*)'\s+\((\d*\.(.*){3})\s+seconds\)"#
 
     /// Regular expression captured groups:
     /// $1 = device
-    case parallelTestingStarted = #"Testing\s+started\s+on\s+'(.*)'"#
+    case parallelTestingStarted = #"^Testing\s+started\s+on\s+'(.*)'"#
 
     /// Regular expression captured groups:
     /// $1 = device
-    case parallelTestingPassed = #"Testing\s+passed\s+on\s+'(.*)'"#
+    case parallelTestingPassed = #"^Testing\s+passed\s+on\s+'(.*)'"#
 
     /// Regular expression captured groups:
     /// $1 = device
-    case parallelTestingFailed = #"Testing\s+failed\s+on\s+'(.*)'"#
+    case parallelTestingFailed = #"^Testing\s+failed\s+on\s+'(.*)'"#
 
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = device
-    case parallelTestSuiteStarted = #"\s*Test\s+Suite\s+'(.*)'\s+started\s+on\s+'(.*)'"#
+    case parallelTestSuiteStarted = #"^\s*Test\s+Suite\s+'(.*)'\s+started\s+on\s+'(.*)'"#
 
     /// Nothing returned here for now
-    case phaseSuccess = #"\*\*\s(.*)\sSUCCEEDED\s\*\*"#
+    case phaseSuccess = #"^\*\*\s(.*)\sSUCCEEDED\s\*\*"#
 
     /// Regular expression captured groups:
     /// $1 = phase name
     /// $2 = target
-    case phaseScriptExecution = #"PhaseScriptExecution\s(.*)\s\/.*\.sh\s\((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case phaseScriptExecution = #"^PhaseScriptExecution\s(.*)\s\/.*\.sh\s\((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 = file
     /// $2 = build target
-    case processPch = #"ProcessPCH(?:\+\+)?\s.*\s\/.*\/(.*) normal .* .* .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case processPch = #"^ProcessPCH(?:\+\+)?\s.*\s\/.*\/(.*) normal .* .* .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 file path
-    case processPchCommand = #"\s*.*\/usr\/bin\/clang\s.*\s\-c\s(.*?)(?<!\\)\s.*\-o\s.*\.gch"#
+    case processPchCommand = #"^\s*.*\/usr\/bin\/clang\s.*\s\-c\s(.*?)(?<!\\)\s.*\-o\s.*\.gch"#
 
     /// Regular expression captured groups:
     /// $1 = file
-    case preprocess = #"Preprocess\s(?:(?:\ |[^ ])*)\s((?:\ |[^ ])*)$"#
+    case preprocess = #"^Preprocess\s(?:(?:\ |[^ ])*)\s((?:\ |[^ ])*)$"#
 
     /// Regular expression captured groups:
     /// $1 = source file
     /// $2 = target file
     /// $3 = build target
-    case pbxcp = #"PBXCp\s(.*)\s\/(.*)\s\((in target: (.*)|in target '(.*)' from project '.*')\)"#
+    case pbxcp = #"^PBXCp\s(.*)\s\/(.*)\s\((in target: (.*)|in target '(.*)' from project '.*')\)"#
 
     /// Regular expression captured groups:
     /// $1 = file path
     /// $2 = filename
     /// $4 = target
-    case processInfoPlist = #"ProcessInfoPlistFile\s.*\.plist\s(.*\/+(.*\.plist))( \((in target: (.*)|in target '(.*)' from project '.*')\))?"#
+    case processInfoPlist = #"^ProcessInfoPlistFile\s.*\.plist\s(.*\/+(.*\.plist))( \((in target: (.*)|in target '(.*)' from project '.*')\))?"#
 
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = result
     /// $3 = time
     #if os(Linux)
-    case testsRunCompletion = #"\s*Test Suite '(.*)' (finished|passed|failed) at (.*)"#
+    case testsRunCompletion = #"^\s*Test Suite '(.*)' (finished|passed|failed) at (.*)"#
     #else
-    case testsRunCompletion = #"\s*Test Suite '(?:.*\/)?(.*[ox]ctest.*)' (finished|passed|failed) at (.*)"#
+    case testsRunCompletion = #"^\s*Test Suite '(?:.*\/)?(.*[ox]ctest.*)' (finished|passed|failed) at (.*)"#
     #endif
 
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = time
     #if os(Linux)
-    case testSuiteStarted = #"\s*Test Suite '(.*)' started at(.*)"#
+    case testSuiteStarted = #"^\s*Test Suite '(.*)' started at(.*)"#
     #else
-    case testSuiteStarted = #"\s*Test Suite '(?:.*\/)?(.*[ox]ctest.*)' started at(.*)"#
+    case testSuiteStarted = #"^\s*Test Suite '(?:.*\/)?(.*[ox]ctest.*)' started at(.*)"#
     #endif
 
     /// Regular expression captured groups:
     /// $1 = test suite name
-    case testSuiteStart = #"\s*Test Suite '(.*)' started at"#
+    case testSuiteStart = #"^\s*Test Suite '(.*)' started at"#
 
     
-    case testSuiteAllTestsPassed = #"\s*Test Suite 'All tests' passed at"#
+    case testSuiteAllTestsPassed = #"^\s*Test Suite 'All tests' passed at"#
     
-    case testSuiteAllTestsFailed = #"\s*Test Suite 'All tests' failed at"#
+    case testSuiteAllTestsFailed = #"^\s*Test Suite 'All tests' failed at"#
     
     /// Regular expression captured groups:
     /// $1 = filename
-    case tiffutil = #"TiffUtil\s(.*)"#
+    case tiffutil = #"^TiffUtil\s(.*)"#
 
     /// Regular expression captured groups:
     /// $1 = filename
     /// $3 = target
-    case touch = #"Touch\s(.*\/(.+))( \((in target: (.*)|in target '(.*)' from project '.*')\))"#
+    case touch = #"^Touch\s(.*\/(.+))( \((in target: (.*)|in target '(.*)' from project '.*')\))"#
 
     /// Regular expression captured groups:
     /// $1 = file path
-    case writeFile = #"write-file\s(.*)"#
+    case writeFile = #"^write-file\s(.*)"#
 
     /// Nothing returned here for now
-    case writeAuxiliaryFiles = #"Write auxiliary files"#
+    case writeAuxiliaryFiles = #"^Write auxiliary files"#
 
     // MARK: - Warning
 
@@ -311,82 +311,82 @@ enum Pattern: String {
     /// $1 = file path
     /// $2 = filename
     /// $3 = reason
-    case compileWarning = #"(([^:]*):\d*:\d*):\swarning:\s(.*)$"#
+    case compileWarning = #"^(([^:]*):\d*:\d*):\swarning:\s(.*)$"#
 
     /// Regular expression captured groups:
     /// $1 = ld prefix
     /// $2 = warning message
-    case ldWarning = #"(ld: )warning: (.*)"#
+    case ldWarning = #"^(ld: )warning: (.*)"#
 
     /// Regular expression captured groups:
     /// $1 = whole warning
-    case genericWarning = #"warning:\s(.*)$"#
+    case genericWarning = #"^warning:\s(.*)$"#
 
     /// Regular expression captured groups:
     /// $1 = whole warning
-    case willNotBeCodeSigned = #"(.* will not be code signed because .*)$"#
+    case willNotBeCodeSigned = #"^(.* will not be code signed because .*)$"#
 
     // MARK: - Error
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    case clangError = #"(clang: error:.*)$"#
+    case clangError = #"^(clang: error:.*)$"#
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    case checkDependenciesErrors = #"(Code\s?Sign error:.*|Code signing is required for product type .* in SDK .*|No profile matching .* found:.*|Provisioning profile .* doesn't .*|Swift is unavailable on .*|.?Use Legacy Swift Language Version.*)$"#
+    case checkDependenciesErrors = #"^(Code\s?Sign error:.*|Code signing is required for product type .* in SDK .*|No profile matching .* found:.*|Provisioning profile .* doesn't .*|Swift is unavailable on .*|.?Use Legacy Swift Language Version.*)$"#
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    case provisioningProfileRequired = #"(.*requires a provisioning profile.*)$"#
+    case provisioningProfileRequired = #"^(.*requires a provisioning profile.*)$"#
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    case noCertificate = #"(No certificate matching.*)$"#
+    case noCertificate = #"^(No certificate matching.*)$"#
 
     /// Regular expression captured groups:
     /// $1 = file path (could be a relative path if you build with Bazel)
     /// $2 = is fatal error
     /// $3 = reason
-    case compileError = #"(([^:]*):\d*:\d*):\s(?:fatal\s)?error:\s(.*)$"#
+    case compileError = #"^(([^:]*):\d*:\d*):\s(?:fatal\s)?error:\s(.*)$"#
 
     /// Regular expression captured groups:
     /// $1 = cursor (with whitespaces and tildes)
-    case cursor = #"([\s~]*\^[\s~]*)$"#
+    case cursor = #"^([\s~]*\^[\s~]*)$"#
 
     /// Regular expression captured groups:
     /// $1 = whole error.
     /// it varies a lot, not sure if it makes sense to catch everything separately
-    case fatalError = #"(fatal error:.*)$"#
+    case fatalError = #"^(fatal error:.*)$"#
 
     /// Regular expression captured groups:
     /// $1 = whole error.
     /// $2 = file path
-    case fileMissingError = #"<unknown>:0:\s(error:\s.*)\s'(\/.+\/.*\..*)'$"#
+    case fileMissingError = #"^<unknown>:0:\s(error:\s.*)\s'(\/.+\/.*\..*)'$"#
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    case ldError = #"(ld:.*)"#
+    case ldError = #"^(ld:.*)"#
 
     /// Regular expression captured groups:
     /// $1 = file path
-    case linkerDuplicateSymbolsLocation = #"\s+(\/.*\.o[\)]?)$"#
+    case linkerDuplicateSymbolsLocation = #"^\s+(\/.*\.o[\)]?)$"#
 
     /// Regular expression captured groups:
     /// $1 = reason
-    case linkerDuplicateSymbols = #"(duplicate symbol .*):$"#
+    case linkerDuplicateSymbols = #"^(duplicate symbol .*):$"#
 
     /// Regular expression captured groups:
     /// $1 = symbol location
-    case linkerUndefinedSymbolLocation = #"(.* in .*\.o)$"#
+    case linkerUndefinedSymbolLocation = #"^(.* in .*\.o)$"#
 
     /// Regular expression captured groups:
     /// $1 = reason
-    case linkerUndefinedSymbols = #"(Undefined symbols for architecture .*):$"#
+    case linkerUndefinedSymbols = #"^(Undefined symbols for architecture .*):$"#
 
     /// Regular expression captured groups:
     /// $1 = reason
-    case podsError = #"(error:\s.*)"#
+    case podsError = #"^(error:\s.*)"#
 
     /// Regular expression captured groups:
     /// $1 = reference
@@ -394,7 +394,7 @@ enum Pattern: String {
 
     /// Regular expression captured groups:
     /// $1 = error reason
-    case moduleIncludesError = #"\<module-includes\>:.*?:.*?:\s(?:fatal\s)?(error:\s.*)$/"#
+    case moduleIncludesError = #"^\<module-includes\>:.*?:.*?:\s(?:fatal\s)?(error:\s.*)$/"#
 
     /// Regular expression captured groups:
     /// $1 = target
@@ -402,16 +402,16 @@ enum Pattern: String {
     case undefinedSymbolLocation = #".+ in (.+)\((.+)\.o\)$"#
 
     /// Regular expression captures groups:
-    case packageGraphResolvingStart = #"\s*(Resolve Package Graph)\s*$"#
-    case packageGraphResolvingEnded = #"(Resolved source packages):$"#
+    case packageGraphResolvingStart = #"^\s*(Resolve Package Graph)\s*$"#
+    case packageGraphResolvingEnded = #"^(Resolved source packages):$"#
 
     /// Regular expression captures groups:
     /// $1 = package name
     /// $2 = package url
     /// $3 = package version
-    case packageGraphResolvedItem = #"\s*([^\s:]+):\s([^ ]+)\s@\s(\d+\.\d+\.\d+)"#;
+    case packageGraphResolvedItem = #"^\s*([^\s:]+):\s([^ ]+)\s@\s(\d+\.\d+\.\d+)"#;
     
     /// Regular expression captured groups:
     /// $1 = whole error
-    case xcodebuildError = #"(xcodebuild: error:.*)$"#;
+    case xcodebuildError = #"^(xcodebuild: error:.*)$"#;
 }


### PR DESCRIPTION
Most of the patterns should match from beginning of string. We can use that knowledge to reduce backtracking. [xcpretty](https://github.com/xcpretty/xcpretty/blob/master/lib/xcpretty/parser.rb) uses this too – almost all their matchers starting from `^`.

For example consider this string from build log:
```
ProcessProductPackagingDER /Users/me/Library/Caches/JetBrains/AppCode2022.2/DerivedData/EmptyProj-bkpufupvitxypoafwouddrisptic/Build/Intermediates.noindex/EmptyProj.build/Debug-iphonesimulator/EmptyProj.build/EmptyProj.app-Simulated.xcent /Users/me/Library/Caches/JetBrains/AppCode2022.2/DerivedData/EmptyProj-bkpufupvitxypoafwouddrisptic/Build/Intermediates.noindex/EmptyProj.build/Debug-iphonesimulator/EmptyProj.build/EmptyProj.app-Simulated.xcent.der (in target 'EmptyProj' from project 'EmptyProj')
```

When we try to match this string using compile warning patter `(([^:]*):\d*:\d*):\swarning:\s(.*)$` it takes 2520 steps before fail (see https://regex101.com/debugger).

If we use updated pattern `^(([^:]*):\d*:\d*):\swarning:\s(.*)$` it takes only 6 steps before fail.


<img width="850" alt="old" src="https://user-images.githubusercontent.com/1800899/199250093-7c1c3f3e-e541-413d-a1ca-4f89bf9681cc.png">
<img width="850" alt="new" src="https://user-images.githubusercontent.com/1800899/199250113-21a0223f-f254-4551-b6f8-08c2029b6dab.png">



In my case this helped reduce build log parsing time from 4 seconds to 20 milliseconds.

Related issue: https://github.com/tuist/xcbeautify/issues/68