### PR TITLE
Allow spaces in the names of test cases

### DIFF
--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -119,7 +119,7 @@ enum Pattern: String {
     #if os(Linux)
     case failingTest = #"^\s*(.+:\d+):\serror:\s(.*)\.(.*)\s:(?:\s'.*'\s\[failed\],)?\s(.*)"#
     #else
-    case failingTest = #"^\s*(.+:\d+):\serror:\s[\+\-]\[(.*)\s(.*)\]\s:(?:\s'.*'\s\[FAILED\],)?\s(.*)"#
+    case failingTest = #"^\s*(.+:\d+):\serror:\s[\+\-]\[(.*?)\s(.*)\]\s:(?:\s'.*'\s\[FAILED\],)?\s(.*)"#
     #endif
 
     /// Regular expression captured groups:
@@ -168,7 +168,7 @@ enum Pattern: String {
     #if os(Linux)
     case testCasePassed = #"^\s*Test Case\s'(.*)\.(.*)'\spassed\s\((\d*\.\d{1,3})\sseconds\)"#
     #else
-    case testCasePassed = #"^\s*Test Case\s'-\[(.*)\s(.*)\]'\spassed\s\((\d*\.\d{3})\sseconds\)."#
+    case testCasePassed = #"^\s*Test Case\s'-\[(.*?)\s(.*)\]'\spassed\s\((\d*\.\d{3})\sseconds\)."#
     #endif
 
     /// Regular expression captured groups:
@@ -177,21 +177,21 @@ enum Pattern: String {
     #if os(Linux)
     case testCaseStarted = #"^Test Case '(.*)\.(.*)' started at"#
     #else
-    case testCaseStarted = #"^Test Case '-\[(.*) (.*)\]' started.$"#
+    case testCaseStarted = #"^Test Case '-\[(.*?) (.*)\]' started.$"#
     #endif
 
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = test case
-    case testCasePending = #"^Test Case\s'-\[(.*)\s(.*)PENDING\]'\spassed"#
+    case testCasePending = #"^Test Case\s'-\[(.*?)\s(.*)PENDING\]'\spassed"#
 
     /// $1 = suite
     /// $2 = test case
     /// $3 = time
     #if os(Linux)
-    case testCaseMeasured = #"^[^:]*:[^:]*:\sTest Case\s'(.*)\.(.*)'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#
+    case testCaseMeasured = #"^[^:]*:[^:]*:\sTest Case\s'(.*?)\.(.*)'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#
     #else
-    case testCaseMeasured = #"^[^:]*:[^:]*:\sTest Case\s'-\[(.*)\s(.*)\]'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#
+    case testCaseMeasured = #"^[^:]*:[^:]*:\sTest Case\s'-\[(.*?)\s(.*)\]'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#
     #endif
 
     /// Regular expression captured groups:
@@ -205,7 +205,7 @@ enum Pattern: String {
     /// $1 = suite
     /// $2 = test case
     /// $3 = time
-    case parallelTestCaseAppKitPassed = #"^\s*Test case\s'-\[(.*)\s(.*)\]'\spassed\son\s'.*'\s\((\d*\.\d{3})\sseconds\)"#
+    case parallelTestCaseAppKitPassed = #"^\s*Test case\s'-\[(.*?)\s(.*)\]'\spassed\son\s'.*'\s\((\d*\.\d{3})\sseconds\)"#
 
     /// Regular expression captured groups:
     /// $1 = suite

--- a/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
+++ b/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
@@ -314,6 +314,16 @@ final class XcbeautifyLibTests: XCTestCase {
     func testNoCertificate() {
     }
 
+    func testTestCaseWithSpacesPassed() {
+        let formatted = noColoredFormatted("Test Case '-[MyProject.MyTestSuite some component, when the disk is full, will display an error]' passed (0.005 seconds).")
+        XCTAssertEqual(formatted, "    ✔ some component, when the disk is full, will display an error (0.005 seconds)")
+    }
+
+    func testTestCaseWithSpacesFailed() {
+        let formatted = noColoredFormatted("/Users/jsmith/MyProject/Example.swift:12: error: -[MyProject.MyTestSuite one, when added to two, produces three] : expected to equal <3>, got <4>")
+        XCTAssertEqual(formatted, "    ✖ one, when added to two, produces three, expected to equal <3>, got <4>")
+    }
+
     func testParallelTestCaseFailed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'xctest (49438)' (0.131 seconds)")
         XCTAssertEqual(formatted, "    ✖ testBuildTarget on 'xctest (49438)' (0.131 seconds)")
@@ -342,6 +352,11 @@ final class XcbeautifyLibTests: XCTestCase {
     func testParallelTestCaseAppKitPassed() {
         let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed on 'xctest (49438)' (0.131 seconds).")
         XCTAssertEqual(formatted, "    ✔ testBuildTarget (0.131) seconds)")
+    }
+
+    func testParallelTestCaseAppKitWithSpacesPassed() {
+        let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests test build target]' passed on 'xctest (49438)' (0.131 seconds).")
+        XCTAssertEqual(formatted, "    ✔ test build target (0.131) seconds)")
     }
 
     func testParallelTestingStarted() {


### PR DESCRIPTION
The recent [Quick 7] release changed how test selectors are created. The main difference is that these names may now include spaces and commas. xcbeautify previously assumed that test-case names would not include spaces; this commit tweaks the regular expressions to assume that test *suite* names will not include spaces, but that test *case* names may.

[Quick 7]: https://github.com/Quick/Quick/releases/tag/v7.0.0