### PR TITLE
Add restarting test failures to junit report 

### DIFF
--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -22,6 +22,8 @@ public final class JunitReporter {
             // Capture standard output
             case Matcher.failingTestMatcher:
                 components.append(.failingTest(generateFailingTest(line: line)))
+            case Matcher.restartingTestMatcher:
+                components.append(.failingTest(generateRestartingTest(line: line)))
             case Matcher.testCasePassedMatcher:
                 components.append(.testCasePassed(generatePassingTest(line: line)))
             case Matcher.testSuiteStartMatcher:
@@ -44,6 +46,16 @@ public final class JunitReporter {
             name: groups[2],
             time: nil,
             failure: .init(message: "\(groups[0]) - \(groups[3])")
+        )
+    }
+    
+    private func generateRestartingTest(line: String) -> Testcase {
+        let groups = line.capturedGroups(with: Matcher.restartingTestMatcher.pattern)
+        return Testcase(
+            classname: groups[1],
+            name: groups[2],
+            time: nil,
+            failure: .init(message: line)
         )
     }
 

--- a/Sources/XcbeautifyLib/Matcher.swift
+++ b/Sources/XcbeautifyLib/Matcher.swift
@@ -63,7 +63,7 @@ struct Matcher {
     static let processPchCommandMatcher = Regex(pattern: .processPchCommand)
     static let processPchMatcher = Regex(pattern: .processPch)
     static let provisioningProfileRequiredMatcher = Regex(pattern: .provisioningProfileRequired)
-    static let restartingTestsMatcher = Regex(pattern: .restartingTests)
+    static let restartingTestMatcher = Regex(pattern: .restartingTest)
     static let shellCommandMatcher = Regex(pattern: .shellCommand)
     static let symbolReferencedFromMatcher = Regex(pattern: .symbolReferencedFrom)
     static let testCaseMeasuredMatcher = Regex(pattern: .testCaseMeasured)

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -32,7 +32,7 @@ public class Parser {
         innerParser(Matcher.cpresourceMatcher, outputType: .task),
         innerParser(Matcher.failingTestMatcher, outputType: .error),
         innerParser(Matcher.uiFailingTestMatcher, outputType: .error),
-        innerParser(Matcher.restartingTestsMatcher, outputType: .test),
+        innerParser(Matcher.restartingTestMatcher, outputType: .test),
         innerParser(Matcher.generateCoverageDataMatcher, outputType: .task),
         innerParser(Matcher.generatedCoverageReportMatcher, outputType: .task),
         innerParser(Matcher.generateDsymMatcher, outputType: .task),

--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -128,7 +128,10 @@ enum Pattern: String {
     case uiFailingTest = #"^\s{4}t = \s+\d+\.\d+s\s+Assertion Failure: (.*:\d+): (.*)$"#
 
     /// Regular expression captured groups:
-    case restartingTests = #"^Restarting after unexpected exit.+$"#
+    /// $1 = test suite + test case
+    /// $2 = test suite
+    /// $3 = test case
+    case restartingTest = #"^Restarting after unexpected exit, crash, or test timeout in (-\[(\w+)\s(\w+)\]|(\w+)\.(\w+)\(\));"#
 
     /// Nothing returned here for now.
     case generateCoverageData = #"^generating\s+coverage\s+data\.*"#

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -54,7 +54,7 @@ extension String {
             return nil
         case .failingTest,
              .uiFailingTest,
-             .restartingTests,
+             .restartingTest,
              .testCasePassed,
              .testCasePending,
              .testCaseMeasured,
@@ -347,7 +347,7 @@ extension String {
             let file = groups[0]
             let failingReason = groups[1]
             return _colored ? indent + TestStatus.fail.rawValue.foreground.Red + " "  + file + ", " + failingReason : indent + TestStatus.fail.rawValue + " "  + file + ", " + failingReason
-        case .restartingTests:
+        case .restartingTest:
             return _colored ? indent + TestStatus.fail.rawValue.foreground.Red + " "  + self : indent + TestStatus.fail.rawValue + " "  + self
         case .testCasePending:
             let testCase = groups[1]

--- a/Tests/XcbeautifyLibTests/JunitReporterTests.swift
+++ b/Tests/XcbeautifyLibTests/JunitReporterTests.swift
@@ -177,6 +177,8 @@ class JunitReporterTests: XCTestCase {
         Test Case '-[XcbeautifyLibTests.XcbeautifyLibTests testWriteAuxiliaryFiles]' passed (0.000 seconds).
         Test Case '-[XcbeautifyLibTests.XcbeautifyLibTests testWriteFile]' started.
         Test Case '-[XcbeautifyLibTests.XcbeautifyLibTests testWriteFile]' passed (0.000 seconds).
+        Restarting after unexpected exit, crash, or test timeout in SwiftTests.testExample(); summary will include totals from previous launches.
+        Restarting after unexpected exit, crash, or test timeout in -[ObjCTests testExample]; summary will include totals from previous launches.
         Test Suite 'XcbeautifyLibTests' failed at 2021-11-05 01:08:23.443.
              Executed 77 tests, with 1 failure (0 unexpected) in 0.147 (0.149) seconds
         Test Suite 'xcbeautifyPackageTests.xctest' failed at 2021-11-05 01:08:23.443.
@@ -186,7 +188,7 @@ class JunitReporterTests: XCTestCase {
         """
 
     private let expectedMacOsXml = """
-        <testsuites name="All tests" tests="83" failures="1">
+        <testsuites name="All tests" tests="85" failures="3">
             <testsuite name="XcbeautifyLibTests.OutputHandlerTests" tests="6" failures="0">
                 <testcase classname="XcbeautifyLibTests.OutputHandlerTests" name="testEarlyReturnIfEmptyString" time="0.054" />
                 <testcase classname="XcbeautifyLibTests.OutputHandlerTests" name="testPrintAllOutputTypeByDefault" time="0.000" />
@@ -276,11 +278,21 @@ class JunitReporterTests: XCTestCase {
                 <testcase classname="XcbeautifyLibTests.XcbeautifyLibTests" name="testWriteAuxiliaryFiles" time="0.000" />
                 <testcase classname="XcbeautifyLibTests.XcbeautifyLibTests" name="testWriteFile" time="0.000" />
             </testsuite>
+            <testsuite name="SwiftTests" tests="1" failures="1">
+                <testcase classname="SwiftTests" name="testExample">
+                    <failure message="Restarting after unexpected exit, crash, or test timeout in SwiftTests.testExample(); summary will include totals from previous launches." />
+                </testcase>
+            </testsuite>
+            <testsuite name="ObjCTests" tests="1" failures="1">
+                <testcase classname="ObjCTests" name="testExample">
+                    <failure message="Restarting after unexpected exit, crash, or test timeout in -[ObjCTests testExample]; summary will include totals from previous launches." />
+                </testcase>
+            </testsuite>
         </testsuites>
         """
 
     private let expectedLinuxXml = """
-        <testsuites name="All tests" tests="83" failures="1">
+        <testsuites name="All tests" tests="85" failures="3">
             <testsuite name="-[XcbeautifyLibTests" tests="83" failures="1">
                 <testcase classname="-[XcbeautifyLibTests" name="OutputHandlerTests testEarlyReturnIfEmptyString]" time="0.054" />
                 <testcase classname="-[XcbeautifyLibTests" name="OutputHandlerTests testPrintAllOutputTypeByDefault]" time="0.000" />
@@ -367,6 +379,16 @@ class JunitReporterTests: XCTestCase {
                 <testcase classname="-[XcbeautifyLibTests" name="XcbeautifyLibTests testWillNotBeCodeSigned]" time="0.000" />
                 <testcase classname="-[XcbeautifyLibTests" name="XcbeautifyLibTests testWriteAuxiliaryFiles]" time="0.000" />
                 <testcase classname="-[XcbeautifyLibTests" name="XcbeautifyLibTests testWriteFile]" time="0.000" />
+            </testsuite>
+            <testsuite name="SwiftTests" tests="1" failures="1">
+                <testcase classname="SwiftTests" name="testExample">
+                    <failure message="Restarting after unexpected exit, crash, or test timeout in SwiftTests.testExample(); summary will include totals from previous launches." />
+                </testcase>
+            </testsuite>
+            <testsuite name="ObjCTests" tests="1" failures="1">
+                <testcase classname="ObjCTests" name="testExample">
+                    <failure message="Restarting after unexpected exit, crash, or test timeout in -[ObjCTests testExample]; summary will include totals from previous launches." />
+                </testcase>
             </testsuite>
         </testsuites>
         """


### PR DESCRIPTION
I noticed junit reports didn't include restarting tests (e.g. tests timing out, causing a crash, etc...).

This PR is extracting the restarting test suite and case and reports it in the junit file.