### PR TITLE
Add support for xcodebuild exportLocalizations warnings

### DIFF
--- a/Sources/XcbeautifyLib/Matcher.swift
+++ b/Sources/XcbeautifyLib/Matcher.swift
@@ -21,6 +21,7 @@ struct Matcher {
     static let copyStringsMatcher = Regex(pattern: .copyStrings)
     static let cpresourceMatcher = Regex(pattern: .cpresource)
     static let cursorMatcher = Regex(pattern: .cursor)
+    static let dupliateLocalizedStringKey = Regex(pattern: .duplicateLocalizedStringKey)
     static let executedMatcher = Regex(pattern: .executed)
     static let executedWithSkippedMatcher = Regex(pattern: .executedWithSkipped)
     static let failingTestMatcher = Regex(pattern: .failingTest)

--- a/Sources/XcbeautifyLib/Matcher.swift
+++ b/Sources/XcbeautifyLib/Matcher.swift
@@ -21,7 +21,7 @@ struct Matcher {
     static let copyStringsMatcher = Regex(pattern: .copyStrings)
     static let cpresourceMatcher = Regex(pattern: .cpresource)
     static let cursorMatcher = Regex(pattern: .cursor)
-    static let dupliateLocalizedStringKey = Regex(pattern: .duplicateLocalizedStringKey)
+    static let duplicateLocalizedStringKey = Regex(pattern: .duplicateLocalizedStringKey)
     static let executedMatcher = Regex(pattern: .executed)
     static let executedWithSkippedMatcher = Regex(pattern: .executedWithSkipped)
     static let failingTestMatcher = Regex(pattern: .failingTest)

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -89,7 +89,7 @@ public class Parser {
         innerParser(Matcher.packageGraphResolvingEnded, outputType: .task),
         innerParser(Matcher.packageGraphResolvedItem, outputType: .task),
         innerParser(Matcher.xcodebuildErrorMatcher, outputType: .error),
-        innerParser(Matcher.dupliateLocalizedStringKey, outputType: .warning)
+        innerParser(Matcher.duplicateLocalizedStringKey, outputType: .warning)
     ]
     
     // MARK: - Init

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -88,7 +88,8 @@ public class Parser {
         innerParser(Matcher.packageGraphResolvingStart, outputType: .task),
         innerParser(Matcher.packageGraphResolvingEnded, outputType: .task),
         innerParser(Matcher.packageGraphResolvedItem, outputType: .task),
-        innerParser(Matcher.xcodebuildErrorMatcher, outputType: .error)
+        innerParser(Matcher.xcodebuildErrorMatcher, outputType: .error),
+        innerParser(Matcher.dupliateLocalizedStringKey, outputType: .warning)
     ]
     
     // MARK: - Init

--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -326,6 +326,12 @@ enum Pattern: String {
     /// $1 = whole warning
     case willNotBeCodeSigned = #"^(.* will not be code signed because .*)$"#
 
+    /// Regular expresion captured groups:
+    /// $1 = duplicate key
+    /// $2 = value kept
+    /// $3 = value ignored
+    case duplicateLocalizedStringKey = #"^[\d\s-:]+ --- WARNING: Key "(.*)" used with multiple values. Value "(.*)" kept. Value "(.*)" ignored.$"#
+
     // MARK: - Error
 
     /// Regular expression captured groups:
@@ -414,10 +420,4 @@ enum Pattern: String {
     /// Regular expression captured groups:
     /// $1 = whole error
     case xcodebuildError = #"^(xcodebuild: error:.*)$"#;
-
-    /// Regular expresion captured groups:
-    /// $1 = duplicate key
-    /// $2 = value kept
-    /// $3 = value ignored
-    case duplicateLocalizedStringKey = #"Key "(.*)" used with multiple values. Value "(.*)" kept. Value "(.*)" ignored."#
 }

--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -327,10 +327,8 @@ enum Pattern: String {
     case willNotBeCodeSigned = #"^(.* will not be code signed because .*)$"#
 
     /// Regular expresion captured groups:
-    /// $1 = duplicate key
-    /// $2 = value kept
-    /// $3 = value ignored
-    case duplicateLocalizedStringKey = #"^[\d\s-:]+ --- WARNING: Key "(.*)" used with multiple values. Value "(.*)" kept. Value "(.*)" ignored.$"#
+    /// $1 = warning message.
+    case duplicateLocalizedStringKey = #"^[\d\s-:]+ --- WARNING: (Key ".*" used with multiple values. Value ".*" kept. Value ".*" ignored.)$"#
 
     // MARK: - Error
 

--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -414,4 +414,10 @@ enum Pattern: String {
     /// Regular expression captured groups:
     /// $1 = whole error
     case xcodebuildError = #"^(xcodebuild: error:.*)$"#;
+
+    /// Regular expresion captured groups:
+    /// $1 = duplicate key
+    /// $2 = value kept
+    /// $3 = value ignored
+    case duplicateLocalizedStringKey = #"Key "(.*)" used with multiple values. Value "(.*)" kept. Value "(.*)" ignored."#
 }

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -535,10 +535,7 @@ extension String {
 
     private func formatDuplicateLocalizedStringKey(pattern: Pattern) -> String? {
         let groups = capturedGroups(with: pattern)
-        let key = groups[0]
-        let kept = groups[1]
-        let ignored = groups[2]
-        let string = "Key \"\(key)\" used with multiple values. Value \"\(kept)\" kept. Value \"\(ignored)\" ignored."
-        return _colored ? Symbol.warning.rawValue + " " + string.f.Yellow : Symbol.asciiWarning.rawValue + " " + string
+        let message = groups[0]
+        return _colored ? Symbol.warning.rawValue + " " + message.f.Yellow : Symbol.asciiWarning.rawValue + " " + message
     }
 }

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -538,7 +538,7 @@ extension String {
         let key = groups[0]
         let kept = groups[1]
         let ignored = groups[2]
-        return _colored ? Symbol.warning.rawValue + " " + self.f.Yellow : Symbol.asciiWarning.rawValue + " " +
-            "Key \"\(key)\" used with multiple values. Value \"\(kept)\" kept. Value \"\(ignored)\" ignored."
+        let string = "Key \"\(key)\" used with multiple values. Value \"\(kept)\" kept. Value \"\(ignored)\" ignored."
+        return _colored ? Symbol.warning.rawValue + " " + string.f.Yellow : Symbol.asciiWarning.rawValue + " " + string
     }
 }

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -150,6 +150,8 @@ extension String {
             return formatPackageEnd(pattern: pattern)
         case .packageGraphResolvedItem:
             return formatPackgeItem(pattern: pattern)
+        case .duplicateLocalizedStringKey:
+            return formatDuplicateLocalizedStringKey(pattern: pattern)
         }
     }
 
@@ -529,5 +531,14 @@ extension String {
         let url = groups[1]
         let version = groups[2]
         return _colored ? name.s.Bold.f.Cyan + " - " + url.s.Bold + " @ " + version.f.Green : "\(name) - \(url) @ \(version)"
+    }
+
+    private func formatDuplicateLocalizedStringKey(pattern: Pattern) -> String? {
+        let groups = capturedGroups(with: pattern)
+        let key = groups[0]
+        let kept = groups[1]
+        let ignored = groups[2]
+        return _colored ? Symbol.warning.rawValue + " " + self.f.Yellow : Symbol.asciiWarning.rawValue + " " +
+            "Key \"\(key)\" used with multiple values. Value \"\(kept)\" kept. Value \"\(ignored)\" ignored."
     }
 }

--- a/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
+++ b/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
@@ -541,4 +541,10 @@ final class XcbeautifyLibTests: XCTestCase {
         let formatted = noColoredFormatted("xcodebuild: error: Existing file at -resultBundlePath \"/output/file.xcresult\"")
         XCTAssertEqual(formatted, "[x] xcodebuild: error: Existing file at -resultBundlePath \"/output/file.xcresult\"")
     }
+
+    func testDuplicateLocalizedStringKey() {
+        let formatted = noColoredFormatted(#"2022-12-07 16:26:40 --- WARNING: Key "duplicate" used with multiple values. Value "First" kept. Value "Second" ignored."#)
+        XCTAssertEqual(formatted, #"[!] Key "duplicate" used with multiple values. Value "First" kept. Value "Second" ignored."#)
+        XCTAssertEqual(parser.outputType, .warning)
+    }
 }


### PR DESCRIPTION
The `xcodebuild -exportLocalizations` subcommand will warn when you have reused a localized string key with different values. This PR adds support for forwarding that warning through xcbeautify. I've decided to keep the original message as it is informative and already quite terse. I didn't use `formatCompleteWarning` because there is a `--- WARNING: ` prefix before the message.