### PR TITLE
Introduce Type-Safe Capture Groups

### DIFF
--- a/Sources/XcbeautifyLib/Array+Safe.swift
+++ b/Sources/XcbeautifyLib/Array+Safe.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension Array {
+    /// Returns the element at the specified index if it is within bounds, otherwise nil.
+    subscript (safe index: Index) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -2,6 +2,10 @@ import Foundation
 
 protocol CaptureGroup { }
 
+protocol ErrorCaptureGroup: CaptureGroup {
+    var wholeError: String { get }
+}
+
 struct EmptyCaptureGroup: CaptureGroup { }
 
 struct AnalyzeCaptureGroup: CaptureGroup {

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -387,7 +387,10 @@ struct PackageUpdatingCaptureGroup: CaptureGroup {
     let source: String
 }
 
-struct PackageCheckingOutCaptureGroup: CaptureGroup { }
+struct PackageCheckingOutCaptureGroup: CaptureGroup {
+    let version: String
+    let package: String
+}
 
 struct PackageGraphResolvingStartCaptureGroup: CaptureGroup { }
 

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -379,7 +379,9 @@ struct UndefinedSymbolLocationCaptureGroup: CaptureGroup {
     let filename: String
 }
 
-struct PackageFetchingCaptureGroup: CaptureGroup { }
+struct PackageFetchingCaptureGroup: CaptureGroup {
+    let source: String
+}
 
 struct PackageUpdatingCaptureGroup: CaptureGroup { }
 

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -314,19 +314,19 @@ struct DuplicateLocalizedStringKeyCaptureGroup: CaptureGroup {
     let warningMessage: String
 }
 
-struct ClangErrorCaptureGroup: CaptureGroup {
+struct ClangErrorCaptureGroup: ErrorCaptureGroup {
     let wholeError: String
 }
 
-struct CheckDependenciesErrorsCaptureGroup: CaptureGroup {
+struct CheckDependenciesErrorsCaptureGroup: ErrorCaptureGroup {
     let wholeError: String
 }
 
-struct ProvisioningProfileRequiredCaptureGroup: CaptureGroup {
+struct ProvisioningProfileRequiredCaptureGroup: ErrorCaptureGroup {
     let wholeError: String
 }
 
-struct NoCertificateCaptureGroup: CaptureGroup {
+struct NoCertificateCaptureGroup: ErrorCaptureGroup {
     let wholeError: String
 }
 
@@ -340,7 +340,7 @@ struct CursorCaptureGroup: CaptureGroup {
     let cursor: String
 }
 
-struct FatalErrorCaptureGroup: CaptureGroup {
+struct FatalErrorCaptureGroup: ErrorCaptureGroup {
     let wholeError: String
 }
 
@@ -349,7 +349,7 @@ struct FileMissingErrorCaptureGroup: CaptureGroup {
     let filePath: String
 }
 
-struct LDErrorCaptureGroup: CaptureGroup {
+struct LDErrorCaptureGroup: ErrorCaptureGroup {
     let wholeError: String
 }
 
@@ -369,16 +369,16 @@ struct LinkerUndefinedSymbolsCaptureGroup: CaptureGroup {
     let reason: String
 }
 
-struct PodsErrorCaptureGroup: CaptureGroup {
-    let reason: String
+struct PodsErrorCaptureGroup: ErrorCaptureGroup {
+    let wholeError: String
 }
 
 struct SymbolReferencedFromCaptureGroup: CaptureGroup {
     let reference: String
 }
 
-struct ModuleIncludesErrorCaptureGroup: CaptureGroup {
-    let errorReason: String
+struct ModuleIncludesErrorCaptureGroup: ErrorCaptureGroup {
+    let wholeError: String
 }
 
 struct UndefinedSymbolLocationCaptureGroup: CaptureGroup {
@@ -409,7 +409,7 @@ struct PackageGraphResolvedItemCaptureGroup: CaptureGroup {
     let packageVersion: String
 }
 
-struct XcodebuildErrorCaptureGroup: CaptureGroup {
+struct XcodebuildErrorCaptureGroup: ErrorCaptureGroup {
     let wholeError: String
 }
 

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -48,7 +48,7 @@ struct CodesignCaptureGroup: CaptureGroup {
 }
 
 struct CodesignFrameworkCaptureGroup: CaptureGroup {
-    let file: String
+    let frameworkPath: String
 }
 
 #if os(Linux)

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -248,7 +248,7 @@ struct PbxcpCaptureGroup: CaptureGroup {
 struct ProcessInfoPlistCaptureGroup: CaptureGroup {
     let filePath: String
     let filename: String
-    let target: String?
+    let target: String? // Xcode 10+
 }
 
 struct TestsRunCompletionCaptureGroup: CaptureGroup {

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -148,7 +148,7 @@ struct GenerateDSYMCaptureGroup: CaptureGroup {
 }
 
 struct LibtoolCaptureGroup: CaptureGroup {
-    let library: String
+    let fileName: String
     let target: String
 }
 

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -220,7 +220,9 @@ struct ParallelTestSuiteStartedCaptureGroup: CaptureGroup {
     let device: String
 }
 
-struct PhaseSuccessCaptureGroup: CaptureGroup { }
+struct PhaseSuccessCaptureGroup: CaptureGroup {
+    let phase: String
+}
 
 struct PhaseScriptExecutionCaptureGroup: CaptureGroup {
     let phaseName: String

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -383,7 +383,9 @@ struct PackageFetchingCaptureGroup: CaptureGroup {
     let source: String
 }
 
-struct PackageUpdatingCaptureGroup: CaptureGroup { }
+struct PackageUpdatingCaptureGroup: CaptureGroup {
+    let source: String
+}
 
 struct PackageCheckingOutCaptureGroup: CaptureGroup { }
 

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -17,6 +17,11 @@ protocol CompileFileCaptureGroup: CaptureGroup {
     var target: String { get }
 }
 
+protocol CopyCaptureGroup: CaptureGroup {
+    var file: String { get }
+    var target: String { get }
+}
+
 struct EmptyCaptureGroup: CaptureGroup { }
 
 struct AnalyzeCaptureGroup: CaptureGroup {
@@ -94,23 +99,25 @@ struct CompileStoryboardCaptureGroup: CompileFileCaptureGroup {
     let target: String
 }
 
-struct CopyHeaderCaptureGroup: CaptureGroup {
-    let sourceFile: String
+struct CopyHeaderCaptureGroup: CopyCaptureGroup {
+    let file: String
     let targetFile: String
     let target: String
 }
 
-struct CopyPlistCaptureGroup: CaptureGroup {
-    let sourceFile: String
-    let targetFile: String
-}
-
-struct CopyStringsCaptureGroup: CaptureGroup {
+struct CopyPlistCaptureGroup: CopyCaptureGroup {
     let file: String
+    let target: String
 }
 
-struct CpresourceCaptureGroup: CaptureGroup {
-    let resource: String
+struct CopyStringsCaptureGroup: CopyCaptureGroup {
+    let file: String
+    let target: String
+}
+
+struct CpresourceCaptureGroup: CopyCaptureGroup {
+    let file: String
+    let target: String
 }
 
 struct ExecutedCaptureGroup: CaptureGroup {
@@ -253,10 +260,10 @@ struct PreprocessCaptureGroup: CaptureGroup {
     let file: String
 }
 
-struct PbxcpCaptureGroup: CaptureGroup {
-    let sourceFile: String
+struct PbxcpCaptureGroup: CopyCaptureGroup {
+    let file: String
     let targetFile: String
-    let buildTarget: String
+    let target: String
 }
 
 struct ProcessInfoPlistCaptureGroup: CaptureGroup {

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -7,6 +7,7 @@ struct EmptyCaptureGroup: CaptureGroup { }
 struct AnalyzeCaptureGroup: CaptureGroup {
     let filePath: String
     let fileName: String
+    let target: String
 }
 
 struct BuildTargetCaptureGroup: CaptureGroup {

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -178,13 +178,16 @@ struct TestCasePendingCaptureGroup: CaptureGroup {
 struct TestCaseMeasuredCaptureGroup: CaptureGroup {
     let suite: String
     let testCase: String
-    let time: String
+    let name: String
+    let unitName: String
+    let value: String
+    let deviation: String
 }
 
 struct ParallelTestCasePassedCaptureGroup: CaptureGroup {
     let suite: String
     let testCase: String
-    let installedAppFileAndID: String
+    let device: String
     let time: String
 }
 
@@ -197,7 +200,7 @@ struct ParallelTestCaseAppKitPassedCaptureGroup: CaptureGroup {
 struct ParallelTestCaseFailedCaptureGroup: CaptureGroup {
     let suite: String
     let testCase: String
-    let installedAppFileAndID: String
+    let device: String
     let time: String
 }
 

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -338,7 +338,7 @@ struct FatalErrorCaptureGroup: CaptureGroup {
 }
 
 struct FileMissingErrorCaptureGroup: CaptureGroup {
-    let wholeError: String
+    let reason: String
     let filePath: String
 }
 

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -12,6 +12,11 @@ protocol TargetCaptureGroup: CaptureGroup {
     var configuration: String { get }
 }
 
+protocol CompileFileCaptureGroup: CaptureGroup {
+    var filename: String { get }
+    var target: String { get }
+}
+
 struct EmptyCaptureGroup: CaptureGroup { }
 
 struct AnalyzeCaptureGroup: CaptureGroup {
@@ -64,7 +69,7 @@ struct CodesignFrameworkCaptureGroup: CaptureGroup {
     let frameworkPath: String
 }
 
-struct CompileCaptureGroup: CaptureGroup {
+struct CompileCaptureGroup: CompileFileCaptureGroup {
 #if !os(Linux)
     let filePath: String
 #endif
@@ -77,13 +82,13 @@ struct CompileCommandCaptureGroup: CaptureGroup {
     let filePath: String
 }
 
-struct CompileXibCaptureGroup: CaptureGroup {
+struct CompileXibCaptureGroup: CompileFileCaptureGroup {
     let filePath: String
     let filename: String
     let target: String
 }
 
-struct CompileStoryboardCaptureGroup: CaptureGroup {
+struct CompileStoryboardCaptureGroup: CompileFileCaptureGroup {
     let filePath: String
     let filename: String
     let target: String

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -152,16 +152,12 @@ struct LibtoolCaptureGroup: CaptureGroup {
     let target: String
 }
 
-#if os(Linux)
 struct LinkingCaptureGroup: CaptureGroup {
-    let target: String
-}
-#else
-struct LinkingCaptureGroup: CaptureGroup {
+#if !os(Linux)
     let binaryFilename: String
+#endif
     let target: String
 }
-#endif
 
 struct TestCasePassedCaptureGroup: CaptureGroup {
     let suite: String

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+protocol CaptureGroup { }

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -58,18 +58,13 @@ struct CodesignFrameworkCaptureGroup: CaptureGroup {
     let frameworkPath: String
 }
 
-#if os(Linux)
 struct CompileCaptureGroup: CaptureGroup {
-    let filename: String
-    let target: String
-}
-#else
-struct CompileCaptureGroup: CaptureGroup {
+#if !os(Linux)
     let filePath: String
+#endif
     let filename: String
     let target: String
 }
-#endif
 
 struct CompileCommandCaptureGroup: CaptureGroup {
     let compilerCommand: String

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -1,3 +1,402 @@
 import Foundation
 
 protocol CaptureGroup { }
+
+struct EmptyCaptureGroup: CaptureGroup { }
+
+struct AnalyzeCaptureGroup: CaptureGroup {
+    let filePath: String
+    let fileName: String
+}
+
+struct BuildTargetCaptureGroup: CaptureGroup {
+    let target: String
+    let project: String
+    let configuration: String
+}
+
+struct AggregateTargetCaptureGroup: CaptureGroup {
+    let target: String
+    let project: String
+    let configuration: String
+}
+
+struct AnalyzeTargetCaptureGroup: CaptureGroup {
+    let target: String
+    let project: String
+    let configuration: String
+}
+
+/// Nothing returned here for now
+struct CheckDependenciesCaptureGroup: CaptureGroup { }
+
+struct ShellCommandCaptureGroup: CaptureGroup {
+    let commandPath: String
+    let arguments: String
+}
+
+struct CleanRemoveCaptureGroup: CaptureGroup { }
+
+struct CleanTargetCaptureGroup: CaptureGroup {
+    let target: String
+    let project: String
+    let configuration: String
+}
+
+struct CodesignCaptureGroup: CaptureGroup {
+    let file: String
+}
+
+struct CodesignFrameworkCaptureGroup: CaptureGroup {
+    let file: String
+}
+
+#if os(Linux)
+struct CompileCaptureGroup: CaptureGroup {
+    let filename: String
+    let target: String
+}
+#else
+struct CompileCaptureGroup: CaptureGroup {
+    let filePath: String
+    let filename: String
+    let target: String
+}
+#endif
+
+struct CompileCommandCaptureGroup: CaptureGroup {
+    let compilerCommand: String
+    let filePath: String
+}
+
+struct CompileXibCaptureGroup: CaptureGroup {
+    let filePath: String
+    let filename: String
+    let target: String
+}
+
+struct CompileStoryboardCaptureGroup: CaptureGroup {
+    let filePath: String
+    let filename: String
+    let target: String
+}
+
+struct CopyHeaderCaptureGroup: CaptureGroup {
+    let sourceFile: String
+    let targetFile: String
+    let target: String
+}
+
+struct CopyPlistCaptureGroup: CaptureGroup {
+    let sourceFile: String
+    let targetFile: String
+}
+
+struct CopyStringsCaptureGroup: CaptureGroup {
+    let file: String
+}
+
+struct CpresourceCaptureGroup: CaptureGroup {
+    let resource: String
+}
+
+struct ExecutedCaptureGroup: CaptureGroup {
+    let numberOfTests: String
+    let numberOfFailures: String
+    let numberOfUnexpectedFailures: String
+    let wallClockTimeInSeconds: String
+}
+
+struct ExecutedWithSkippedCaptureGroup: CaptureGroup {
+    let numberOfTests: String
+    let numberOfSkipped: String
+    let numberOfFailures: String
+    let numberOfUnexpectedFailures: String
+    let wallClockTimeInSeconds: String
+}
+
+struct FailingTestCaptureGroup: CaptureGroup {
+    let file: String
+    let testSuite: String
+    let testCase: String
+    let reason: String
+}
+
+struct UIFailingTestCaptureGroup: CaptureGroup {
+    let file: String
+    let reason: String
+}
+
+struct RestartingTestCaptureGroup: CaptureGroup {
+    let testSuiteAndTestCase: String
+    let testSuite: String
+    let testCase: String
+}
+
+struct GenerateCoverageDataCaptureGroup: CaptureGroup { }
+
+struct GeneratedCoverageReportCaptureGroup: CaptureGroup {
+    let coverageReportFilePath: String
+}
+
+struct GenerateDSYMCaptureGroup: CaptureGroup {
+    let dsym: String
+    let target: String
+}
+
+struct LibtoolCaptureGroup: CaptureGroup {
+    let library: String
+    let target: String
+}
+
+#if os(Linux)
+struct LinkingCaptureGroup: CaptureGroup {
+    let target: String
+}
+#else
+struct LinkingCaptureGroup: CaptureGroup {
+    let binaryFilename: String
+    let target: String
+}
+#endif
+
+struct TestCasePassedCaptureGroup: CaptureGroup {
+    let suite: String
+    let testCase: String
+    let time: String
+}
+
+struct TestCaseStartedCaptureGroup: CaptureGroup {
+    let suite: String
+    let testCase: String
+}
+
+struct TestCasePendingCaptureGroup: CaptureGroup {
+    let suite: String
+    let testCase: String
+}
+
+struct TestCaseMeasuredCaptureGroup: CaptureGroup {
+    let suite: String
+    let testCase: String
+    let time: String
+}
+
+struct ParallelTestCasePassedCaptureGroup: CaptureGroup {
+    let suite: String
+    let testCase: String
+    let installedAppFileAndID: String
+    let time: String
+}
+
+struct ParallelTestCaseAppKitPassedCaptureGroup: CaptureGroup {
+    let suite: String
+    let testCase: String
+    let time: String
+}
+
+struct ParallelTestCaseFailedCaptureGroup: CaptureGroup {
+    let suite: String
+    let testCase: String
+    let installedAppFileAndID: String
+    let time: String
+}
+
+struct ParallelTestingStartedCaptureGroup: CaptureGroup {
+    let device: String
+}
+
+struct ParallelTestingPassedCaptureGroup: CaptureGroup {
+    let device: String
+}
+
+struct ParallelTestingFailedCaptureGroup: CaptureGroup {
+    let device: String
+}
+
+struct ParallelTestSuiteStartedCaptureGroup: CaptureGroup {
+    let suite: String
+    let device: String
+}
+
+struct PhaseSuccessCaptureGroup: CaptureGroup { }
+
+struct PhaseScriptExecutionCaptureGroup: CaptureGroup {
+    let phaseName: String
+    let target: String
+}
+
+struct ProcessPchCaptureGroup: CaptureGroup {
+    let file: String
+    let buildTarget: String
+}
+
+struct ProcessPchCommandCaptureGroup: CaptureGroup {
+    let filePath: String
+}
+
+struct PreprocessCaptureGroup: CaptureGroup {
+    let file: String
+}
+
+struct PbxcpCaptureGroup: CaptureGroup {
+    let sourceFile: String
+    let targetFile: String
+    let buildTarget: String
+}
+
+struct ProcessInfoPlistCaptureGroup: CaptureGroup {
+    let filePath: String
+    let filename: String
+    let target: String
+}
+
+struct TestsRunCompletionCaptureGroup: CaptureGroup {
+    let suite: String
+    let result: String
+    let time: String
+}
+
+struct TestSuiteStartedCaptureGroup: CaptureGroup {
+    let suite: String
+    let time: String
+}
+
+struct TestSuiteStartCaptureGroup: CaptureGroup {
+    let testSuiteName: String
+}
+
+struct TestSuiteAllTestsPassedCaptureGroup: CaptureGroup { }
+
+struct TestSuiteAllTestsFailedCaptureGroup: CaptureGroup { }
+
+struct TIFFutilCaptureGroup: CaptureGroup {
+    let filename: String
+}
+
+struct TouchCaptureGroup: CaptureGroup {
+    let filename: String
+    let target: String
+}
+
+struct WriteFileCaptureGroup: CaptureGroup {
+    let filePath: String
+}
+
+struct WriteAuxiliaryFilesCaptureGroup: CaptureGroup { }
+
+struct CompileWarningCaptureGroup: CaptureGroup {
+    let filePath: String
+    let filename: String
+    let reason: String
+}
+
+struct LDWarningCaptureGroup: CaptureGroup {
+    let ldPrefix: String
+    let warningMessage: String
+}
+
+struct GenericWarningCaptureGroup: CaptureGroup {
+    let wholeWarning: String
+}
+
+struct WillNotBeCodeSignedCaptureGroup: CaptureGroup {
+    let wholeWarning: String
+}
+
+struct DuplicateLocalizedStringKeyCaptureGroup: CaptureGroup {
+    let warningMessage: String
+}
+
+struct ClangErrorCaptureGroup: CaptureGroup {
+    let wholeError: String
+}
+
+struct CheckDependenciesErrorsCaptureGroup: CaptureGroup {
+    let wholeError: String
+}
+
+struct ProvisioningProfileRequiredCaptureGroup: CaptureGroup {
+    let wholeError: String
+}
+
+struct NoCertificateCaptureGroup: CaptureGroup {
+    let wholeError: String
+}
+
+struct CompileErrorCaptureGroup: CaptureGroup {
+    let filePath: String
+    let isFatalError: String
+    let reason: String
+}
+
+struct CursorCaptureGroup: CaptureGroup {
+    let cursor: String
+}
+
+struct FatalErrorCaptureGroup: CaptureGroup {
+    let wholeError: String
+}
+
+struct FileMissingErrorCaptureGroup: CaptureGroup {
+    let wholeError: String
+    let filePath: String
+}
+
+struct LDErrorCaptureGroup: CaptureGroup {
+    let wholeError: String
+}
+
+struct LinkerDuplicateSymbolsLocationCaptureGroup: CaptureGroup {
+    let filePath: String
+}
+
+struct LinkerDuplicateSymbolsCaptureGroup: CaptureGroup {
+    let reason: String
+}
+
+struct LinkerUndefinedSymbolLocationCaptureGroup: CaptureGroup {
+    let symbolLocation: String
+}
+
+struct LinkerUndefinedSymbolsCaptureGroup: CaptureGroup {
+    let reason: String
+}
+
+struct PodsErrorCaptureGroup: CaptureGroup {
+    let reason: String
+}
+
+struct SymbolReferencedFromCaptureGroup: CaptureGroup {
+    let reference: String
+}
+
+struct ModuleIncludesErrorCaptureGroup: CaptureGroup {
+    let errorReason: String
+}
+
+struct UndefinedSymbolLocationCaptureGroup: CaptureGroup {
+    let target: String
+    let filename: String
+}
+
+struct PackageFetchingCaptureGroup: CaptureGroup { }
+
+struct PackageUpdatingCaptureGroup: CaptureGroup { }
+
+struct PackageCheckingOutCaptureGroup: CaptureGroup { }
+
+struct PackageGraphResolvingStartCaptureGroup: CaptureGroup { }
+
+struct PackageGraphResolvingEndedCaptureGroup: CaptureGroup { }
+
+struct PackageGraphResolvedItemCaptureGroup: CaptureGroup {
+    let packageName: String
+    let packageURL: String
+    let packageVersion: String
+}
+
+struct XcodebuildErrorCaptureGroup: CaptureGroup {
+    let wholeError: String
+}
+

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -248,7 +248,7 @@ struct PbxcpCaptureGroup: CaptureGroup {
 struct ProcessInfoPlistCaptureGroup: CaptureGroup {
     let filePath: String
     let filename: String
-    let target: String
+    let target: String?
 }
 
 struct TestsRunCompletionCaptureGroup: CaptureGroup {

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -36,7 +36,9 @@ struct ShellCommandCaptureGroup: CaptureGroup {
     let arguments: String
 }
 
-struct CleanRemoveCaptureGroup: CaptureGroup { }
+struct CleanRemoveCaptureGroup: CaptureGroup {
+    let directory: String
+}
 
 struct CleanTargetCaptureGroup: CaptureGroup {
     let target: String

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -6,6 +6,12 @@ protocol ErrorCaptureGroup: CaptureGroup {
     var wholeError: String { get }
 }
 
+protocol TargetCaptureGroup: CaptureGroup {
+    var target: String { get }
+    var project: String { get }
+    var configuration: String { get }
+}
+
 struct EmptyCaptureGroup: CaptureGroup { }
 
 struct AnalyzeCaptureGroup: CaptureGroup {
@@ -14,19 +20,19 @@ struct AnalyzeCaptureGroup: CaptureGroup {
     let target: String
 }
 
-struct BuildTargetCaptureGroup: CaptureGroup {
+struct BuildTargetCaptureGroup: TargetCaptureGroup {
     let target: String
     let project: String
     let configuration: String
 }
 
-struct AggregateTargetCaptureGroup: CaptureGroup {
+struct AggregateTargetCaptureGroup: TargetCaptureGroup {
     let target: String
     let project: String
     let configuration: String
 }
 
-struct AnalyzeTargetCaptureGroup: CaptureGroup {
+struct AnalyzeTargetCaptureGroup: TargetCaptureGroup {
     let target: String
     let project: String
     let configuration: String
@@ -44,7 +50,7 @@ struct CleanRemoveCaptureGroup: CaptureGroup {
     let directory: String
 }
 
-struct CleanTargetCaptureGroup: CaptureGroup {
+struct CleanTargetCaptureGroup: TargetCaptureGroup {
     let target: String
     let project: String
     let configuration: String

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -40,20 +40,20 @@ public final class JunitReporter {
     }
 
     private func generateFailingTest(line: String) -> Testcase {
-        let groups: [String] = line.capturedGroups(with: Matcher.failingTestMatcher.pattern)
+        let group: [String] = line.captureGroup(with: Matcher.failingTestMatcher.pattern)
         return Testcase(
-            classname: groups[1],
-            name: groups[2],
+            classname: group[1],
+            name: group[2],
             time: nil,
-            failure: .init(message: "\(groups[0]) - \(groups[3])")
+            failure: .init(message: "\(group[0]) - \(group[3])")
         )
     }
     
     private func generateRestartingTest(line: String) -> Testcase {
-        let groups: [String] = line.capturedGroups(with: Matcher.restartingTestMatcher.pattern)
+        let group: [String] = line.captureGroup(with: Matcher.restartingTestMatcher.pattern)
         return Testcase(
-            classname: groups[1],
-            name: groups[2],
+            classname: group[1],
+            name: group[2],
             time: nil,
             failure: .init(message: line)
         )
@@ -61,28 +61,28 @@ public final class JunitReporter {
 
     private func generateParallelFailingTest(line: String) -> Testcase {
         // Parallel tests do not provide meaningful failure messages
-        let groups: [String] = line.capturedGroups(with: Matcher.parallelTestCaseFailedMatcher.pattern)
+        let group: [String] = line.captureGroup(with: Matcher.parallelTestCaseFailedMatcher.pattern)
         return Testcase(
-            classname: groups[0],
-            name: groups[1],
+            classname: group[0],
+            name: group[1],
             time: nil,
             failure: .init(message: "Parallel test failed")
         )
     }
 
     private func generatePassingTest(line: String) -> Testcase {
-        let groups: [String] = line.capturedGroups(with: Matcher.testCasePassedMatcher.pattern)
-        return Testcase(classname: groups[0], name: groups[1], time: groups[2], failure: nil)
+        let group: [String] = line.captureGroup(with: Matcher.testCasePassedMatcher.pattern)
+        return Testcase(classname: group[0], name: group[1], time: group[2], failure: nil)
     }
 
     private func generatePassingParallelTest(line: String) -> Testcase {
-        let groups: [String] = line.capturedGroups(with: Matcher.parallelTestCasePassedMatcher.pattern)
-        return Testcase(classname: groups[0], name: groups[1], time: groups[3], failure: nil)
+        let group: [String] = line.captureGroup(with: Matcher.parallelTestCasePassedMatcher.pattern)
+        return Testcase(classname: group[0], name: group[1], time: group[3], failure: nil)
     }
   
     private func generateSuiteStart(line: String) -> String {
-        let groups: [String] = line.capturedGroups(with: Matcher.testSuiteStartMatcher.pattern)
-        return groups[0]
+        let group: [String] = line.captureGroup(with: Matcher.testSuiteStartMatcher.pattern)
+        return group[0]
     }
     
     public func generateReport() throws -> Data {

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -40,7 +40,7 @@ public final class JunitReporter {
     }
 
     private func generateFailingTest(line: String) -> Testcase {
-        let groups = line.capturedGroups(with: Matcher.failingTestMatcher.pattern)
+        let groups: [String] = line.capturedGroups(with: Matcher.failingTestMatcher.pattern)
         return Testcase(
             classname: groups[1],
             name: groups[2],
@@ -50,7 +50,7 @@ public final class JunitReporter {
     }
     
     private func generateRestartingTest(line: String) -> Testcase {
-        let groups = line.capturedGroups(with: Matcher.restartingTestMatcher.pattern)
+        let groups: [String] = line.capturedGroups(with: Matcher.restartingTestMatcher.pattern)
         return Testcase(
             classname: groups[1],
             name: groups[2],
@@ -61,7 +61,7 @@ public final class JunitReporter {
 
     private func generateParallelFailingTest(line: String) -> Testcase {
         // Parallel tests do not provide meaningful failure messages
-        let groups = line.capturedGroups(with: Matcher.parallelTestCaseFailedMatcher.pattern)
+        let groups: [String] = line.capturedGroups(with: Matcher.parallelTestCaseFailedMatcher.pattern)
         return Testcase(
             classname: groups[0],
             name: groups[1],
@@ -71,17 +71,17 @@ public final class JunitReporter {
     }
 
     private func generatePassingTest(line: String) -> Testcase {
-        let groups = line.capturedGroups(with: Matcher.testCasePassedMatcher.pattern)
+        let groups: [String] = line.capturedGroups(with: Matcher.testCasePassedMatcher.pattern)
         return Testcase(classname: groups[0], name: groups[1], time: groups[2], failure: nil)
     }
 
     private func generatePassingParallelTest(line: String) -> Testcase {
-      let groups = line.capturedGroups(with: Matcher.parallelTestCasePassedMatcher.pattern)
-      return Testcase(classname: groups[0], name: groups[1], time: groups[3], failure: nil)
+        let groups: [String] = line.capturedGroups(with: Matcher.parallelTestCasePassedMatcher.pattern)
+        return Testcase(classname: groups[0], name: groups[1], time: groups[3], failure: nil)
     }
   
     private func generateSuiteStart(line: String) -> String {
-        let groups = line.capturedGroups(with: Matcher.testSuiteStartMatcher.pattern)
+        let groups: [String] = line.capturedGroups(with: Matcher.testSuiteStartMatcher.pattern)
         return groups[0]
     }
     

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -159,13 +159,13 @@ public class Parser {
             return
         }
         
-        let groups: [String] = line.capturedGroups(with: .executed)
+        let group: [String] = line.captureGroup(with: .executed)
         summary = TestSummary(
-            testsCount: Int(groups[0]) ?? 0,
+            testsCount: Int(group[0]) ?? 0,
             skippedCount: 0,
-            failuresCount: Int(groups[1]) ?? 0,
-            unexpectedCount: Int(groups[2]) ?? 0,
-            time: Double(groups[3]) ?? 0,
+            failuresCount: Int(group[1]) ?? 0,
+            unexpectedCount: Int(group[2]) ?? 0,
+            time: Double(group[3]) ?? 0,
             colored: colored,
             testSummary: summary)
         
@@ -177,13 +177,13 @@ public class Parser {
             return
         }
         
-        let groups: [String] = line.capturedGroups(with: .executedWithSkipped)
+        let group: [String] = line.captureGroup(with: .executedWithSkipped)
         summary = TestSummary(
-            testsCount: Int(groups[0]) ?? 0,
-            skippedCount: Int(groups[1]) ?? 0,
-            failuresCount: Int(groups[2]) ?? 0,
-            unexpectedCount: Int(groups[3]) ?? 0,
-            time: Double(groups[4]) ?? 0,
+            testsCount: Int(group[0]) ?? 0,
+            skippedCount: Int(group[1]) ?? 0,
+            failuresCount: Int(group[2]) ?? 0,
+            unexpectedCount: Int(group[3]) ?? 0,
+            time: Double(group[4]) ?? 0,
             colored: colored,
             testSummary: summary)
         

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -159,7 +159,7 @@ public class Parser {
             return
         }
         
-        let groups = line.capturedGroups(with: .executed)
+        let groups: [String] = line.capturedGroups(with: .executed)
         summary = TestSummary(
             testsCount: Int(groups[0]) ?? 0,
             skippedCount: 0,
@@ -177,7 +177,7 @@ public class Parser {
             return
         }
         
-        let groups = line.capturedGroups(with: .executedWithSkipped)
+        let groups: [String] = line.capturedGroups(with: .executedWithSkipped)
         summary = TestSummary(
             testsCount: Int(groups[0]) ?? 0,
             skippedCount: Int(groups[1]) ?? 0,

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -24,7 +24,7 @@ extension String {
         case (.compileStoryboard, let group as CompileStoryboardCaptureGroup):
             return formatCompile(pattern: pattern)
         case (.compileCommand, let group as CompileCommandCaptureGroup):
-            return formatCompileCommand(pattern: pattern)
+            return formatCompileCommand(group: group)
         case (.buildTarget, let group as BuildTargetCaptureGroup):
             return formatTargetCommand(command: "Build", pattern: pattern)
         case (.analyzeTarget, let group as AnalyzeTargetCaptureGroup):
@@ -249,7 +249,7 @@ extension String {
         return _colored ? "\("Preprocessing".s.Bold) \(filePath)" : "Preprocessing \(filePath)"
     }
 
-    private func formatCompileCommand(pattern: Pattern) -> String? {
+    private func formatCompileCommand(group: CompileCommandCaptureGroup) -> String? {
         return nil
     }
     private func formatCompile(pattern: Pattern) -> String? {

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -102,8 +102,7 @@ extension String {
         case (.touch, let group as TouchCaptureGroup):
             return formatTouch(group: group)
         case (.phaseSuccess, let group as PhaseSuccessCaptureGroup):
-            let phase = capturedGroups(with: .phaseSuccess)[0].capitalized
-            return _colored ? "\(phase) Succeeded".s.Bold.f.Green : "\(phase) Succeeded"
+            return formatPhaseSuccess(group: group)
         case (.phaseScriptExecution, let group as PhaseScriptExecutionCaptureGroup):
             return formatPhaseScriptExecution(group: group)
         case (.preprocess, let group as PreprocessCaptureGroup):
@@ -292,6 +291,11 @@ extension String {
         let filename = group.filename
         let target = group.target
         return _colored ? "[\(target.f.Cyan)] \("Touching".s.Bold) \(filename)" : "[\(target)] Touching \(filename)"
+    }
+
+    private func formatPhaseSuccess(group: PhaseSuccessCaptureGroup) -> String? {
+        let phase = group.phase.capitalized
+        return _colored ? "\(phase) Succeeded".s.Bold.f.Green : "\(phase) Succeeded"
     }
 
     private func formatLinking(group: LinkingCaptureGroup) -> String? {

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -98,7 +98,7 @@ extension String {
         case (.processInfoPlist, let group as ProcessInfoPlistCaptureGroup):
             return formatProcessInfoPlist(group: group)
         case (.processPch, let group as ProcessPchCaptureGroup):
-            return formatProcessPch(pattern: pattern)
+            return formatProcessPch(group: group)
         case (.touch, let group as TouchCaptureGroup):
             return formatTouch(group: group)
         case (.phaseSuccess, let group as PhaseSuccessCaptureGroup):
@@ -238,10 +238,9 @@ extension String {
         return _colored ? "\("Signing".s.Bold) \(frameworkPath)" : "Signing \(frameworkPath)"
     }
 
-    private func formatProcessPch(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let filename = groups[0]
-        guard let target = groups.last else { return nil }
+    private func formatProcessPch(group: ProcessPchCaptureGroup) -> String? {
+        let filename = group.file
+        let target = group.buildTarget
         return _colored ? "[\(target.f.Cyan)] \("Processing".s.Bold) \(filename)" : "[\(target)] Processing \(filename)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -26,13 +26,13 @@ extension String {
         case (.compileCommand, let group as CompileCommandCaptureGroup):
             return formatCompileCommand(group: group)
         case (.buildTarget, let group as BuildTargetCaptureGroup):
-            return formatTargetCommand(command: "Build", pattern: pattern)
+            return formatTargetCommand(command: "Build", group: group)
         case (.analyzeTarget, let group as AnalyzeTargetCaptureGroup):
-            return formatTargetCommand(command: "Analyze", pattern: pattern)
+            return formatTargetCommand(command: "Analyze", group: group)
         case (.aggregateTarget, let group as AggregateTargetCaptureGroup):
-            return formatTargetCommand(command: "Aggregate", pattern: pattern)
+            return formatTargetCommand(command: "Aggregate", group: group)
         case (.cleanTarget, let group as CleanTargetCaptureGroup):
-            return formatTargetCommand(command: "Clean", pattern: pattern)
+            return formatTargetCommand(command: "Clean", group: group)
         case (.generateCoverageData, let group as GenerateCoverageDataCaptureGroup):
             return formatGenerateCoverageData(group: group)
         case (.generatedCoverageReport, let group as GeneratedCoverageReportCaptureGroup):
@@ -191,11 +191,10 @@ extension String {
 
     // MARK: - Private
 
-    private func formatTargetCommand(command: String, pattern: Pattern) -> String {
-        let groups: [String] = capturedGroups(with: pattern)
-        let target = groups[0]
-        let project = groups[1]
-        let configuration = groups[2]
+    private func formatTargetCommand(command: String, group: TargetCaptureGroup) -> String {
+        let target = group.target
+        let project = group.project
+        let configuration = group.configuration
         return _colored ? "\(command) target \(target) of project \(project) with configuration \(configuration)".s.Bold.f.Cyan : "\(command) target \(target) of project \(project) with configuration \(configuration)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -198,12 +198,6 @@ extension String {
         return _colored ? "\(command) target \(target) of project \(project) with configuration \(configuration)".s.Bold.f.Cyan : "\(command) target \(target) of project \(project) with configuration \(configuration)"
     }
 
-    private func format(command: String, pattern: Pattern) -> String {
-        let groups: [String] = capturedGroups(with: pattern)
-        let sourceFile = groups[0]
-        return _colored ? command.s.Bold + " " + sourceFile.lastPathComponent : command + " " + sourceFile.lastPathComponent
-    }
-
     private func format(command: String, pattern: Pattern, arguments: String) -> String? {
         let template = command.style.Bold + " " + arguments
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -105,7 +105,7 @@ extension String {
             let phase = capturedGroups(with: .phaseSuccess)[0].capitalized
             return _colored ? "\(phase) Succeeded".s.Bold.f.Green : "\(phase) Succeeded"
         case (.phaseScriptExecution, let group as PhaseScriptExecutionCaptureGroup):
-            return formatPhaseScriptExecution()
+            return formatPhaseScriptExecution(group: group)
         case (.preprocess, let group as PreprocessCaptureGroup):
             return format(command: "Preprocessing", pattern: pattern, arguments: "$1")
         case (.processPchCommand, let group as ProcessPchCommandCaptureGroup):
@@ -313,12 +313,11 @@ extension String {
 #endif
     }
 
-    private func formatPhaseScriptExecution() -> String? {
-        let groups: [String] = capturedGroups(with: .phaseScriptExecution)
-        let phaseName = groups[0]
+    private func formatPhaseScriptExecution(group: PhaseScriptExecutionCaptureGroup) -> String? {
+        let phaseName = group.phaseName
+        let target = group.target
         // Strip backslashed added by xcodebuild before spaces in the build phase name
         let strippedPhaseName = phaseName.replacingOccurrences(of: "\\ ", with: " ")
-        guard let target = groups.last else { return nil }
         return _colored ? "[\(target.f.Cyan)] \("Running script".s.Bold) \(strippedPhaseName)" : "[\(target)] Running script \(strippedPhaseName)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -86,7 +86,7 @@ extension String {
         case (.codesign, let group as CodesignCaptureGroup):
             return format(command: "Signing", pattern: pattern)
         case (.codesignFramework, let group as CodesignFrameworkCaptureGroup):
-            return formatCodeSignFramework(pattern: pattern)
+            return formatCodeSignFramework(group: group)
         case (.copyHeader, let group as CopyHeaderCaptureGroup):
             return formatCopy(pattern: pattern)
         case (.copyPlist, let group as CopyPlistCaptureGroup):
@@ -239,9 +239,8 @@ extension String {
         return _colored ? "\("Cleaning".s.Bold) \(directory)" : "Cleaning \(directory)"
     }
 
-    private func formatCodeSignFramework(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let frameworkPath = groups[0]
+    private func formatCodeSignFramework(group: CodesignFrameworkCaptureGroup) -> String? {
+        let frameworkPath = group.frameworkPath
         return _colored ? "\("Signing".s.Bold) \(frameworkPath)" : "Signing \(frameworkPath)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -14,7 +14,7 @@ extension String {
             return formatAnalyze(group: group)
         #if os(Linux)
         case (.compile, let group as CompileCaptureGroup):
-            return formatCompileLinux(pattern: pattern)
+            return formatCompile(pattern: pattern)
         #else
         case (.compile, let group as CompileCaptureGroup):
             return formatCompile(pattern: .compile)
@@ -252,17 +252,10 @@ extension String {
     private func formatCompileCommand(group: CompileCommandCaptureGroup) -> String? {
         return nil
     }
+
     private func formatCompile(pattern: Pattern) -> String? {
-        return innerFormatCompile(pattern: pattern, fileIndex: 1, targetIndex: 2)
-    }
-    
-    private func formatCompileLinux(pattern: Pattern) -> String? {
-        return innerFormatCompile(pattern: pattern, fileIndex: 1, targetIndex: 0)
-    }
-    
-    private func innerFormatCompile(pattern: Pattern, fileIndex: Int, targetIndex: Int) -> String? {
         let groups: [String] = capturedGroups(with: pattern)
-        let filename = groups[fileIndex]
+        let filename = groups[1]
         guard let target = groups.last else { return nil }
         return _colored ? "[\(target.f.Cyan)] \("Compiling".s.Bold) \(filename)" : "[\(target)] Compiling \(filename)"
     }

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -14,15 +14,15 @@ extension String {
             return formatAnalyze(group: group)
         #if os(Linux)
         case (.compile, let group as CompileCaptureGroup):
-            return formatCompile(pattern: pattern)
+            return formatCompile(group: group)
         #else
         case (.compile, let group as CompileCaptureGroup):
-            return formatCompile(pattern: .compile)
+            return formatCompile(group: group)
         #endif
         case (.compileXib, let group as CompileXibCaptureGroup):
-            return formatCompile(pattern: pattern)
+            return formatCompile(group: group)
         case (.compileStoryboard, let group as CompileStoryboardCaptureGroup):
-            return formatCompile(pattern: pattern)
+            return formatCompile(group: group)
         case (.compileCommand, let group as CompileCommandCaptureGroup):
             return formatCompileCommand(group: group)
         case (.buildTarget, let group as BuildTargetCaptureGroup):
@@ -257,10 +257,9 @@ extension String {
         return nil
     }
 
-    private func formatCompile(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let filename = groups[1]
-        guard let target = groups.last else { return nil }
+    private func formatCompile(group: CompileFileCaptureGroup) -> String? {
+        let filename = group.filename
+        let target = group.target
         return _colored ? "[\(target.f.Cyan)] \("Compiling".s.Bold) \(filename)" : "[\(target)] Compiling \(filename)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -133,7 +133,7 @@ extension String {
         case (.genericWarning, let group as GenericWarningCaptureGroup):
             return formatWarning(pattern: pattern)
         case (.willNotBeCodeSigned, let group as WillNotBeCodeSignedCaptureGroup):
-            return formatWillNotBeCodesignWarning(pattern: pattern)
+            return formatWillNotBeCodesignWarning(group: group)
         case (.clangError, let group as ClangErrorCaptureGroup):
             return formatError(pattern: pattern)
         case (.fatalError, let group as FatalErrorCaptureGroup):
@@ -500,9 +500,8 @@ extension String {
         return _colored ? "\(Symbol.error.rawValue) \(reason.f.Red)" : "\(Symbol.asciiError.rawValue) \(reason)"
     }
 
-    private func formatWillNotBeCodesignWarning(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        guard let warningMessage = groups.first else { return nil }
+    private func formatWillNotBeCodesignWarning(group: WillNotBeCodeSignedCaptureGroup) -> String? {
+        let warningMessage = group.wholeWarning
         return _colored ? Symbol.warning.rawValue + " " + warningMessage.f.Yellow : Symbol.asciiWarning.rawValue + " " + warningMessage
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -165,7 +165,7 @@ extension String {
         case (.linkerUndefinedSymbolLocation, let group as LinkerUndefinedSymbolLocationCaptureGroup):
             return nil
         case (.linkerUndefinedSymbols, let group as LinkerUndefinedSymbolsCaptureGroup):
-            return formatLinkerUndefinedSymbolsError(pattern: pattern)
+            return formatLinkerUndefinedSymbolsError(group: group)
         case (.symbolReferencedFrom, let group as SymbolReferencedFromCaptureGroup):
             return formatCompleteError()
         case (.undefinedSymbolLocation, let group as UndefinedSymbolLocationCaptureGroup):
@@ -490,9 +490,7 @@ extension String {
     }
 
     // TODO: Print symbol and reference location
-    private func formatLinkerUndefinedSymbolsError(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let reason = groups[0]
+    private func formatLinkerUndefinedSymbolsError(group: LinkerUndefinedSymbolsCaptureGroup) -> String? {        let reason = group.reason
         return _colored ? "\(Symbol.error.rawValue) \(reason.f.Red)" : "\(Symbol.asciiError.rawValue) \(reason)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -38,7 +38,7 @@ extension String {
         case (.generatedCoverageReport, let group as GeneratedCoverageReportCaptureGroup):
             return formatCoverageReport(group: group)
         case (.generateDsym, let group as GenerateDSYMCaptureGroup):
-            return formatGenerateDsym(pattern: pattern)
+            return formatGenerateDsym(group: group)
         case (.libtool, let group as LibtoolCaptureGroup):
             return formatLibtool(pattern: pattern)
         case (.linking, let group as LinkingCaptureGroup):
@@ -280,10 +280,9 @@ extension String {
         return _colored ? "[\(target.f.Cyan)] \("Copying".s.Bold) \(filename)" : "[\(target)] Copying \(filename)"
     }
 
-    private func formatGenerateDsym(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let dsym = groups[0]
-        guard let target = groups.last else { return nil }
+    private func formatGenerateDsym(group: GenerateDSYMCaptureGroup) -> String? {
+        let dsym = group.dsym
+        let target = group.target
         return _colored ? "[\(target.f.Cyan)] \("Generating".s.Bold) \(dsym)" : "[\(target)] Generating \(dsym)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -7,7 +7,7 @@ extension String {
     func beautify(pattern: Pattern, colored: Bool, additionalLines: @escaping () -> (String?)) -> String? {
         _colored = colored
 
-        let group: CaptureGroup = self.capturedGroups(with: pattern)
+        let group: CaptureGroup = self.captureGroup(with: pattern)
 
         switch (pattern, group) {
         case (.analyze, let group as AnalyzeCaptureGroup):

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -84,15 +84,15 @@ extension String {
         case (.codesignFramework, let group as CodesignFrameworkCaptureGroup):
             return formatCodeSignFramework(group: group)
         case (.copyHeader, let group as CopyHeaderCaptureGroup):
-            return formatCopy(pattern: pattern)
+            return formatCopy(group: group)
         case (.copyPlist, let group as CopyPlistCaptureGroup):
-            return formatCopy(pattern: pattern)
+            return formatCopy(group: group)
         case (.copyStrings, let group as CopyStringsCaptureGroup):
-            return formatCopy(pattern: pattern)
+            return formatCopy(group: group)
         case (.cpresource, let group as CpresourceCaptureGroup):
-            return formatCopy(pattern: pattern)
+            return formatCopy(group: group)
         case (.pbxcp, let group as PbxcpCaptureGroup):
-            return formatCopy(pattern: pattern)
+            return formatCopy(group: group)
         case (.checkDependencies, let group as CheckDependenciesCaptureGroup):
             return format(command: "Check Dependencies", pattern: .checkDependencies, arguments: "")
         case (.processInfoPlist, let group as ProcessInfoPlistCaptureGroup):
@@ -263,10 +263,9 @@ extension String {
         return _colored ? "[\(target.f.Cyan)] \("Compiling".s.Bold) \(filename)" : "[\(target)] Compiling \(filename)"
     }
 
-    private func formatCopy(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let filename = groups[0].lastPathComponent
-        guard let target = groups.last else { return nil }
+    private func formatCopy(group: CopyCaptureGroup) -> String? {
+        let filename = group.file
+        let target = group.target
         return _colored ? "[\(target.f.Cyan)] \("Copying".s.Bold) \(filename)" : "[\(target)] Copying \(filename)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -34,9 +34,9 @@ extension String {
         case (.cleanTarget, let group as CleanTargetCaptureGroup):
             return formatTargetCommand(command: "Clean", pattern: pattern)
         case (.generateCoverageData, let group as GenerateCoverageDataCaptureGroup):
-            return formatCodeCoverage(pattern: pattern)
+            return formatGenerateCoverageData(group: group)
         case (.generatedCoverageReport, let group as GeneratedCoverageReportCaptureGroup):
-            return formatCodeCoverage(pattern: pattern)
+            return formatCoverageReport(group: group)
         case (.generateDsym, let group as GenerateDSYMCaptureGroup):
             return formatGenerateDsym(pattern: pattern)
         case (.libtool, let group as LibtoolCaptureGroup):
@@ -287,18 +287,13 @@ extension String {
         return _colored ? "[\(target.f.Cyan)] \("Generating".s.Bold) \(dsym)" : "[\(target)] Generating \(dsym)"
     }
 
-    private func formatCodeCoverage(pattern: Pattern) -> String? {
-        switch pattern {
-        case .generateCoverageData:
-            return _colored ? "\("Generating".s.Bold) code coverage data..." : "Generating code coverage data..."
-        case .generatedCoverageReport:
-            let filePath = capturedGroups(with: pattern)[0]
-            return _colored
-                ? "\("Generated".s.Bold) code coverage report: \(filePath.s.Italic)"
-                : "Generated code coverage report: \(filePath)"
-        default:
-            return nil
-        }
+    private func formatGenerateCoverageData(group: GenerateCoverageDataCaptureGroup) -> String? {
+        return _colored ? "\("Generating".s.Bold) code coverage data..." : "Generating code coverage data..."
+    }
+
+    private func formatCoverageReport(group: GeneratedCoverageReportCaptureGroup) -> String? {
+        let filePath = group.coverageReportFilePath
+        return _colored ? "\("Generated".s.Bold) code coverage report: \(filePath.s.Italic)" : "Generated code coverage report: \(filePath)"
     }
 
     private func formatLibtool(pattern: Pattern) -> String? {

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -183,7 +183,7 @@ extension String {
         case (.packageGraphResolvedItem, let group as PackageGraphResolvedItemCaptureGroup):
             return formatPackgeItem(group: group)
         case (.duplicateLocalizedStringKey, let group as DuplicateLocalizedStringKeyCaptureGroup):
-            return formatDuplicateLocalizedStringKey(pattern: pattern)
+            return formatDuplicateLocalizedStringKey(group: group)
         case (_, _):
             assertionFailure()
             return nil
@@ -556,9 +556,8 @@ extension String {
         return _colored ? name.s.Bold.f.Cyan + " - " + url.s.Bold + " @ " + version.f.Green : "\(name) - \(url) @ \(version)"
     }
 
-    private func formatDuplicateLocalizedStringKey(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let message = groups[0]
+    private func formatDuplicateLocalizedStringKey(group: DuplicateLocalizedStringKeyCaptureGroup) -> String? {
+        let message = group.warningMessage
         return _colored ? Symbol.warning.rawValue + " " + message.f.Yellow : Symbol.asciiWarning.rawValue + " " + message
     }
 }

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -173,7 +173,7 @@ extension String {
         case (.packageFetching, let group as PackageFetchingCaptureGroup):
             return formatPackageFetching(group: group)
         case (.packageUpdating, let group as PackageUpdatingCaptureGroup):
-            return formatPackageUpdating(pattern: pattern)
+            return formatPackageUpdating(group: group)
         case (.packageCheckingOut, let group as PackageCheckingOutCaptureGroup):
             return formatPackageCheckingOut(pattern: pattern)
         case (.packageGraphResolvingStart, let group as PackageGraphResolvingStartCaptureGroup):
@@ -530,9 +530,8 @@ extension String {
         return "Fetching " + source
     }
 
-    private func formatPackageUpdating(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let source = groups[0]
+    private func formatPackageUpdating(group: PackageUpdatingCaptureGroup) -> String? {
+        let source = group.source
         return "Updating " + source
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -164,7 +164,7 @@ extension String {
     // MARK: - Private
 
     private func formatTargetCommand(command: String, pattern: Pattern) -> String {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let target = groups[0]
         let project = groups[1]
         let configuration = groups[2]
@@ -172,7 +172,7 @@ extension String {
     }
 
     private func format(command: String, pattern: Pattern) -> String {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let sourceFile = groups[0]
         return _colored ? command.s.Bold + " " + sourceFile.lastPathComponent : command + " " + sourceFile.lastPathComponent
     }
@@ -194,33 +194,33 @@ extension String {
     }
 
     private func formatAnalyze(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let filename = groups[1]
         guard let target = groups.last else { return nil }
         return _colored ? "[\(target.f.Cyan)] \("Analyzing".s.Bold) \(filename)" : "[\(target)] Analyzing \(filename)"
     }
 
     private func formatCleanRemove(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let directory = groups[0].lastPathComponent
         return _colored ? "\("Cleaning".s.Bold) \(directory)" : "Cleaning \(directory)"
     }
 
     private func formatCodeSignFramework(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let frameworkPath = groups[0]
         return _colored ? "\("Signing".s.Bold) \(frameworkPath)" : "Signing \(frameworkPath)"
     }
 
     private func formatProcessPch(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let filename = groups[0]
         guard let target = groups.last else { return nil }
         return _colored ? "[\(target.f.Cyan)] \("Processing".s.Bold) \(filename)" : "[\(target)] Processing \(filename)"
     }
 
     private func formatProcessPchCommand(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         guard let filePath = groups.last else { return nil }
         return _colored ? "\("Preprocessing".s.Bold) \(filePath)" : "Preprocessing \(filePath)"
     }
@@ -237,21 +237,21 @@ extension String {
     }
     
     private func innerFormatCompile(pattern: Pattern, fileIndex: Int, targetIndex: Int) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let filename = groups[fileIndex]
         guard let target = groups.last else { return nil }
         return _colored ? "[\(target.f.Cyan)] \("Compiling".s.Bold) \(filename)" : "[\(target)] Compiling \(filename)"
     }
 
     private func formatCopy(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let filename = groups[0].lastPathComponent
         guard let target = groups.last else { return nil }
         return _colored ? "[\(target.f.Cyan)] \("Copying".s.Bold) \(filename)" : "[\(target)] Copying \(filename)"
     }
 
     private func formatGenerateDsym(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let dsym = groups[0]
         guard let target = groups.last else { return nil }
         return _colored ? "[\(target.f.Cyan)] \("Generating".s.Bold) \(dsym)" : "[\(target)] Generating \(dsym)"
@@ -272,34 +272,34 @@ extension String {
     }
 
     private func formatLibtool(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let filename = groups[0]
         guard let target = groups.last else { return nil }
         return _colored ? "[\(target.f.Cyan)] \("Building library".s.Bold) \(filename)" : "[\(target)] Building library \(filename)"
     }
 
     private func formatTouch(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let filename = groups[1]
         guard let target = groups.last else { return nil }
         return _colored ? "[\(target.f.Cyan)] \("Touching".s.Bold) \(filename)" : "[\(target)] Touching \(filename)"
     }
 
     private func formatLinking(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let filename = groups[0].lastPathComponent
         guard let target = groups.last else { return nil }
         return _colored ? "[\(target.f.Cyan)] \("Linking".s.Bold) \(filename)" : "[\(target)] Linking \(filename)"
     }
     
     private func formatLinkingLinux(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let target = groups[0]
         return _colored ? "[\(target.f.Cyan)] \("Linking".s.Bold)" : "[\(target)] Linking"
     }
 
     private func formatPhaseScriptExecution() -> String? {
-        let groups = capturedGroups(with: .phaseScriptExecution)
+        let groups: [String] = capturedGroups(with: .phaseScriptExecution)
         let phaseName = groups[0]
         // Strip backslashed added by xcodebuild before spaces in the build phase name
         let strippedPhaseName = phaseName.replacingOccurrences(of: "\\ ", with: " ")
@@ -308,7 +308,7 @@ extension String {
     }
 
     private func formatTestHeading(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let testSuite = groups[0]
 
         switch pattern {
@@ -332,7 +332,7 @@ extension String {
 
     private func formatTest(pattern: Pattern) -> String? {
         let indent = "    "
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
 
         switch pattern {
         case .testCasePassed:
@@ -388,7 +388,7 @@ extension String {
     }
 
     private func formatError(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         guard let errorMessage = groups.first else { return nil }
         return _colored ? Symbol.error.rawValue + " " + errorMessage.f.Red : Symbol.asciiError.rawValue + " " + errorMessage
     }
@@ -398,7 +398,7 @@ extension String {
     }
 
     private func formatCompileError(pattern: Pattern, additionalLines: @escaping () -> (String?)) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let filePath = groups[0]
         let reason = groups[2]
 
@@ -420,14 +420,14 @@ extension String {
     }
 
     private func formatFileMissingError(pattern: Pattern) -> String {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let reason = groups[0]
         let filePath = groups[1]
         return _colored ? "\(Symbol.error.rawValue) \(filePath): \(reason.f.Red)" : "\(Symbol.asciiError.rawValue) \(filePath): \(reason)"
     }
 
     private func formatWarning(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         guard let warningMessage = groups.first else { return nil }
         return _colored ? Symbol.warning.rawValue + " " + warningMessage.f.Yellow : Symbol.asciiWarning.rawValue + " " + warningMessage
     }
@@ -437,7 +437,7 @@ extension String {
     }
 
     private func formatCompileWarning(pattern: Pattern, additionalLines: @escaping () -> (String?)) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let filePath = groups[0]
         let reason = groups[2]
 
@@ -459,14 +459,14 @@ extension String {
     }
 
     private func formatLdWarning(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let prefix = groups[0]
         let message = groups[1]
         return _colored ? "\(Symbol.warning.rawValue) \(prefix.f.Yellow)\(message.f.Yellow)" : "\(Symbol.asciiWarning.rawValue) \(prefix)\(message)"
     }
 
     private func formatProcessInfoPlist(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let plist = groups[1]
 
         // Xcode 9 output
@@ -481,20 +481,20 @@ extension String {
 
     // TODO: Print symbol and reference location
     private func formatLinkerUndefinedSymbolsError(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let reason = groups[0]
         return _colored ? "\(Symbol.error.rawValue) \(reason.f.Red)" : "\(Symbol.asciiError.rawValue) \(reason)"
     }
 
     // TODO: Print file path
     private func formatLinkerDuplicateSymbolsError(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let reason = groups[0]
         return _colored ? "\(Symbol.error.rawValue) \(reason.f.Red)" : "\(Symbol.asciiError.rawValue) \(reason)"
     }
 
     private func formatWillNotBeCodesignWarning(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         guard let warningMessage = groups.first else { return nil }
         return _colored ? Symbol.warning.rawValue + " " + warningMessage.f.Yellow : Symbol.asciiWarning.rawValue + " " + warningMessage
     }
@@ -522,19 +522,19 @@ extension String {
     }
 
     private func formatPackageFetching(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let source = groups[0]
         return "Fetching " + source
     }
 
     private func formatPackageUpdating(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let source = groups[0]
         return "Updating " + source
     }
 
     private func formatPackageCheckingOut(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let version = groups[0]
         let package = groups[1]
         return _colored ? "Checking out " + package.s.Bold + " @ " + version.f.Green : "Checking out \(package) @ \(version)"
@@ -549,7 +549,7 @@ extension String {
     }
 
     private func formatPackgeItem(pattern: Pattern) -> String?  {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let name = groups[0]
         let url = groups[1]
         let version = groups[2]
@@ -557,7 +557,7 @@ extension String {
     }
 
     private func formatDuplicateLocalizedStringKey(pattern: Pattern) -> String? {
-        let groups = capturedGroups(with: pattern)
+        let groups: [String] = capturedGroups(with: pattern)
         let message = groups[0]
         return _colored ? Symbol.warning.rawValue + " " + message.f.Yellow : Symbol.asciiWarning.rawValue + " " + message
     }

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -171,7 +171,7 @@ extension String {
         case (.undefinedSymbolLocation, let group as UndefinedSymbolLocationCaptureGroup):
             return formatCompleteWarning()
         case (.packageFetching, let group as PackageFetchingCaptureGroup):
-            return formatPackageFetching(pattern: pattern)
+            return formatPackageFetching(group: group)
         case (.packageUpdating, let group as PackageUpdatingCaptureGroup):
             return formatPackageUpdating(pattern: pattern)
         case (.packageCheckingOut, let group as PackageCheckingOutCaptureGroup):
@@ -525,9 +525,8 @@ extension String {
         return f.Red
     }
 
-    private func formatPackageFetching(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let source = groups[0]
+    private func formatPackageFetching(group: PackageFetchingCaptureGroup) -> String? {
+        let source = group.source
         return "Fetching " + source
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -181,7 +181,7 @@ extension String {
         case (.packageGraphResolvingEnded, let group as PackageGraphResolvingEndedCaptureGroup):
             return formatPackageEnd()
         case (.packageGraphResolvedItem, let group as PackageGraphResolvedItemCaptureGroup):
-            return formatPackgeItem(pattern: pattern)
+            return formatPackgeItem(group: group)
         case (.duplicateLocalizedStringKey, let group as DuplicateLocalizedStringKeyCaptureGroup):
             return formatDuplicateLocalizedStringKey(pattern: pattern)
         case (_, _):
@@ -549,11 +549,10 @@ extension String {
         return _colored ? "Resolved source packages".s.Bold.f.Green : "Resolved source packages"
     }
 
-    private func formatPackgeItem(pattern: Pattern) -> String?  {
-        let groups: [String] = capturedGroups(with: pattern)
-        let name = groups[0]
-        let url = groups[1]
-        let version = groups[2]
+    private func formatPackgeItem(group: PackageGraphResolvedItemCaptureGroup) -> String?  {
+        let name = group.packageName
+        let url = group.packageURL
+        let version = group.packageVersion
         return _colored ? name.s.Bold.f.Cyan + " - " + url.s.Bold + " @ " + version.f.Green : "\(name) - \(url) @ \(version)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -112,7 +112,7 @@ extension String {
             return formatPhaseScriptExecution()
         case (.preprocess, let _ as PreprocessCaptureGroup):
             return format(command: "Preprocessing", pattern: pattern, arguments: "$1")
-        case (.processPchCommand, let group as ProcessPchCaptureGroup):
+        case (.processPchCommand, let group as ProcessPchCommandCaptureGroup):
             return formatProcessPchCommand(pattern: pattern)
         case (.writeFile, let _ as WriteFileCaptureGroup):
             return nil

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -149,7 +149,7 @@ extension String {
         case (.compileError, let group as CompileErrorCaptureGroup):
             return formatCompileError(group: group, additionalLines: additionalLines)
         case (.fileMissingError, let group as FileMissingErrorCaptureGroup):
-            return formatFileMissingError(pattern: pattern)
+            return formatFileMissingError(group: group)
         case (.checkDependenciesErrors, let group as CheckDependenciesCaptureGroup):
             return formatError(pattern: pattern)
         case (.provisioningProfileRequired, let group as ProvisioningProfileRequiredCaptureGroup):
@@ -432,10 +432,9 @@ extension String {
             """
     }
 
-    private func formatFileMissingError(pattern: Pattern) -> String {
-        let groups: [String] = capturedGroups(with: pattern)
-        let reason = groups[0]
-        let filePath = groups[1]
+    private func formatFileMissingError(group: FileMissingErrorCaptureGroup) -> String {
+        let reason = group.reason
+        let filePath = group.filePath
         return _colored ? "\(Symbol.error.rawValue) \(filePath): \(reason.f.Red)" : "\(Symbol.asciiError.rawValue) \(filePath): \(reason)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -96,7 +96,7 @@ extension String {
         case (.checkDependencies, let group as CheckDependenciesCaptureGroup):
             return format(command: "Check Dependencies", pattern: .checkDependencies, arguments: "")
         case (.processInfoPlist, let group as ProcessInfoPlistCaptureGroup):
-            return formatProcessInfoPlist(pattern: .processInfoPlist)
+            return formatProcessInfoPlist(group: group)
         case (.processPch, let group as ProcessPchCaptureGroup):
             return formatProcessPch(pattern: pattern)
         case (.touch, let group as TouchCaptureGroup):
@@ -475,18 +475,16 @@ extension String {
         return _colored ? "\(Symbol.warning.rawValue) \(prefix.f.Yellow)\(message.f.Yellow)" : "\(Symbol.asciiWarning.rawValue) \(prefix)\(message)"
     }
 
-    private func formatProcessInfoPlist(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let plist = groups[1]
+    private func formatProcessInfoPlist(group: ProcessInfoPlistCaptureGroup) -> String? {
+        let plist = group.filename
 
-        // Xcode 9 output
-        if groups.count == 2 {
+        if let target = group.target {
+            // Xcode 10+ output
+            return _colored ? "[\(target.f.Cyan)] \("Processing".s.Bold) \(plist)" : "[\(target)] \("Processing") \(plist)"
+        } else {
+            // Xcode 9 output
             return _colored ? "Processing".s.Bold + " " + plist : "Processing" + " " + plist
         }
-
-        // Xcode 10+ output
-        guard let target = groups.last else { return nil }
-        return _colored ? "[\(target.f.Cyan)] \("Processing".s.Bold) \(plist)" : "[\(target)] \("Processing") \(plist)"
     }
 
     // TODO: Print symbol and reference location

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -44,17 +44,17 @@ extension String {
         case (.linking, let group as LinkingCaptureGroup):
             return formatLinking(group: group)
         case (.testSuiteStarted, let group as TestSuiteStartedCaptureGroup):
-            return formatTestHeading(pattern: pattern)
+            return formatTestSuiteStarted(group: group)
         case (.testSuiteStart, let group as TestSuiteStartCaptureGroup):
-            return formatTestHeading(pattern: pattern)
+            return formatTestSuiteStart(group: group)
         case (.parallelTestingStarted, let group as ParallelTestingStartedCaptureGroup):
-            return formatTestHeading(pattern: pattern)
+            return formatParallelTestingStarted(group: group)
         case (.parallelTestingPassed, let group as ParallelTestingPassedCaptureGroup):
-            return formatTestHeading(pattern: pattern)
+            return formatParallelTestingPassed(group: group)
         case (.parallelTestingFailed, let group as ParallelTestingFailedCaptureGroup):
-            return formatTestHeading(pattern: pattern)
+            return formatParallelTestingFailed(group: group)
         case (.parallelTestSuiteStarted, let group as ParallelTestSuiteStartedCaptureGroup):
-            return formatTestHeading(pattern: pattern)
+            return formatParallelTestSuiteStarted(group: group)
         case (.testSuiteAllTestsPassed, let group as TestSuiteAllTestsPassedCaptureGroup):
             return nil
         case (.testSuiteAllTestsFailed, let group as TestSuiteAllTestsFailedCaptureGroup):
@@ -319,27 +319,34 @@ extension String {
         return _colored ? "[\(target.f.Cyan)] \("Running script".s.Bold) \(strippedPhaseName)" : "[\(target)] Running script \(strippedPhaseName)"
     }
 
-    private func formatTestHeading(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let testSuite = groups[0]
+    private func formatTestSuiteStart(group: TestSuiteStartCaptureGroup) -> String? {
+        let testSuite = group.testSuiteName
+        return _colored ? testSuite.s.Bold : testSuite
+    }
 
-        switch pattern {
-        case .testSuiteStart:
-            return _colored ? testSuite.s.Bold : testSuite
-        case .testSuiteStarted,
-             .parallelTestSuiteStarted:
-            let deviceDescription = pattern == .parallelTestSuiteStarted ? " on '\(groups[1])'" : ""
-            let heading = "Test Suite \(testSuite) started\(deviceDescription)"
-            return _colored ? heading.s.Bold.f.Cyan : heading
-        case .parallelTestingStarted:
-            return _colored ? s.Bold.f.Cyan : self
-        case .parallelTestingPassed:
-            return _colored ? s.Bold.f.Green : self
-        case .parallelTestingFailed:
-            return _colored ? s.Bold.f.Red : self
-        default:
-            return nil
-        }
+    private func formatTestSuiteStarted(group: TestSuiteStartedCaptureGroup) -> String? {
+        let testSuite = group.suite
+        let heading = "Test Suite \(testSuite) started"
+        return _colored ? heading.s.Bold.f.Cyan : heading
+    }
+
+    private func formatParallelTestSuiteStarted(group: ParallelTestSuiteStartedCaptureGroup) -> String? {
+        let testSuite = group.suite
+        let deviceDescription = " on '\(group.device)'"
+        let heading = "Test Suite \(testSuite) started\(deviceDescription)"
+        return _colored ? heading.s.Bold.f.Cyan : heading
+    }
+
+    private func formatParallelTestingStarted(group: ParallelTestingStartedCaptureGroup) -> String? {
+        return _colored ? s.Bold.f.Cyan : self
+    }
+
+    private func formatParallelTestingPassed(group: ParallelTestingPassedCaptureGroup) -> String? {
+        return _colored ? s.Bold.f.Green : self
+    }
+
+    private func formatParallelTestingFailed(group: ParallelTestingFailedCaptureGroup) -> String? {
+        return _colored ? s.Bold.f.Red : self
     }
 
     private func formatTest(pattern: Pattern) -> String? {

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -161,7 +161,7 @@ extension String {
         case (.linkerDuplicateSymbolsLocation, let group as LinkerDuplicateSymbolsLocationCaptureGroup):
             return nil
         case (.linkerDuplicateSymbols, let group as LinkerDuplicateSymbolsCaptureGroup):
-            return formatLinkerDuplicateSymbolsError(pattern: pattern)
+            return formatLinkerDuplicateSymbolsError(group: group)
         case (.linkerUndefinedSymbolLocation, let group as LinkerUndefinedSymbolLocationCaptureGroup):
             return nil
         case (.linkerUndefinedSymbols, let group as LinkerUndefinedSymbolsCaptureGroup):
@@ -495,9 +495,8 @@ extension String {
     }
 
     // TODO: Print file path
-    private func formatLinkerDuplicateSymbolsError(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let reason = groups[0]
+    private func formatLinkerDuplicateSymbolsError(group: LinkerDuplicateSymbolsCaptureGroup) -> String? {
+        let reason = group.reason
         return _colored ? "\(Symbol.error.rawValue) \(reason.f.Red)" : "\(Symbol.asciiError.rawValue) \(reason)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -147,7 +147,7 @@ extension String {
         case (.xcodebuildError, let group as XcodebuildErrorCaptureGroup):
             return formatError(pattern: pattern)
         case (.compileError, let group as CompileErrorCaptureGroup):
-            return formatCompileError(pattern: pattern, additionalLines: additionalLines)
+            return formatCompileError(group: group, additionalLines: additionalLines)
         case (.fileMissingError, let group as FileMissingErrorCaptureGroup):
             return formatFileMissingError(pattern: pattern)
         case (.checkDependenciesErrors, let group as CheckDependenciesCaptureGroup):
@@ -411,10 +411,9 @@ extension String {
         return _colored ? Symbol.error.rawValue + " " + self.f.Red : Symbol.asciiError.rawValue + " " + self
     }
 
-    private func formatCompileError(pattern: Pattern, additionalLines: @escaping () -> (String?)) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let filePath = groups[0]
-        let reason = groups[2]
+    private func formatCompileError(group: CompileErrorCaptureGroup, additionalLines: @escaping () -> (String?)) -> String? {
+        let filePath = group.filePath
+        let reason = group.reason
 
         // Read 2 additional lines to get the error line and cursor position
         let line: String = additionalLines() ?? ""

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -42,11 +42,7 @@ extension String {
         case (.libtool, let group as LibtoolCaptureGroup):
             return formatLibtool(group: group)
         case (.linking, let group as LinkingCaptureGroup):
-        #if os(Linux)
-            return formatLinkingLinux(pattern: pattern)
-        #else
-            return formatLinking(pattern: pattern)
-        #endif
+            return formatLinking(group: group)
         case (.testSuiteStarted, let group as TestSuiteStartedCaptureGroup):
             return formatTestHeading(pattern: pattern)
         case (.testSuiteStart, let group as TestSuiteStartCaptureGroup):
@@ -307,17 +303,14 @@ extension String {
         return _colored ? "[\(target.f.Cyan)] \("Touching".s.Bold) \(filename)" : "[\(target)] Touching \(filename)"
     }
 
-    private func formatLinking(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let filename = groups[0].lastPathComponent
-        guard let target = groups.last else { return nil }
-        return _colored ? "[\(target.f.Cyan)] \("Linking".s.Bold) \(filename)" : "[\(target)] Linking \(filename)"
-    }
-    
-    private func formatLinkingLinux(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let target = groups[0]
+    private func formatLinking(group: LinkingCaptureGroup) -> String? {
+        let target = group.target
+#if os(Linux)
         return _colored ? "[\(target.f.Cyan)] \("Linking".s.Bold)" : "[\(target)] Linking"
+#else
+        let filename = group.binaryFilename
+        return _colored ? "[\(target.f.Cyan)] \("Linking".s.Bold) \(filename)" : "[\(target)] Linking \(filename)"
+#endif
     }
 
     private func formatPhaseScriptExecution() -> String? {

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -135,27 +135,27 @@ extension String {
         case (.willNotBeCodeSigned, let group as WillNotBeCodeSignedCaptureGroup):
             return formatWillNotBeCodesignWarning(group: group)
         case (.clangError, let group as ClangErrorCaptureGroup):
-            return formatError(pattern: pattern)
+            return formatError(group: group)
         case (.fatalError, let group as FatalErrorCaptureGroup):
-            return formatError(pattern: pattern)
+            return formatError(group: group)
         case (.ldError, let group as LDErrorCaptureGroup):
-            return formatError(pattern: pattern)
+            return formatError(group: group)
         case (.podsError, let group as PodsErrorCaptureGroup):
-            return formatError(pattern: pattern)
+            return formatError(group: group)
         case (.moduleIncludesError, let group as ModuleIncludesErrorCaptureGroup):
-            return formatError(pattern: pattern)
+            return formatError(group: group)
         case (.xcodebuildError, let group as XcodebuildErrorCaptureGroup):
-            return formatError(pattern: pattern)
+            return formatError(group: group)
         case (.compileError, let group as CompileErrorCaptureGroup):
             return formatCompileError(group: group, additionalLines: additionalLines)
         case (.fileMissingError, let group as FileMissingErrorCaptureGroup):
             return formatFileMissingError(group: group)
-        case (.checkDependenciesErrors, let group as CheckDependenciesCaptureGroup):
-            return formatError(pattern: pattern)
+        case (.checkDependenciesErrors, let group as CheckDependenciesErrorsCaptureGroup):
+            return formatError(group: group)
         case (.provisioningProfileRequired, let group as ProvisioningProfileRequiredCaptureGroup):
-            return formatError(pattern: pattern)
+            return formatError(group: group)
         case (.noCertificate, let group as NoCertificateCaptureGroup):
-            return formatError(pattern: pattern)
+            return formatError(group: group)
         case (.cursor, let group as CursorCaptureGroup):
             return nil
         case (.linkerDuplicateSymbolsLocation, let group as LinkerDuplicateSymbolsLocationCaptureGroup):
@@ -421,9 +421,8 @@ extension String {
         return _colored ? "    \(TestStatus.fail.rawValue.f.Red) \(testCase) on '\(device)' (\(time.coloredTime()) seconds)" : "    \(TestStatus.fail.rawValue) \(testCase) on '\(device)' (\(time) seconds)"
     }
 
-    private func formatError(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        guard let errorMessage = groups.first else { return nil }
+    private func formatError(group: ErrorCaptureGroup) -> String? {
+        let errorMessage = group.wholeError
         return _colored ? Symbol.error.rawValue + " " + errorMessage.f.Red : Symbol.asciiError.rawValue + " " + errorMessage
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -129,7 +129,7 @@ extension String {
         case (.compileWarning, let group as CompileWarningCaptureGroup):
             return formatCompileWarning(group: group, additionalLines: additionalLines)
         case (.ldWarning, let group as LDWarningCaptureGroup):
-            return formatLdWarning(pattern: pattern)
+            return formatLdWarning(group: group)
         case (.genericWarning, let group as GenericWarningCaptureGroup):
             return formatWarning(pattern: pattern)
         case (.willNotBeCodeSigned, let group as WillNotBeCodeSignedCaptureGroup):
@@ -469,10 +469,9 @@ extension String {
             """
     }
 
-    private func formatLdWarning(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let prefix = groups[0]
-        let message = groups[1]
+    private func formatLdWarning(group: LDWarningCaptureGroup) -> String? {
+        let prefix = group.ldPrefix
+        let message = group.warningMessage
         return _colored ? "\(Symbol.warning.rawValue) \(prefix.f.Yellow)\(message.f.Yellow)" : "\(Symbol.asciiWarning.rawValue) \(prefix)\(message)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -59,9 +59,9 @@ extension String {
             return formatTestHeading(pattern: pattern)
         case (.parallelTestSuiteStarted, let group as ParallelTestSuiteStartedCaptureGroup):
             return formatTestHeading(pattern: pattern)
-        case (.testSuiteAllTestsPassed, let _ as TestSuiteAllTestsPassedCaptureGroup):
+        case (.testSuiteAllTestsPassed, let group as TestSuiteAllTestsPassedCaptureGroup):
             return nil
-        case (.testSuiteAllTestsFailed, let _ as TestSuiteAllTestsFailedCaptureGroup):
+        case (.testSuiteAllTestsFailed, let group as TestSuiteAllTestsFailedCaptureGroup):
             return nil
         case (.failingTest, let group as FailingTestCaptureGroup):
             return formatTest(pattern: pattern)
@@ -97,7 +97,7 @@ extension String {
             return formatCopy(pattern: pattern)
         case (.pbxcp, let group as PbxcpCaptureGroup):
             return formatCopy(pattern: pattern)
-        case (.checkDependencies, let _ as CheckDependenciesCaptureGroup):
+        case (.checkDependencies, let group as CheckDependenciesCaptureGroup):
             return format(command: "Check Dependencies", pattern: .checkDependencies, arguments: "")
         case (.processInfoPlist, let group as ProcessInfoPlistCaptureGroup):
             return formatProcessInfoPlist(pattern: .processInfoPlist)
@@ -105,32 +105,32 @@ extension String {
             return formatProcessPch(pattern: pattern)
         case (.touch, let group as TouchCaptureGroup):
             return formatTouch(pattern: pattern)
-        case (.phaseSuccess, let _ as PhaseSuccessCaptureGroup):
+        case (.phaseSuccess, let group as PhaseSuccessCaptureGroup):
             let phase = capturedGroups(with: .phaseSuccess)[0].capitalized
             return _colored ? "\(phase) Succeeded".s.Bold.f.Green : "\(phase) Succeeded"
-        case (.phaseScriptExecution, let _ as PhaseScriptExecutionCaptureGroup):
+        case (.phaseScriptExecution, let group as PhaseScriptExecutionCaptureGroup):
             return formatPhaseScriptExecution()
-        case (.preprocess, let _ as PreprocessCaptureGroup):
+        case (.preprocess, let group as PreprocessCaptureGroup):
             return format(command: "Preprocessing", pattern: pattern, arguments: "$1")
         case (.processPchCommand, let group as ProcessPchCommandCaptureGroup):
             return formatProcessPchCommand(pattern: pattern)
-        case (.writeFile, let _ as WriteFileCaptureGroup):
+        case (.writeFile, let group as WriteFileCaptureGroup):
             return nil
-        case (.writeAuxiliaryFiles, let _ as WriteAuxiliaryFilesCaptureGroup):
+        case (.writeAuxiliaryFiles, let group as WriteAuxiliaryFilesCaptureGroup):
             return nil
-        case (.shellCommand, let _ as ShellCommandCaptureGroup):
+        case (.shellCommand, let group as ShellCommandCaptureGroup):
             return nil
         case (.cleanRemove, let group as CleanRemoveCaptureGroup):
             return formatCleanRemove(pattern: pattern)
-        case (.executed, let _ as ExecutedCaptureGroup):
+        case (.executed, let group as ExecutedCaptureGroup):
             return nil
-        case (.executedWithSkipped, let _ as ExecutedWithSkippedCaptureGroup):
+        case (.executedWithSkipped, let group as ExecutedWithSkippedCaptureGroup):
             return nil
-        case (.testCaseStarted, let _ as TestCaseStartedCaptureGroup):
+        case (.testCaseStarted, let group as TestCaseStartedCaptureGroup):
             return nil
-        case (.tiffutil, let _ as TIFFutilCaptureGroup):
+        case (.tiffutil, let group as TIFFutilCaptureGroup):
             return nil
-        case (.compileWarning, let _ as CompileWarningCaptureGroup):
+        case (.compileWarning, let group as CompileWarningCaptureGroup):
             return formatCompileWarning(pattern: pattern, additionalLines: additionalLines)
         case (.ldWarning, let group as LDWarningCaptureGroup):
             return formatLdWarning(pattern: pattern)
@@ -150,7 +150,7 @@ extension String {
             return formatError(pattern: pattern)
         case (.xcodebuildError, let group as XcodebuildErrorCaptureGroup):
             return formatError(pattern: pattern)
-        case (.compileError, let _ as CompileErrorCaptureGroup):
+        case (.compileError, let group as CompileErrorCaptureGroup):
             return formatCompileError(pattern: pattern, additionalLines: additionalLines)
         case (.fileMissingError, let group as FileMissingErrorCaptureGroup):
             return formatFileMissingError(pattern: pattern)
@@ -160,19 +160,19 @@ extension String {
             return formatError(pattern: pattern)
         case (.noCertificate, let group as NoCertificateCaptureGroup):
             return formatError(pattern: pattern)
-        case (.cursor, let _ as CursorCaptureGroup):
+        case (.cursor, let group as CursorCaptureGroup):
             return nil
-        case (.linkerDuplicateSymbolsLocation, let _ as LinkerDuplicateSymbolsLocationCaptureGroup):
+        case (.linkerDuplicateSymbolsLocation, let group as LinkerDuplicateSymbolsLocationCaptureGroup):
             return nil
         case (.linkerDuplicateSymbols, let group as LinkerDuplicateSymbolsCaptureGroup):
             return formatLinkerDuplicateSymbolsError(pattern: pattern)
-        case (.linkerUndefinedSymbolLocation, let _ as LinkerUndefinedSymbolLocationCaptureGroup):
+        case (.linkerUndefinedSymbolLocation, let group as LinkerUndefinedSymbolLocationCaptureGroup):
             return nil
         case (.linkerUndefinedSymbols, let group as LinkerUndefinedSymbolsCaptureGroup):
             return formatLinkerUndefinedSymbolsError(pattern: pattern)
-        case (.symbolReferencedFrom, let _ as SymbolReferencedFromCaptureGroup):
+        case (.symbolReferencedFrom, let group as SymbolReferencedFromCaptureGroup):
             return formatCompleteError()
-        case (.undefinedSymbolLocation, let _ as UndefinedSymbolLocationCaptureGroup):
+        case (.undefinedSymbolLocation, let group as UndefinedSymbolLocationCaptureGroup):
             return formatCompleteWarning()
         case (.packageFetching, let group as PackageFetchingCaptureGroup):
             return formatPackageFetching(pattern: pattern)
@@ -180,9 +180,9 @@ extension String {
             return formatPackageUpdating(pattern: pattern)
         case (.packageCheckingOut, let group as PackageCheckingOutCaptureGroup):
             return formatPackageCheckingOut(pattern: pattern)
-        case (.packageGraphResolvingStart, let _ as PackageGraphResolvingStartCaptureGroup):
+        case (.packageGraphResolvingStart, let group as PackageGraphResolvingStartCaptureGroup):
             return formatPackageStart()
-        case (.packageGraphResolvingEnded, let _ as PackageGraphResolvingEndedCaptureGroup):
+        case (.packageGraphResolvingEnded, let group as PackageGraphResolvingEndedCaptureGroup):
             return formatPackageEnd()
         case (.packageGraphResolvedItem, let group as PackageGraphResolvedItemCaptureGroup):
             return formatPackgeItem(pattern: pattern)

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -130,7 +130,7 @@ extension String {
         case (.ldWarning, let group as LDWarningCaptureGroup):
             return formatLdWarning(group: group)
         case (.genericWarning, let group as GenericWarningCaptureGroup):
-            return formatWarning(pattern: pattern)
+            return formatWarning(group: group)
         case (.willNotBeCodeSigned, let group as WillNotBeCodeSignedCaptureGroup):
             return formatWillNotBeCodesignWarning(group: group)
         case (.clangError, let group as ClangErrorCaptureGroup):
@@ -459,9 +459,8 @@ extension String {
         return _colored ? "\(Symbol.error.rawValue) \(filePath): \(reason.f.Red)" : "\(Symbol.asciiError.rawValue) \(filePath): \(reason)"
     }
 
-    private func formatWarning(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        guard let warningMessage = groups.first else { return nil }
+    private func formatWarning(group: GenericWarningCaptureGroup) -> String? {
+        let warningMessage = group.wholeWarning
         return _colored ? Symbol.warning.rawValue + " " + warningMessage.f.Yellow : Symbol.asciiWarning.rawValue + " " + warningMessage
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -109,7 +109,7 @@ extension String {
         case (.preprocess, let group as PreprocessCaptureGroup):
             return format(command: "Preprocessing", pattern: pattern, arguments: "$1")
         case (.processPchCommand, let group as ProcessPchCommandCaptureGroup):
-            return formatProcessPchCommand(pattern: pattern)
+            return formatProcessPchCommand(group: group)
         case (.writeFile, let group as WriteFileCaptureGroup):
             return nil
         case (.writeAuxiliaryFiles, let group as WriteAuxiliaryFilesCaptureGroup):
@@ -244,9 +244,8 @@ extension String {
         return _colored ? "[\(target.f.Cyan)] \("Processing".s.Bold) \(filename)" : "[\(target)] Processing \(filename)"
     }
 
-    private func formatProcessPchCommand(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        guard let filePath = groups.last else { return nil }
+    private func formatProcessPchCommand(group: ProcessPchCommandCaptureGroup) -> String? {
+        let filePath = group.filePath
         return _colored ? "\("Preprocessing".s.Bold) \(filePath)" : "Preprocessing \(filePath)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -11,7 +11,7 @@ extension String {
 
         switch (pattern, group) {
         case (.analyze, let group as AnalyzeCaptureGroup):
-            return formatAnalyze(pattern: pattern)
+            return formatAnalyze(group: group)
         #if os(Linux)
         case (.compile, let group as CompileCaptureGroup):
             return formatCompileLinux(pattern: pattern)
@@ -226,10 +226,9 @@ extension String {
         return formatted
     }
 
-    private func formatAnalyze(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let filename = groups[1]
-        guard let target = groups.last else { return nil }
+    private func formatAnalyze(group: AnalyzeCaptureGroup) -> String? {
+        let filename = group.fileName
+        let target = group.target
         return _colored ? "[\(target.f.Cyan)] \("Analyzing".s.Bold) \(filename)" : "[\(target)] Analyzing \(filename)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -80,7 +80,7 @@ extension String {
         case (.parallelTestCaseFailed, let group as ParallelTestCaseFailedCaptureGroup):
             return formatParallelTestCaseFailed(group: group)
         case (.codesign, let group as CodesignCaptureGroup):
-            return format(command: "Signing", pattern: pattern)
+            return formatCodeSign(group: group)
         case (.codesignFramework, let group as CodesignFrameworkCaptureGroup):
             return formatCodeSignFramework(group: group)
         case (.copyHeader, let group as CopyHeaderCaptureGroup):
@@ -229,6 +229,12 @@ extension String {
     private func formatCleanRemove(group: CleanRemoveCaptureGroup) -> String? {
         let directory = group.directory
         return _colored ? "\("Cleaning".s.Bold) \(directory)" : "Cleaning \(directory)"
+    }
+
+    private func formatCodeSign(group: CodesignCaptureGroup) -> String? {
+        let command = "Signing"
+        let sourceFile = group.file
+        return _colored ? command.s.Bold + " " + sourceFile.lastPathComponent : command + " " + sourceFile.lastPathComponent
     }
 
     private func formatCodeSignFramework(group: CodesignFrameworkCaptureGroup) -> String? {

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -55,9 +55,9 @@ extension String {
             return formatParallelTestingFailed(group: group)
         case (.parallelTestSuiteStarted, let group as ParallelTestSuiteStartedCaptureGroup):
             return formatParallelTestSuiteStarted(group: group)
-        case (.testSuiteAllTestsPassed, let group as TestSuiteAllTestsPassedCaptureGroup):
+        case (.testSuiteAllTestsPassed, _ as TestSuiteAllTestsPassedCaptureGroup):
             return nil
-        case (.testSuiteAllTestsFailed, let group as TestSuiteAllTestsFailedCaptureGroup):
+        case (.testSuiteAllTestsFailed, _ as TestSuiteAllTestsFailedCaptureGroup):
             return nil
         case (.failingTest, let group as FailingTestCaptureGroup):
             return formatFailingTest(group: group)
@@ -71,7 +71,7 @@ extension String {
             return formatTestCasePending(group: group)
         case (.testCaseMeasured, let group as TestCaseMeasuredCaptureGroup):
             return formatTestCaseMeasured(group: group)
-        case (.testsRunCompletion, let group as TestsRunCompletionCaptureGroup):
+        case (.testsRunCompletion, _ as TestsRunCompletionCaptureGroup):
             return nil
         case (.parallelTestCasePassed, let group as ParallelTestCasePassedCaptureGroup):
             return formatParallelTestCasePassed(group: group)
@@ -93,7 +93,7 @@ extension String {
             return formatCopy(group: group)
         case (.pbxcp, let group as PbxcpCaptureGroup):
             return formatCopy(group: group)
-        case (.checkDependencies, let group as CheckDependenciesCaptureGroup):
+        case (.checkDependencies, _ as CheckDependenciesCaptureGroup):
             return format(command: "Check Dependencies", pattern: .checkDependencies, arguments: "")
         case (.processInfoPlist, let group as ProcessInfoPlistCaptureGroup):
             return formatProcessInfoPlist(group: group)
@@ -105,25 +105,25 @@ extension String {
             return formatPhaseSuccess(group: group)
         case (.phaseScriptExecution, let group as PhaseScriptExecutionCaptureGroup):
             return formatPhaseScriptExecution(group: group)
-        case (.preprocess, let group as PreprocessCaptureGroup):
+        case (.preprocess, _ as PreprocessCaptureGroup):
             return format(command: "Preprocessing", pattern: pattern, arguments: "$1")
         case (.processPchCommand, let group as ProcessPchCommandCaptureGroup):
             return formatProcessPchCommand(group: group)
-        case (.writeFile, let group as WriteFileCaptureGroup):
+        case (.writeFile, _ as WriteFileCaptureGroup):
             return nil
-        case (.writeAuxiliaryFiles, let group as WriteAuxiliaryFilesCaptureGroup):
+        case (.writeAuxiliaryFiles, _ as WriteAuxiliaryFilesCaptureGroup):
             return nil
-        case (.shellCommand, let group as ShellCommandCaptureGroup):
+        case (.shellCommand, _ as ShellCommandCaptureGroup):
             return nil
         case (.cleanRemove, let group as CleanRemoveCaptureGroup):
             return formatCleanRemove(group: group)
-        case (.executed, let group as ExecutedCaptureGroup):
+        case (.executed, _ as ExecutedCaptureGroup):
             return nil
-        case (.executedWithSkipped, let group as ExecutedWithSkippedCaptureGroup):
+        case (.executedWithSkipped, _ as ExecutedWithSkippedCaptureGroup):
             return nil
-        case (.testCaseStarted, let group as TestCaseStartedCaptureGroup):
+        case (.testCaseStarted, _ as TestCaseStartedCaptureGroup):
             return nil
-        case (.tiffutil, let group as TIFFutilCaptureGroup):
+        case (.tiffutil, _ as TIFFutilCaptureGroup):
             return nil
         case (.compileWarning, let group as CompileWarningCaptureGroup):
             return formatCompileWarning(group: group, additionalLines: additionalLines)
@@ -155,19 +155,19 @@ extension String {
             return formatError(group: group)
         case (.noCertificate, let group as NoCertificateCaptureGroup):
             return formatError(group: group)
-        case (.cursor, let group as CursorCaptureGroup):
+        case (.cursor, _ as CursorCaptureGroup):
             return nil
-        case (.linkerDuplicateSymbolsLocation, let group as LinkerDuplicateSymbolsLocationCaptureGroup):
+        case (.linkerDuplicateSymbolsLocation, _ as LinkerDuplicateSymbolsLocationCaptureGroup):
             return nil
         case (.linkerDuplicateSymbols, let group as LinkerDuplicateSymbolsCaptureGroup):
             return formatLinkerDuplicateSymbolsError(group: group)
-        case (.linkerUndefinedSymbolLocation, let group as LinkerUndefinedSymbolLocationCaptureGroup):
+        case (.linkerUndefinedSymbolLocation, _ as LinkerUndefinedSymbolLocationCaptureGroup):
             return nil
         case (.linkerUndefinedSymbols, let group as LinkerUndefinedSymbolsCaptureGroup):
             return formatLinkerUndefinedSymbolsError(group: group)
-        case (.symbolReferencedFrom, let group as SymbolReferencedFromCaptureGroup):
+        case (.symbolReferencedFrom, _ as SymbolReferencedFromCaptureGroup):
             return formatCompleteError()
-        case (.undefinedSymbolLocation, let group as UndefinedSymbolLocationCaptureGroup):
+        case (.undefinedSymbolLocation, _ as UndefinedSymbolLocationCaptureGroup):
             return formatCompleteWarning()
         case (.packageFetching, let group as PackageFetchingCaptureGroup):
             return formatPackageFetching(group: group)
@@ -175,9 +175,9 @@ extension String {
             return formatPackageUpdating(group: group)
         case (.packageCheckingOut, let group as PackageCheckingOutCaptureGroup):
             return formatPackageCheckingOut(group: group)
-        case (.packageGraphResolvingStart, let group as PackageGraphResolvingStartCaptureGroup):
+        case (.packageGraphResolvingStart, _ as PackageGraphResolvingStartCaptureGroup):
             return formatPackageStart()
-        case (.packageGraphResolvingEnded, let group as PackageGraphResolvingEndedCaptureGroup):
+        case (.packageGraphResolvingEnded, _ as PackageGraphResolvingEndedCaptureGroup):
             return formatPackageEnd()
         case (.packageGraphResolvedItem, let group as PackageGraphResolvedItemCaptureGroup):
             return formatPackgeItem(group: group)

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -175,7 +175,7 @@ extension String {
         case (.packageUpdating, let group as PackageUpdatingCaptureGroup):
             return formatPackageUpdating(group: group)
         case (.packageCheckingOut, let group as PackageCheckingOutCaptureGroup):
-            return formatPackageCheckingOut(pattern: pattern)
+            return formatPackageCheckingOut(group: group)
         case (.packageGraphResolvingStart, let group as PackageGraphResolvingStartCaptureGroup):
             return formatPackageStart()
         case (.packageGraphResolvingEnded, let group as PackageGraphResolvingEndedCaptureGroup):
@@ -535,10 +535,9 @@ extension String {
         return "Updating " + source
     }
 
-    private func formatPackageCheckingOut(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let version = groups[0]
-        let package = groups[1]
+    private func formatPackageCheckingOut(group: PackageCheckingOutCaptureGroup) -> String? {
+        let version = group.version
+        let package = group.package
         return _colored ? "Checking out " + package.s.Bold + " @ " + version.f.Green : "Checking out \(package) @ \(version)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -40,7 +40,7 @@ extension String {
         case (.generateDsym, let group as GenerateDSYMCaptureGroup):
             return formatGenerateDsym(group: group)
         case (.libtool, let group as LibtoolCaptureGroup):
-            return formatLibtool(pattern: pattern)
+            return formatLibtool(group: group)
         case (.linking, let group as LinkingCaptureGroup):
         #if os(Linux)
             return formatLinkingLinux(pattern: pattern)
@@ -295,10 +295,9 @@ extension String {
         return _colored ? "\("Generated".s.Bold) code coverage report: \(filePath.s.Italic)" : "Generated code coverage report: \(filePath)"
     }
 
-    private func formatLibtool(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let filename = groups[0]
-        guard let target = groups.last else { return nil }
+    private func formatLibtool(group: LibtoolCaptureGroup) -> String? {
+        let filename = group.fileName
+        let target = group.target
         return _colored ? "[\(target.f.Cyan)] \("Building library".s.Bold) \(filename)" : "[\(target)] Building library \(filename)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -104,7 +104,7 @@ extension String {
         case (.processPch, let group as ProcessPchCaptureGroup):
             return formatProcessPch(pattern: pattern)
         case (.touch, let group as TouchCaptureGroup):
-            return formatTouch(pattern: pattern)
+            return formatTouch(group: group)
         case (.phaseSuccess, let group as PhaseSuccessCaptureGroup):
             let phase = capturedGroups(with: .phaseSuccess)[0].capitalized
             return _colored ? "\(phase) Succeeded".s.Bold.f.Green : "\(phase) Succeeded"
@@ -301,10 +301,9 @@ extension String {
         return _colored ? "[\(target.f.Cyan)] \("Building library".s.Bold) \(filename)" : "[\(target)] Building library \(filename)"
     }
 
-    private func formatTouch(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let filename = groups[1]
-        guard let target = groups.last else { return nil }
+    private func formatTouch(group: TouchCaptureGroup) -> String? {
+        let filename = group.filename
+        let target = group.target
         return _colored ? "[\(target.f.Cyan)] \("Touching".s.Bold) \(filename)" : "[\(target)] Touching \(filename)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -12,13 +12,8 @@ extension String {
         switch (pattern, group) {
         case (.analyze, let group as AnalyzeCaptureGroup):
             return formatAnalyze(group: group)
-        #if os(Linux)
         case (.compile, let group as CompileCaptureGroup):
             return formatCompile(group: group)
-        #else
-        case (.compile, let group as CompileCaptureGroup):
-            return formatCompile(group: group)
-        #endif
         case (.compileXib, let group as CompileXibCaptureGroup):
             return formatCompile(group: group)
         case (.compileStoryboard, let group as CompileStoryboardCaptureGroup):

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -121,7 +121,7 @@ extension String {
         case (.shellCommand, let group as ShellCommandCaptureGroup):
             return nil
         case (.cleanRemove, let group as CleanRemoveCaptureGroup):
-            return formatCleanRemove(pattern: pattern)
+            return formatCleanRemove(group: group)
         case (.executed, let group as ExecutedCaptureGroup):
             return nil
         case (.executedWithSkipped, let group as ExecutedWithSkippedCaptureGroup):
@@ -232,9 +232,8 @@ extension String {
         return _colored ? "[\(target.f.Cyan)] \("Analyzing".s.Bold) \(filename)" : "[\(target)] Analyzing \(filename)"
     }
 
-    private func formatCleanRemove(pattern: Pattern) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let directory = groups[0].lastPathComponent
+    private func formatCleanRemove(group: CleanRemoveCaptureGroup) -> String? {
+        let directory = group.directory
         return _colored ? "\("Cleaning".s.Bold) \(directory)" : "Cleaning \(directory)"
     }
 

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -127,7 +127,7 @@ extension String {
         case (.tiffutil, let group as TIFFutilCaptureGroup):
             return nil
         case (.compileWarning, let group as CompileWarningCaptureGroup):
-            return formatCompileWarning(pattern: pattern, additionalLines: additionalLines)
+            return formatCompileWarning(group: group, additionalLines: additionalLines)
         case (.ldWarning, let group as LDWarningCaptureGroup):
             return formatLdWarning(pattern: pattern)
         case (.genericWarning, let group as GenericWarningCaptureGroup):
@@ -448,10 +448,9 @@ extension String {
         return _colored ? Symbol.warning.rawValue + " " + self.f.Yellow : Symbol.asciiWarning.rawValue + " " + self
     }
 
-    private func formatCompileWarning(pattern: Pattern, additionalLines: @escaping () -> (String?)) -> String? {
-        let groups: [String] = capturedGroups(with: pattern)
-        let filePath = groups[0]
-        let reason = groups[2]
+    private func formatCompileWarning(group: CompileWarningCaptureGroup, additionalLines: @escaping () -> (String?)) -> String? {
+        let filePath = group.filePath
+        let reason = group.reason
 
         // Read 2 additional lines to get the warning line and cursor position
         let line: String = additionalLines() ?? ""

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -193,9 +193,9 @@ extension String {
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return TestCaseMeasuredCaptureGroup(suite: suite, testCase: testCase, time: time)
         case .parallelTestCasePassed:
-            assert(results.count >= 1)
-            guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
-            return ParallelTestingPassedCaptureGroup(device: device)
+            assert(results.count >= 4)
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let installedAppFileAndID = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
+            return ParallelTestCasePassedCaptureGroup(suite: suite, testCase: testCase, installedAppFileAndID: installedAppFileAndID, time: time)
         case .parallelTestCaseAppKitPassed:
             assert(results.count >= 3)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension String {
-    func capturedGroups(with pattern: Pattern) -> [String] {
+    func captureGroup(with pattern: Pattern) -> [String] {
         var results = [String]()
 
         var regex: NSRegularExpression
@@ -29,7 +29,7 @@ extension String {
 }
 
 extension String {
-    func capturedGroups(with pattern: Pattern) -> CaptureGroup {
+    func captureGroup(with pattern: Pattern) -> CaptureGroup {
         var regex: NSRegularExpression
         do {
             regex = try NSRegularExpression(pattern: pattern.rawValue, options: [.caseInsensitive])

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -382,8 +382,9 @@ extension String {
             guard let source = results[safe: 0] else { return EmptyCaptureGroup() }
             return PackageFetchingCaptureGroup(source: source)
         case .packageUpdating:
-            assert(results.count >= 0)
-            return PackageUpdatingCaptureGroup()
+            assert(results.count >= 1)
+            guard let source = results[safe: 0] else { return EmptyCaptureGroup() }
+            return PackageUpdatingCaptureGroup(source: source)
         case .packageCheckingOut:
             assert(results.count >= 0)
             return PackageCheckingOutCaptureGroup()

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -78,8 +78,9 @@ extension String {
             guard let commandPath = results[safe: 0], let arguments = results[safe: 1] else { return EmptyCaptureGroup() }
             return ShellCommandCaptureGroup(commandPath: commandPath, arguments: arguments)
         case .cleanRemove:
-            assert(results.count >= 0)
-            return CleanRemoveCaptureGroup()
+            assert(results.count >= 1)
+            guard let directory = results[safe: 0] else { return EmptyCaptureGroup() }
+            return CleanRemoveCaptureGroup(directory: directory.lastPathComponent)
         case .cleanTarget:
             assert(results.count >= 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -223,8 +223,9 @@ extension String {
             guard let suite = results[safe: 0], let device = results[safe: 1] else { return EmptyCaptureGroup() }
             return ParallelTestSuiteStartedCaptureGroup(suite: suite, device: device)
         case .phaseSuccess:
-            assert(results.count >= 0)
-            return PhaseSuccessCaptureGroup()
+            assert(results.count >= 1)
+            guard let phase = results[safe: 0] else { return EmptyCaptureGroup() }
+            return PhaseSuccessCaptureGroup(phase: phase)
         case .phaseScriptExecution:
             assert(results.count >= 2)
             guard let phaseName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -245,9 +245,11 @@ extension String {
             guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1], let buildTarget = results[safe: 2] else { return EmptyCaptureGroup() }
             return PbxcpCaptureGroup(sourceFile: sourceFile, targetFile: targetFile, buildTarget: buildTarget)
         case .processInfoPlist:
-            assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
-            return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: target)
+            assert(results.count >= 2)
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
+            // Xcode 10+ includes target output
+            // TODO: Test with target included
+            return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: results.last)
         case .testsRunCompletion:
             assert(results.count >= 3)
             guard let suite = results[safe: 0], let result = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -54,340 +54,340 @@ extension String {
 
         switch pattern {
         case .analyze:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
             return AnalyzeCaptureGroup(filePath: filePath, fileName: fileName)
         case .buildTarget:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return BuildTargetCaptureGroup(target: target, project: project, configuration: configuration)
         case .aggregateTarget:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return AggregateTargetCaptureGroup(target: target, project: project, configuration: configuration)
         case .analyzeTarget:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return AnalyzeTargetCaptureGroup(target: target, project: project, configuration: configuration)
         case .checkDependencies:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return CheckDependenciesCaptureGroup()
         case .shellCommand:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let commandPath = results[safe: 0], let arguments = results[safe: 1] else { return EmptyCaptureGroup() }
             return ShellCommandCaptureGroup(commandPath: commandPath, arguments: arguments)
         case .cleanRemove:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return CleanRemoveCaptureGroup()
         case .cleanTarget:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return CleanTargetCaptureGroup(target: target, project: project, configuration: configuration)
         case .codesign:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
             return CodesignCaptureGroup(file: file)
         case .codesignFramework:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
             return CodesignFrameworkCaptureGroup(file: file)
 #if os(Linux)
         case .compile:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let fileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return CompileCaptureGroup(filename: fileName, target: target)
 #else
         case .compile:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileCaptureGroup(filePath: filePath, filename: fileName, target: target)
 #endif
         case .compileCommand:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let compilerCommand = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
             return CompileCommandCaptureGroup(compilerCommand: compilerCommand, filePath: filePath)
         case .compileXib:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileXibCaptureGroup(filePath: filePath, filename: fileName, target: target)
         case .compileStoryboard:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileStoryboardCaptureGroup(filePath: filePath, filename: fileName, target: target)
         case .copyHeader:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
             return CopyHeaderCaptureGroup(sourceFile: sourceFile, targetFile: targetFile, target: target)
         case .copyPlist:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1] else { return EmptyCaptureGroup() }
             return CopyPlistCaptureGroup(sourceFile: sourceFile, targetFile: targetFile)
         case .copyStrings:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
             return CopyStringsCaptureGroup(file: file)
         case .cpresource:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let resource = results[safe: 0] else { return EmptyCaptureGroup() }
             return CpresourceCaptureGroup(resource: resource)
         case .executed:
-            assert(results.count == 4)
+            assert(results.count >= 4)
             guard let numberOfTests = results[safe: 0], let numberOfFailures = results[safe: 1], let numberOfUnexpectedFailures = results[safe: 2], let wallClockTimeInSeconds = results[safe: 3] else { return EmptyCaptureGroup() }
             return ExecutedCaptureGroup(numberOfTests: numberOfTests, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
         case .executedWithSkipped:
-            assert(results.count == 5)
+            assert(results.count >= 5)
             guard let numberOfTests = results[safe: 0], let numberOfSkipped = results[safe: 1], let numberOfFailures = results[safe: 2], let numberOfUnexpectedFailures = results[safe: 3], let wallClockTimeInSeconds = results[safe: 4] else { return EmptyCaptureGroup() }
             return ExecutedWithSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfSkipped: numberOfSkipped, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
         case .failingTest:
-            assert(results.count == 4)
+            assert(results.count >= 4)
             guard let file = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2], let reason = results[safe: 3] else { return EmptyCaptureGroup() }
             return FailingTestCaptureGroup(file: file, testSuite: testSuite, testCase: testCase, reason: reason)
         case .uiFailingTest:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let file = results[safe: 0], let reason = results[safe: 1] else { return EmptyCaptureGroup() }
             return UIFailingTestCaptureGroup(file: file, reason: reason)
         case .restartingTest:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let testSuiteAndTestCase = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2] else { return EmptyCaptureGroup() }
             return RestartingTestCaptureGroup(testSuiteAndTestCase: testSuiteAndTestCase, testSuite: testSuite, testCase: testCase)
         case .generateCoverageData:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return GenerateCoverageDataCaptureGroup()
         case .generatedCoverageReport:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let coverageReportFilePath = results[safe: 0] else { return EmptyCaptureGroup() }
             return GeneratedCoverageReportCaptureGroup(coverageReportFilePath: coverageReportFilePath)
         case .generateDsym:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let dsym = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return GenerateDSYMCaptureGroup(dsym: dsym, target: target)
         case .libtool:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let library = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return LibtoolCaptureGroup(library: library, target: target)
 #if os(Linux)
         case .linking:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let target = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkingCaptureGroup(target: target)
 #else
         case .linking:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let binaryFileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return LinkingCaptureGroup(binaryFilename: binaryFileName, target: target)
 #endif
         case .testCasePassed:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return TestCasePassedCaptureGroup(suite: suite, testCase: testCase, time: time)
         case .testCaseStarted:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
             return TestCaseStartedCaptureGroup(suite: suite, testCase: testCase)
         case .testCasePending:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
             return TestCasePendingCaptureGroup(suite: suite, testCase: testCase)
         case .testCaseMeasured:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return TestCaseMeasuredCaptureGroup(suite: suite, testCase: testCase, time: time)
         case .parallelTestCasePassed:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingPassedCaptureGroup(device: device)
         case .parallelTestCaseAppKitPassed:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return ParallelTestCaseAppKitPassedCaptureGroup(suite: suite, testCase: testCase, time: time)
         case .parallelTestCaseFailed:
-            assert(results.count == 4)
+            assert(results.count >= 4)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let installedAppFileAndID = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
             return ParallelTestCaseFailedCaptureGroup(suite: suite, testCase: testCase, installedAppFileAndID: installedAppFileAndID, time: time)
         case .parallelTestingStarted:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingStartedCaptureGroup(device: device)
         case .parallelTestingPassed:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingPassedCaptureGroup(device: device)
         case .parallelTestingFailed:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingFailedCaptureGroup(device: device)
         case .parallelTestSuiteStarted:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let suite = results[safe: 0], let device = results[safe: 1] else { return EmptyCaptureGroup() }
             return ParallelTestSuiteStartedCaptureGroup(suite: suite, device: device)
         case .phaseSuccess:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return PhaseSuccessCaptureGroup()
         case .phaseScriptExecution:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let phaseName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return PhaseScriptExecutionCaptureGroup(phaseName: phaseName, target: target)
         case .processPch:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let file = results[safe: 0], let buildTarget = results[safe: 1] else { return EmptyCaptureGroup() }
             return ProcessPchCaptureGroup(file: file, buildTarget: buildTarget)
         case .processPchCommand:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let filePath = results[safe: 0] else { return EmptyCaptureGroup() }
             return ProcessPchCommandCaptureGroup(filePath: filePath)
         case .preprocess:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
             return PreprocessCaptureGroup(file: file)
         case .pbxcp:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1], let buildTarget = results[safe: 2] else { return EmptyCaptureGroup() }
             return PbxcpCaptureGroup(sourceFile: sourceFile, targetFile: targetFile, buildTarget: buildTarget)
         case .processInfoPlist:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
             return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: target)
         case .testsRunCompletion:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let suite = results[safe: 0], let result = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return TestsRunCompletionCaptureGroup(suite: suite, result: result, time: time)
         case .testSuiteStarted:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let suite = results[safe: 0], let time = results[safe: 1] else { return EmptyCaptureGroup() }
             return TestSuiteStartedCaptureGroup(suite: suite, time: time)
         case .testSuiteStart:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let testSuiteName = results[safe: 0] else { return EmptyCaptureGroup() }
             return TestSuiteStartCaptureGroup(testSuiteName: testSuiteName)
         case .testSuiteAllTestsPassed:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return TestSuiteAllTestsPassedCaptureGroup()
         case .testSuiteAllTestsFailed:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return TestSuiteAllTestsFailedCaptureGroup()
         case .tiffutil:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let fileName = results[safe: 0] else { return EmptyCaptureGroup() }
             return TIFFutilCaptureGroup(filename: fileName)
         case .touch:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let fileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return TouchCaptureGroup(filename: fileName, target: target)
         case .writeFile:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let filePath = results[safe: 0] else { return EmptyCaptureGroup() }
             return WriteFileCaptureGroup(filePath: filePath)
         case .writeAuxiliaryFiles:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return WriteAuxiliaryFilesCaptureGroup()
         case .compileWarning:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let reason = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileWarningCaptureGroup(filePath: filePath, filename: fileName, reason: reason)
         case .ldWarning:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let ldPrefix = results[safe: 0], let warningMessage = results[safe: 1] else { return EmptyCaptureGroup() }
             return LDWarningCaptureGroup(ldPrefix: ldPrefix, warningMessage: warningMessage)
         case .genericWarning:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let wholeWarning = results[safe: 0] else { return EmptyCaptureGroup() }
             return GenericWarningCaptureGroup(wholeWarning: wholeWarning)
         case .willNotBeCodeSigned:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let wholeWarning = results[safe: 0] else { return EmptyCaptureGroup() }
             return WillNotBeCodeSignedCaptureGroup(wholeWarning: wholeWarning)
         case .duplicateLocalizedStringKey:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let wholeMessage = results[safe: 0] else { return EmptyCaptureGroup() }
             return DuplicateLocalizedStringKeyCaptureGroup(warningMessage: wholeMessage)
         case .clangError:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return ClangErrorCaptureGroup(wholeError: wholeError)
         case .checkDependenciesErrors:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return CheckDependenciesCaptureGroup()
         case .provisioningProfileRequired:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return ProvisioningProfileRequiredCaptureGroup(wholeError: wholeError)
         case .noCertificate:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return NoCertificateCaptureGroup(wholeError: wholeError)
         case .compileError:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let filePath = results[safe: 0], let isFatalError = results[safe: 1], let reason = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileErrorCaptureGroup(filePath: filePath, isFatalError: isFatalError, reason: reason)
         case .cursor:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let cursor = results[safe: 0] else { return EmptyCaptureGroup() }
             return CursorCaptureGroup(cursor: cursor)
         case .fatalError:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return FatalErrorCaptureGroup(wholeError: wholeError)
         case .fileMissingError:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let wholeError = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
             return FileMissingErrorCaptureGroup(wholeError: wholeError, filePath: filePath)
         case .ldError:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return LDErrorCaptureGroup(wholeError: wholeError)
         case .linkerDuplicateSymbolsLocation:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
         case .linkerDuplicateSymbols:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
         case .linkerUndefinedSymbolLocation:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
         case .linkerUndefinedSymbols:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
         case .podsError:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return PodsErrorCaptureGroup(reason: reason)
         case .symbolReferencedFrom:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let reference = results[safe: 0] else { return EmptyCaptureGroup() }
             return SymbolReferencedFromCaptureGroup(reference: reference)
         case .moduleIncludesError:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let errorReason = results[safe: 0] else { return EmptyCaptureGroup() }
             return ModuleIncludesErrorCaptureGroup(errorReason: errorReason)
         case .undefinedSymbolLocation:
-            assert(results.count == 2)
+            assert(results.count >= 2)
             guard let target = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
             return UndefinedSymbolLocationCaptureGroup(target: target, filename: fileName)
         case .packageFetching:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return PackageFetchingCaptureGroup()
         case .packageUpdating:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return PackageUpdatingCaptureGroup()
         case .packageCheckingOut:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return PackageCheckingOutCaptureGroup()
         case .packageGraphResolvingStart:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return PackageGraphResolvingStartCaptureGroup()
         case .packageGraphResolvingEnded:
-            assert(results.count == 0)
+            assert(results.count >= 0)
             return PackageGraphResolvingEndedCaptureGroup()
         case .packageGraphResolvedItem:
-            assert(results.count == 3)
+            assert(results.count >= 3)
             guard let packageName = results[safe: 0], let packageURL = results[safe: 1], let packageVersion = results[safe: 2] else { return EmptyCaptureGroup() }
             return PackageGraphResolvedItemCaptureGroup(packageName: packageName, packageURL: packageURL, packageVersion: packageVersion)
         case .xcodebuildError:
-            assert(results.count == 1)
+            assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return XcodebuildErrorCaptureGroup(wholeError: wholeError)
         }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -82,13 +82,12 @@ extension String {
             guard let frameworkPath = results[safe: 0] else { return EmptyCaptureGroup() }
             return CodesignFrameworkCaptureGroup(frameworkPath: frameworkPath)
 
-#if os(Linux)
         case .compile:
+#if os(Linux)
             assert(results.count >= 2)
             guard let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return CompileCaptureGroup(filename: fileName, target: target)
 #else
-        case .compile:
             assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return CompileCaptureGroup(filePath: filePath, filename: fileName, target: target)
@@ -173,13 +172,12 @@ extension String {
             guard let fileName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return LibtoolCaptureGroup(fileName: fileName, target: target)
 
-#if os(Linux)
         case .linking:
+#if os(Linux)
             assert(results.count >= 1)
             guard let target = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkingCaptureGroup(target: target)
 #else
-        case .linking:
             assert(results.count >= 2)
             guard let binaryFileName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return LinkingCaptureGroup(binaryFilename: binaryFileName.lastPathComponent, target: target)

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -55,7 +55,7 @@ extension String {
 
         switch pattern {
         case .analyze:
-            assert(results.count >= 2)
+            assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return AnalyzeCaptureGroup(filePath: filePath, fileName: fileName, target: target)
         case .buildTarget:

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -30,28 +30,7 @@ extension String {
 
 extension String {
     func captureGroup(with pattern: Pattern) -> CaptureGroup {
-        var regex: NSRegularExpression
-        do {
-            regex = try NSRegularExpression(pattern: pattern.rawValue, options: [.caseInsensitive])
-        } catch {
-            return EmptyCaptureGroup()
-        }
-
-        let matches = regex.matches(in: self, range: NSRange(location:0, length: self.utf16.count))
-
-        var results = [String]()
-
-        if let match = matches.first {
-            let lastRangeIndex = match.numberOfRanges - 1
-
-            if lastRangeIndex >= 1 {
-                for i in 1...lastRangeIndex {
-                    let capturedGroupIndex = match.range(at: i)
-                    guard let matchedString = substring(with: capturedGroupIndex) else { continue }
-                    results.append(matchedString)
-                }
-            }
-        }
+        let results: [String] = captureGroup(with: pattern)
 
         switch pattern {
         case .analyze:

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -363,16 +363,16 @@ extension String {
             return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
         case .podsError:
             assert(results.count >= 1)
-            guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
-            return PodsErrorCaptureGroup(reason: reason)
+            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            return PodsErrorCaptureGroup(wholeError: wholeError)
         case .symbolReferencedFrom:
             assert(results.count >= 1)
             guard let reference = results[safe: 0] else { return EmptyCaptureGroup() }
             return SymbolReferencedFromCaptureGroup(reference: reference)
         case .moduleIncludesError:
             assert(results.count >= 1)
-            guard let errorReason = results[safe: 0] else { return EmptyCaptureGroup() }
-            return ModuleIncludesErrorCaptureGroup(errorReason: errorReason)
+            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            return ModuleIncludesErrorCaptureGroup(wholeError: wholeError)
         case .undefinedSymbolLocation:
             assert(results.count >= 2)
             guard let target = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -191,21 +191,21 @@ extension String {
             guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
             return TestCasePendingCaptureGroup(suite: suite, testCase: testCase)
         case .testCaseMeasured:
-            assert(results.count >= 3)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
-            return TestCaseMeasuredCaptureGroup(suite: suite, testCase: testCase, time: time)
+            assert(results.count >= 6)
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let name = results[safe: 2], let unitName = results[safe: 3], let value = results[safe: 4], let deviation = results[safe: 5] else { return EmptyCaptureGroup() }
+            return TestCaseMeasuredCaptureGroup(suite: suite, testCase: testCase, name: name, unitName: unitName, value: value, deviation: deviation)
         case .parallelTestCasePassed:
             assert(results.count >= 4)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let installedAppFileAndID = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
-            return ParallelTestCasePassedCaptureGroup(suite: suite, testCase: testCase, installedAppFileAndID: installedAppFileAndID, time: time)
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let device = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
+            return ParallelTestCasePassedCaptureGroup(suite: suite, testCase: testCase, device: device, time: time)
         case .parallelTestCaseAppKitPassed:
             assert(results.count >= 3)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return ParallelTestCaseAppKitPassedCaptureGroup(suite: suite, testCase: testCase, time: time)
         case .parallelTestCaseFailed:
             assert(results.count >= 4)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let installedAppFileAndID = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
-            return ParallelTestCaseFailedCaptureGroup(suite: suite, testCase: testCase, installedAppFileAndID: installedAppFileAndID, time: time)
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let device = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
+            return ParallelTestCaseFailedCaptureGroup(suite: suite, testCase: testCase, device: device, time: time)
         case .parallelTestingStarted:
             assert(results.count >= 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -58,41 +58,51 @@ extension String {
             assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return AnalyzeCaptureGroup(filePath: filePath, fileName: fileName, target: target)
+
         case .buildTarget:
             assert(results.count >= 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return BuildTargetCaptureGroup(target: target, project: project, configuration: configuration)
+
         case .aggregateTarget:
             assert(results.count >= 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return AggregateTargetCaptureGroup(target: target, project: project, configuration: configuration)
+
         case .analyzeTarget:
             assert(results.count >= 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return AnalyzeTargetCaptureGroup(target: target, project: project, configuration: configuration)
+
         case .checkDependencies:
             assert(results.count >= 0)
             return CheckDependenciesCaptureGroup()
+
         case .shellCommand:
             assert(results.count >= 2)
             guard let commandPath = results[safe: 0], let arguments = results[safe: 1] else { return EmptyCaptureGroup() }
             return ShellCommandCaptureGroup(commandPath: commandPath, arguments: arguments)
+
         case .cleanRemove:
             assert(results.count >= 1)
             guard let directory = results[safe: 0] else { return EmptyCaptureGroup() }
             return CleanRemoveCaptureGroup(directory: directory.lastPathComponent)
+
         case .cleanTarget:
             assert(results.count >= 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return CleanTargetCaptureGroup(target: target, project: project, configuration: configuration)
+
         case .codesign:
             assert(results.count >= 1)
             guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
             return CodesignCaptureGroup(file: file)
+
         case .codesignFramework:
             assert(results.count >= 1)
             guard let frameworkPath = results[safe: 0] else { return EmptyCaptureGroup() }
             return CodesignFrameworkCaptureGroup(frameworkPath: frameworkPath)
+
 #if os(Linux)
         case .compile:
             assert(results.count >= 2)
@@ -104,69 +114,86 @@ extension String {
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return CompileCaptureGroup(filePath: filePath, filename: fileName, target: target)
 #endif
+
         case .compileCommand:
             assert(results.count >= 2)
             guard let compilerCommand = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
             return CompileCommandCaptureGroup(compilerCommand: compilerCommand, filePath: filePath)
+
         case .compileXib:
             assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return CompileXibCaptureGroup(filePath: filePath, filename: fileName, target: target)
+
         case .compileStoryboard:
             assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return CompileStoryboardCaptureGroup(filePath: filePath, filename: fileName, target: target)
+
         case .copyHeader:
             assert(results.count >= 3)
             guard let file = results[safe: 0], let targetFile = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return CopyHeaderCaptureGroup(file: file.lastPathComponent, targetFile: targetFile, target: target)
+
         case .copyPlist:
             assert(results.count >= 2)
             guard let file = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return CopyPlistCaptureGroup(file: file.lastPathComponent, target: target)
+
         case .copyStrings:
             assert(results.count >= 2)
             guard let file = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return CopyStringsCaptureGroup(file: file.lastPathComponent, target: target)
+
         case .cpresource:
             assert(results.count >= 2)
             guard let file = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return CpresourceCaptureGroup(file: file.lastPathComponent, target: target)
+
         case .executed:
             assert(results.count >= 4)
             guard let numberOfTests = results[safe: 0], let numberOfFailures = results[safe: 1], let numberOfUnexpectedFailures = results[safe: 2], let wallClockTimeInSeconds = results[safe: 3] else { return EmptyCaptureGroup() }
             return ExecutedCaptureGroup(numberOfTests: numberOfTests, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
+
         case .executedWithSkipped:
             assert(results.count >= 5)
             guard let numberOfTests = results[safe: 0], let numberOfSkipped = results[safe: 1], let numberOfFailures = results[safe: 2], let numberOfUnexpectedFailures = results[safe: 3], let wallClockTimeInSeconds = results[safe: 4] else { return EmptyCaptureGroup() }
             return ExecutedWithSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfSkipped: numberOfSkipped, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
+
         case .failingTest:
             assert(results.count >= 4)
             guard let file = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2], let reason = results[safe: 3] else { return EmptyCaptureGroup() }
             return FailingTestCaptureGroup(file: file, testSuite: testSuite, testCase: testCase, reason: reason)
+
         case .uiFailingTest:
             assert(results.count >= 2)
             guard let file = results[safe: 0], let reason = results[safe: 1] else { return EmptyCaptureGroup() }
             return UIFailingTestCaptureGroup(file: file, reason: reason)
+
         case .restartingTest:
             assert(results.count >= 3)
             guard let testSuiteAndTestCase = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2] else { return EmptyCaptureGroup() }
             return RestartingTestCaptureGroup(testSuiteAndTestCase: testSuiteAndTestCase, testSuite: testSuite, testCase: testCase)
+
         case .generateCoverageData:
             assert(results.count >= 0)
             return GenerateCoverageDataCaptureGroup()
+
         case .generatedCoverageReport:
             assert(results.count >= 1)
             guard let coverageReportFilePath = results[safe: 0] else { return EmptyCaptureGroup() }
             return GeneratedCoverageReportCaptureGroup(coverageReportFilePath: coverageReportFilePath)
+
         case .generateDsym:
             assert(results.count >= 2)
             guard let dsym = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return GenerateDSYMCaptureGroup(dsym: dsym, target: target)
+
         case .libtool:
             assert(results.count >= 2)
             guard let fileName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return LibtoolCaptureGroup(fileName: fileName, target: target)
+
 #if os(Linux)
         case .linking:
             assert(results.count >= 1)
@@ -178,74 +205,92 @@ extension String {
             guard let binaryFileName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return LinkingCaptureGroup(binaryFilename: binaryFileName.lastPathComponent, target: target)
 #endif
+
         case .testCasePassed:
             assert(results.count >= 3)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return TestCasePassedCaptureGroup(suite: suite, testCase: testCase, time: time)
+
         case .testCaseStarted:
             assert(results.count >= 2)
             guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
             return TestCaseStartedCaptureGroup(suite: suite, testCase: testCase)
+
         case .testCasePending:
             assert(results.count >= 2)
             guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
             return TestCasePendingCaptureGroup(suite: suite, testCase: testCase)
+
         case .testCaseMeasured:
             assert(results.count >= 6)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let name = results[safe: 2], let unitName = results[safe: 3], let value = results[safe: 4], let deviation = results[safe: 5] else { return EmptyCaptureGroup() }
             return TestCaseMeasuredCaptureGroup(suite: suite, testCase: testCase, name: name, unitName: unitName, value: value, deviation: deviation)
+
         case .parallelTestCasePassed:
             assert(results.count >= 4)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let device = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
             return ParallelTestCasePassedCaptureGroup(suite: suite, testCase: testCase, device: device, time: time)
+
         case .parallelTestCaseAppKitPassed:
             assert(results.count >= 3)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return ParallelTestCaseAppKitPassedCaptureGroup(suite: suite, testCase: testCase, time: time)
+
         case .parallelTestCaseFailed:
             assert(results.count >= 4)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let device = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
             return ParallelTestCaseFailedCaptureGroup(suite: suite, testCase: testCase, device: device, time: time)
+
         case .parallelTestingStarted:
             assert(results.count >= 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingStartedCaptureGroup(device: device)
+
         case .parallelTestingPassed:
             assert(results.count >= 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingPassedCaptureGroup(device: device)
+
         case .parallelTestingFailed:
             assert(results.count >= 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingFailedCaptureGroup(device: device)
+
         case .parallelTestSuiteStarted:
             assert(results.count >= 2)
             guard let suite = results[safe: 0], let device = results[safe: 1] else { return EmptyCaptureGroup() }
             return ParallelTestSuiteStartedCaptureGroup(suite: suite, device: device)
+
         case .phaseSuccess:
             assert(results.count >= 1)
             guard let phase = results[safe: 0] else { return EmptyCaptureGroup() }
             return PhaseSuccessCaptureGroup(phase: phase)
+
         case .phaseScriptExecution:
             assert(results.count >= 2)
             guard let phaseName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return PhaseScriptExecutionCaptureGroup(phaseName: phaseName, target: target)
+
         case .processPch:
             assert(results.count >= 2)
             guard let file = results[safe: 0], let buildTarget = results.last else { return EmptyCaptureGroup() }
             return ProcessPchCaptureGroup(file: file, buildTarget: buildTarget)
+
         case .processPchCommand:
             assert(results.count >= 1)
             guard let filePath = results.last else { return EmptyCaptureGroup() }
             return ProcessPchCommandCaptureGroup(filePath: filePath)
+
         case .preprocess:
             assert(results.count >= 1)
             guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
             return PreprocessCaptureGroup(file: file)
+
         case .pbxcp:
             assert(results.count >= 3)
             guard let file = results[safe: 0], let targetFile = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return PbxcpCaptureGroup(file: file.lastPathComponent, targetFile: targetFile, target: target)
+
         case .processInfoPlist:
             assert(results.count >= 2)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
@@ -258,148 +303,186 @@ extension String {
                 // Xcode 10+ includes target output
                 return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: results.last)
             }
+
         case .testsRunCompletion:
             assert(results.count >= 3)
             guard let suite = results[safe: 0], let result = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return TestsRunCompletionCaptureGroup(suite: suite, result: result, time: time)
+
         case .testSuiteStarted:
             assert(results.count >= 2)
             guard let suite = results[safe: 0], let time = results[safe: 1] else { return EmptyCaptureGroup() }
             return TestSuiteStartedCaptureGroup(suite: suite, time: time)
+
         case .testSuiteStart:
             assert(results.count >= 1)
             guard let testSuiteName = results[safe: 0] else { return EmptyCaptureGroup() }
             return TestSuiteStartCaptureGroup(testSuiteName: testSuiteName)
+
         case .testSuiteAllTestsPassed:
             assert(results.count >= 0)
             return TestSuiteAllTestsPassedCaptureGroup()
+
         case .testSuiteAllTestsFailed:
             assert(results.count >= 0)
             return TestSuiteAllTestsFailedCaptureGroup()
+
         case .tiffutil:
             assert(results.count >= 1)
             guard let fileName = results[safe: 0] else { return EmptyCaptureGroup() }
             return TIFFutilCaptureGroup(filename: fileName)
+
         case .touch:
             assert(results.count >= 3)
             guard let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return TouchCaptureGroup(filename: fileName, target: target)
+
         case .writeFile:
             assert(results.count >= 1)
             guard let filePath = results[safe: 0] else { return EmptyCaptureGroup() }
             return WriteFileCaptureGroup(filePath: filePath)
+
         case .writeAuxiliaryFiles:
             assert(results.count >= 0)
             return WriteAuxiliaryFilesCaptureGroup()
+
         case .compileWarning:
             assert(results.count >= 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let reason = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileWarningCaptureGroup(filePath: filePath, filename: fileName, reason: reason)
+
         case .ldWarning:
             assert(results.count >= 2)
             guard let ldPrefix = results[safe: 0], let warningMessage = results[safe: 1] else { return EmptyCaptureGroup() }
             return LDWarningCaptureGroup(ldPrefix: ldPrefix, warningMessage: warningMessage)
+
         case .genericWarning:
             assert(results.count >= 1)
             guard let wholeWarning = results[safe: 0] else { return EmptyCaptureGroup() }
             return GenericWarningCaptureGroup(wholeWarning: wholeWarning)
+
         case .willNotBeCodeSigned:
             assert(results.count >= 1)
             guard let wholeWarning = results[safe: 0] else { return EmptyCaptureGroup() }
             return WillNotBeCodeSignedCaptureGroup(wholeWarning: wholeWarning)
+
         case .duplicateLocalizedStringKey:
             assert(results.count >= 1)
             guard let wholeMessage = results[safe: 0] else { return EmptyCaptureGroup() }
             return DuplicateLocalizedStringKeyCaptureGroup(warningMessage: wholeMessage)
+
         case .clangError:
             assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return ClangErrorCaptureGroup(wholeError: wholeError)
+
         case .checkDependenciesErrors:
             assert(results.count >= 0)
             return CheckDependenciesCaptureGroup()
+
         case .provisioningProfileRequired:
             assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return ProvisioningProfileRequiredCaptureGroup(wholeError: wholeError)
+
         case .noCertificate:
             assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return NoCertificateCaptureGroup(wholeError: wholeError)
+
         case .compileError:
             assert(results.count >= 3)
             guard let filePath = results[safe: 0], let isFatalError = results[safe: 1], let reason = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileErrorCaptureGroup(filePath: filePath, isFatalError: isFatalError, reason: reason)
+
         case .cursor:
             assert(results.count >= 1)
             guard let cursor = results[safe: 0] else { return EmptyCaptureGroup() }
             return CursorCaptureGroup(cursor: cursor)
+
         case .fatalError:
             assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return FatalErrorCaptureGroup(wholeError: wholeError)
+
         case .fileMissingError:
             assert(results.count >= 2)
             guard let reason = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
             return FileMissingErrorCaptureGroup(reason: reason, filePath: filePath)
+
         case .ldError:
             assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return LDErrorCaptureGroup(wholeError: wholeError)
+
         case .linkerDuplicateSymbolsLocation:
             assert(results.count >= 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
+
         case .linkerDuplicateSymbols:
             assert(results.count >= 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
+
         case .linkerUndefinedSymbolLocation:
             assert(results.count >= 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
+
         case .linkerUndefinedSymbols:
             assert(results.count >= 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
+
         case .podsError:
             assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return PodsErrorCaptureGroup(wholeError: wholeError)
+
         case .symbolReferencedFrom:
             assert(results.count >= 1)
             guard let reference = results[safe: 0] else { return EmptyCaptureGroup() }
             return SymbolReferencedFromCaptureGroup(reference: reference)
+
         case .moduleIncludesError:
             assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return ModuleIncludesErrorCaptureGroup(wholeError: wholeError)
+
         case .undefinedSymbolLocation:
             assert(results.count >= 2)
             guard let target = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
             return UndefinedSymbolLocationCaptureGroup(target: target, filename: fileName)
+
         case .packageFetching:
             assert(results.count >= 1)
             guard let source = results[safe: 0] else { return EmptyCaptureGroup() }
             return PackageFetchingCaptureGroup(source: source)
+
         case .packageUpdating:
             assert(results.count >= 1)
             guard let source = results[safe: 0] else { return EmptyCaptureGroup() }
             return PackageUpdatingCaptureGroup(source: source)
+
         case .packageCheckingOut:
             assert(results.count >= 2)
             guard let version = results[safe: 0], let package = results[safe: 1] else { return EmptyCaptureGroup() }
             return PackageCheckingOutCaptureGroup(version: version, package: package)
+
         case .packageGraphResolvingStart:
             assert(results.count >= 0)
             return PackageGraphResolvingStartCaptureGroup()
+
         case .packageGraphResolvingEnded:
             assert(results.count >= 0)
             return PackageGraphResolvingEndedCaptureGroup()
+
         case .packageGraphResolvedItem:
             assert(results.count >= 3)
             guard let packageName = results[safe: 0], let packageURL = results[safe: 1], let packageVersion = results[safe: 2] else { return EmptyCaptureGroup() }
             return PackageGraphResolvedItemCaptureGroup(packageName: packageName, packageURL: packageURL, packageVersion: packageVersion)
+
         case .xcodebuildError:
             assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -274,8 +274,8 @@ extension String {
             guard let fileName = results[safe: 0] else { return EmptyCaptureGroup() }
             return TIFFutilCaptureGroup(filename: fileName)
         case .touch:
-            assert(results.count >= 2)
-            guard let fileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            assert(results.count >= 3)
+            guard let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return TouchCaptureGroup(filename: fileName, target: target)
         case .writeFile:
             assert(results.count >= 1)

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -175,8 +175,8 @@ extension String {
 #else
         case .linking:
             assert(results.count >= 2)
-            guard let binaryFileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
-            return LinkingCaptureGroup(binaryFilename: binaryFileName, target: target)
+            guard let binaryFileName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            return LinkingCaptureGroup(binaryFilename: binaryFileName.lastPathComponent, target: target)
 #endif
         case .testCasePassed:
             assert(results.count >= 3)

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -118,20 +118,20 @@ extension String {
             return CompileStoryboardCaptureGroup(filePath: filePath, filename: fileName, target: target)
         case .copyHeader:
             assert(results.count >= 3)
-            guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
-            return CopyHeaderCaptureGroup(sourceFile: sourceFile, targetFile: targetFile, target: target)
+            guard let file = results[safe: 0], let targetFile = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            return CopyHeaderCaptureGroup(file: file.lastPathComponent, targetFile: targetFile, target: target)
         case .copyPlist:
             assert(results.count >= 2)
-            guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1] else { return EmptyCaptureGroup() }
-            return CopyPlistCaptureGroup(sourceFile: sourceFile, targetFile: targetFile)
+            guard let file = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            return CopyPlistCaptureGroup(file: file.lastPathComponent, target: target)
         case .copyStrings:
-            assert(results.count >= 1)
-            guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
-            return CopyStringsCaptureGroup(file: file)
+            assert(results.count >= 2)
+            guard let file = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            return CopyStringsCaptureGroup(file: file.lastPathComponent, target: target)
         case .cpresource:
-            assert(results.count >= 1)
-            guard let resource = results[safe: 0] else { return EmptyCaptureGroup() }
-            return CpresourceCaptureGroup(resource: resource)
+            assert(results.count >= 2)
+            guard let file = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            return CpresourceCaptureGroup(file: file.lastPathComponent, target: target)
         case .executed:
             assert(results.count >= 4)
             guard let numberOfTests = results[safe: 0], let numberOfFailures = results[safe: 1], let numberOfUnexpectedFailures = results[safe: 2], let wallClockTimeInSeconds = results[safe: 3] else { return EmptyCaptureGroup() }
@@ -244,8 +244,8 @@ extension String {
             return PreprocessCaptureGroup(file: file)
         case .pbxcp:
             assert(results.count >= 3)
-            guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1], let buildTarget = results[safe: 2] else { return EmptyCaptureGroup() }
-            return PbxcpCaptureGroup(sourceFile: sourceFile, targetFile: targetFile, buildTarget: buildTarget)
+            guard let file = results[safe: 0], let targetFile = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            return PbxcpCaptureGroup(file: file.lastPathComponent, targetFile: targetFile, target: target)
         case .processInfoPlist:
             assert(results.count >= 2)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -161,7 +161,7 @@ extension String {
             return GeneratedCoverageReportCaptureGroup(coverageReportFilePath: coverageReportFilePath)
         case .generateDsym:
             assert(results.count >= 2)
-            guard let dsym = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let dsym = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return GenerateDSYMCaptureGroup(dsym: dsym, target: target)
         case .libtool:
             assert(results.count >= 2)

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -39,17 +39,18 @@ extension String {
 
         let matches = regex.matches(in: self, range: NSRange(location:0, length: self.utf16.count))
 
-        guard let match = matches.first else { return EmptyCaptureGroup() }
-
-        let lastRangeIndex = match.numberOfRanges - 1
-        guard lastRangeIndex >= 1 else { return EmptyCaptureGroup() }
-
         var results = [String]()
 
-        for i in 1...lastRangeIndex {
-            let capturedGroupIndex = match.range(at: i)
-            guard let matchedString = substring(with: capturedGroupIndex) else { continue }
-            results.append(matchedString)
+        if let match = matches.first {
+            let lastRangeIndex = match.numberOfRanges - 1
+
+            if lastRangeIndex >= 1 {
+                for i in 1...lastRangeIndex {
+                    let capturedGroupIndex = match.range(at: i)
+                    guard let matchedString = substring(with: capturedGroupIndex) else { continue }
+                    results.append(matchedString)
+                }
+            }
         }
 
         switch pattern {

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -165,8 +165,8 @@ extension String {
             return GenerateDSYMCaptureGroup(dsym: dsym, target: target)
         case .libtool:
             assert(results.count >= 2)
-            guard let library = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
-            return LibtoolCaptureGroup(library: library, target: target)
+            guard let fileName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            return LibtoolCaptureGroup(fileName: fileName, target: target)
 #if os(Linux)
         case .linking:
             assert(results.count >= 1)

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -96,12 +96,12 @@ extension String {
 #if os(Linux)
         case .compile:
             assert(results.count >= 2)
-            guard let fileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return CompileCaptureGroup(filename: fileName, target: target)
 #else
         case .compile:
             assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return CompileCaptureGroup(filePath: filePath, filename: fileName, target: target)
 #endif
         case .compileCommand:
@@ -110,11 +110,11 @@ extension String {
             return CompileCommandCaptureGroup(compilerCommand: compilerCommand, filePath: filePath)
         case .compileXib:
             assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return CompileXibCaptureGroup(filePath: filePath, filename: fileName, target: target)
         case .compileStoryboard:
             assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
             return CompileStoryboardCaptureGroup(filePath: filePath, filename: fileName, target: target)
         case .copyHeader:
             assert(results.count >= 3)

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -386,8 +386,9 @@ extension String {
             guard let source = results[safe: 0] else { return EmptyCaptureGroup() }
             return PackageUpdatingCaptureGroup(source: source)
         case .packageCheckingOut:
-            assert(results.count >= 0)
-            return PackageCheckingOutCaptureGroup()
+            assert(results.count >= 2)
+            guard let version = results[safe: 0], let package = results[safe: 1] else { return EmptyCaptureGroup() }
+            return PackageCheckingOutCaptureGroup(version: version, package: package)
         case .packageGraphResolvingStart:
             assert(results.count >= 0)
             return PackageGraphResolvingStartCaptureGroup()

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -56,8 +56,8 @@ extension String {
         switch pattern {
         case .analyze:
             assert(results.count >= 2)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
-            return AnalyzeCaptureGroup(filePath: filePath, fileName: fileName)
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            return AnalyzeCaptureGroup(filePath: filePath, fileName: fileName, target: target)
         case .buildTarget:
             assert(results.count >= 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -378,8 +378,9 @@ extension String {
             guard let target = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
             return UndefinedSymbolLocationCaptureGroup(target: target, filename: fileName)
         case .packageFetching:
-            assert(results.count >= 0)
-            return PackageFetchingCaptureGroup()
+            assert(results.count >= 1)
+            guard let source = results[safe: 0] else { return EmptyCaptureGroup() }
+            return PackageFetchingCaptureGroup(source: source)
         case .packageUpdating:
             assert(results.count >= 0)
             return PackageUpdatingCaptureGroup()

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -333,8 +333,8 @@ extension String {
             return FatalErrorCaptureGroup(wholeError: wholeError)
         case .fileMissingError:
             assert(results.count >= 2)
-            guard let wholeError = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
-            return FileMissingErrorCaptureGroup(wholeError: wholeError, filePath: filePath)
+            guard let reason = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
+            return FileMissingErrorCaptureGroup(reason: reason, filePath: filePath)
         case .ldError:
             assert(results.count >= 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -27,3 +27,283 @@ extension String {
         return results
     }
 }
+
+extension String {
+    func capturedGroups(with pattern: Pattern) -> CaptureGroup {
+        var regex: NSRegularExpression
+        do {
+            regex = try NSRegularExpression(pattern: pattern.rawValue, options: [.caseInsensitive])
+        } catch {
+            return EmptyCaptureGroup()
+        }
+
+        let matches = regex.matches(in: self, range: NSRange(location:0, length: self.utf16.count))
+
+        guard let match = matches.first else { return EmptyCaptureGroup() }
+
+        let lastRangeIndex = match.numberOfRanges - 1
+        guard lastRangeIndex >= 1 else { return EmptyCaptureGroup() }
+
+        var results = [String]()
+
+        for i in 1...lastRangeIndex {
+            let capturedGroupIndex = match.range(at: i)
+            guard let matchedString = substring(with: capturedGroupIndex) else { continue }
+            results.append(matchedString)
+        }
+
+        switch pattern {
+        case .analyze:
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
+            return AnalyzeCaptureGroup(filePath: filePath, fileName: fileName)
+        case .buildTarget:
+            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
+            return BuildTargetCaptureGroup(target: target, project: project, configuration: configuration)
+        case .aggregateTarget:
+            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
+            return AggregateTargetCaptureGroup(target: target, project: project, configuration: configuration)
+        case .analyzeTarget:
+            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
+            return AnalyzeTargetCaptureGroup(target: target, project: project, configuration: configuration)
+        case .checkDependencies:
+            return CheckDependenciesCaptureGroup()
+        case .shellCommand:
+            guard let commandPath = results[safe: 0], let arguments = results[safe: 1] else { return EmptyCaptureGroup() }
+            return ShellCommandCaptureGroup(commandPath: commandPath, arguments: arguments)
+        case .cleanRemove:
+            return CleanRemoveCaptureGroup()
+        case .cleanTarget:
+            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
+            return CleanTargetCaptureGroup(target: target, project: project, configuration: configuration)
+        case .codesign:
+            guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
+            return CodesignCaptureGroup(file: file)
+        case .codesignFramework:
+            guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
+            return CodesignFrameworkCaptureGroup(file: file)
+#if os(Linux)
+        case .compile:
+            guard let fileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            return CompileCaptureGroup(filename: fileName, target: target)
+#else
+        case .compile:
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
+            return CompileCaptureGroup(filePath: filePath, filename: fileName, target: target)
+#endif
+        case .compileCommand:
+            guard let compilerCommand = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
+            return CompileCommandCaptureGroup(compilerCommand: compilerCommand, filePath: filePath)
+        case .compileXib:
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
+            return CompileXibCaptureGroup(filePath: filePath, filename: fileName, target: target)
+        case .compileStoryboard:
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
+            return CompileStoryboardCaptureGroup(filePath: filePath, filename: fileName, target: target)
+        case .copyHeader:
+            guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
+            return CopyHeaderCaptureGroup(sourceFile: sourceFile, targetFile: targetFile, target: target)
+        case .copyPlist:
+            guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1] else { return EmptyCaptureGroup() }
+            return CopyPlistCaptureGroup(sourceFile: sourceFile, targetFile: targetFile)
+        case .copyStrings:
+            guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
+            return CopyStringsCaptureGroup(file: file)
+        case .cpresource:
+            guard let resource = results[safe: 0] else { return EmptyCaptureGroup() }
+            return CpresourceCaptureGroup(resource: resource)
+        case .executed:
+            guard let numberOfTests = results[safe: 0], let numberOfFailures = results[safe: 1], let numberOfUnexpectedFailures = results[safe: 2], let wallClockTimeInSeconds = results[safe: 3] else { return EmptyCaptureGroup() }
+            return ExecutedCaptureGroup(numberOfTests: numberOfTests, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
+        case .executedWithSkipped:
+            guard let numberOfTests = results[safe: 0], let numberOfSkipped = results[safe: 1], let numberOfFailures = results[safe: 2], let numberOfUnexpectedFailures = results[safe: 3], let wallClockTimeInSeconds = results[safe: 4] else { return EmptyCaptureGroup() }
+            return ExecutedWithSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfSkipped: numberOfSkipped, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
+        case .failingTest:
+            guard let file = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2], let reason = results[safe: 3] else { return EmptyCaptureGroup() }
+            return FailingTestCaptureGroup(file: file, testSuite: testSuite, testCase: testCase, reason: reason)
+        case .uiFailingTest:
+            guard let file = results[safe: 0], let reason = results[safe: 1] else { return EmptyCaptureGroup() }
+            return UIFailingTestCaptureGroup(file: file, reason: reason)
+        case .restartingTest:
+            guard let testSuiteAndTestCase = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2] else { return EmptyCaptureGroup() }
+            return RestartingTestCaptureGroup(testSuiteAndTestCase: testSuiteAndTestCase, testSuite: testSuite, testCase: testCase)
+        case .generateCoverageData:
+            return GenerateCoverageDataCaptureGroup()
+        case .generatedCoverageReport:
+            guard let coverageReportFilePath = results[safe: 0] else { return EmptyCaptureGroup() }
+            return GeneratedCoverageReportCaptureGroup(coverageReportFilePath: coverageReportFilePath)
+        case .generateDsym:
+            guard let dsym = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            return GenerateDSYMCaptureGroup(dsym: dsym, target: target)
+        case .libtool:
+            guard let library = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            return LibtoolCaptureGroup(library: library, target: target)
+#if os(Linux)
+        case .linking:
+            guard let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            return LinkingCaptureGroup(target: target)
+#else
+        case .linking:
+            guard let binaryFileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            return LinkingCaptureGroup(binaryFilename: binaryFileName, target: target)
+#endif
+        case .testCasePassed:
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
+            return TestCasePassedCaptureGroup(suite: suite, testCase: testCase, time: time)
+        case .testCaseStarted:
+            guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
+            return TestCaseStartedCaptureGroup(suite: suite, testCase: testCase)
+        case .testCasePending:
+            guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
+            return TestCasePendingCaptureGroup(suite: suite, testCase: testCase)
+        case .testCaseMeasured:
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
+            return TestCaseMeasuredCaptureGroup(suite: suite, testCase: testCase, time: time)
+        case .parallelTestCasePassed:
+            guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
+            return ParallelTestingPassedCaptureGroup(device: device)
+        case .parallelTestCaseAppKitPassed:
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
+            return ParallelTestCaseAppKitPassedCaptureGroup(suite: suite, testCase: testCase, time: time)
+        case .parallelTestCaseFailed:
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let installedAppFileAndID = results[safe: 2], let time = results[safe: 2] else { return EmptyCaptureGroup() }
+            return ParallelTestCaseFailedCaptureGroup(suite: suite, testCase: testCase, installedAppFileAndID: installedAppFileAndID, time: time)
+        case .parallelTestingStarted:
+            guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
+            return ParallelTestingStartedCaptureGroup(device: device)
+        case .parallelTestingPassed:
+            guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
+            return ParallelTestingPassedCaptureGroup(device: device)
+        case .parallelTestingFailed:
+            guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
+            return ParallelTestingFailedCaptureGroup(device: device)
+        case .parallelTestSuiteStarted:
+            guard let suite = results[safe: 0], let device = results[safe: 1] else { return EmptyCaptureGroup() }
+            return ParallelTestSuiteStartedCaptureGroup(suite: suite, device: device)
+        case .phaseSuccess:
+            return PhaseSuccessCaptureGroup()
+        case .phaseScriptExecution:
+            guard let phaseName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            return PhaseScriptExecutionCaptureGroup(phaseName: phaseName, target: target)
+        case .processPch:
+            guard let file = results[safe: 0], let buildTarget = results[safe: 1] else { return EmptyCaptureGroup() }
+            return ProcessPchCaptureGroup(file: file, buildTarget: buildTarget)
+        case .processPchCommand:
+            guard let filePath = results[safe: 0] else { return EmptyCaptureGroup() }
+            return ProcessPchCommandCaptureGroup(filePath: filePath)
+        case .preprocess:
+            guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
+            return PreprocessCaptureGroup(file: file)
+        case .pbxcp:
+            guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1], let buildTarget = results[safe: 2] else { return EmptyCaptureGroup() }
+            return PbxcpCaptureGroup(sourceFile: sourceFile, targetFile: targetFile, buildTarget: buildTarget)
+        case .processInfoPlist:
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
+            return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: target)
+        case .testsRunCompletion:
+            guard let suite = results[safe: 0], let result = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
+            return TestsRunCompletionCaptureGroup(suite: suite, result: result, time: time)
+        case .testSuiteStarted:
+            guard let suite = results[safe: 0], let time = results[safe: 1] else { return EmptyCaptureGroup() }
+            return TestSuiteStartedCaptureGroup(suite: suite, time: time)
+        case .testSuiteStart:
+            guard let testSuiteName = results[safe: 0] else { return EmptyCaptureGroup() }
+            return TestSuiteStartCaptureGroup(testSuiteName: testSuiteName)
+        case .testSuiteAllTestsPassed:
+            return TestSuiteAllTestsPassedCaptureGroup()
+        case .testSuiteAllTestsFailed:
+            return TestSuiteAllTestsFailedCaptureGroup()
+        case .tiffutil:
+            guard let fileName = results[safe: 0] else { return EmptyCaptureGroup() }
+            return TIFFutilCaptureGroup(filename: fileName)
+        case .touch:
+            guard let fileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            return TouchCaptureGroup(filename: fileName, target: target)
+        case .writeFile:
+            guard let filePath = results[safe: 0] else { return EmptyCaptureGroup() }
+            return WriteFileCaptureGroup(filePath: filePath)
+        case .writeAuxiliaryFiles:
+            return WriteAuxiliaryFilesCaptureGroup()
+        case .compileWarning:
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let reason = results[safe: 2] else { return EmptyCaptureGroup() }
+            return CompileWarningCaptureGroup(filePath: filePath, filename: fileName, reason: reason)
+        case .ldWarning:
+            guard let ldPrefix = results[safe: 0], let warningMessage = results[safe: 1]  else { return EmptyCaptureGroup() }
+            return LDWarningCaptureGroup(ldPrefix: ldPrefix, warningMessage: warningMessage)
+        case .genericWarning:
+            guard let wholeWarning = results[safe: 0] else { return EmptyCaptureGroup() }
+            return GenericWarningCaptureGroup(wholeWarning: wholeWarning)
+        case .willNotBeCodeSigned:
+            guard let wholeWarning = results[safe: 0] else { return EmptyCaptureGroup() }
+            return WillNotBeCodeSignedCaptureGroup(wholeWarning: wholeWarning)
+        case .duplicateLocalizedStringKey:
+            guard let wholeMessage = results[safe: 0] else { return EmptyCaptureGroup() }
+            return DuplicateLocalizedStringKeyCaptureGroup(warningMessage: wholeMessage)
+        case .clangError:
+            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            return ClangErrorCaptureGroup(wholeError: wholeError)
+        case .checkDependenciesErrors:
+            return CheckDependenciesCaptureGroup()
+        case .provisioningProfileRequired:
+            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            return ProvisioningProfileRequiredCaptureGroup(wholeError: wholeError)
+        case .noCertificate:
+            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            return NoCertificateCaptureGroup(wholeError: wholeError)
+        case .compileError:
+            guard let filePath = results[safe: 0], let isFatalError = results[safe: 1], let reason = results[safe: 2] else { return EmptyCaptureGroup() }
+            return CompileErrorCaptureGroup(filePath: filePath, isFatalError: isFatalError, reason: reason)
+        case .cursor:
+            guard let cursor = results[safe: 0] else { return EmptyCaptureGroup() }
+            return CursorCaptureGroup(cursor: cursor)
+        case .fatalError:
+            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            return FatalErrorCaptureGroup(wholeError: wholeError)
+        case .fileMissingError:
+            guard let wholeError = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
+            return FileMissingErrorCaptureGroup(wholeError: wholeError, filePath: filePath)
+        case .ldError:
+            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            return LDErrorCaptureGroup(wholeError: wholeError)
+        case .linkerDuplicateSymbolsLocation:
+            guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
+            return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
+        case .linkerDuplicateSymbols:
+            guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
+            return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
+        case .linkerUndefinedSymbolLocation:
+            guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
+            return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
+        case .linkerUndefinedSymbols:
+            guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
+            return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
+        case .podsError:
+            guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
+            return PodsErrorCaptureGroup(reason: reason)
+        case .symbolReferencedFrom:
+            guard let reference = results[safe: 0] else { return EmptyCaptureGroup() }
+            return SymbolReferencedFromCaptureGroup(reference: reference)
+        case .moduleIncludesError:
+            guard let errorReason = results[safe: 0] else { return EmptyCaptureGroup() }
+            return ModuleIncludesErrorCaptureGroup(errorReason: errorReason)
+        case .undefinedSymbolLocation:
+            guard let target = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
+            return UndefinedSymbolLocationCaptureGroup(target: target, filename: fileName)
+        case .packageFetching:
+            return PackageFetchingCaptureGroup()
+        case .packageUpdating:
+            return PackageUpdatingCaptureGroup()
+        case .packageCheckingOut:
+            return PackageCheckingOutCaptureGroup()
+        case .packageGraphResolvingStart:
+            return PackageGraphResolvingStartCaptureGroup()
+        case .packageGraphResolvingEnded:
+            return PackageGraphResolvingEndedCaptureGroup()
+        case .packageGraphResolvedItem:
+            guard let packageName = results[safe: 0], let packageURL = results[safe: 1], let packageVersion = results[safe: 2] else { return EmptyCaptureGroup() }
+            return PackageGraphResolvedItemCaptureGroup(packageName: packageName, packageURL: packageURL, packageVersion: packageVersion)
+        case .xcodebuildError:
+            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            return XcodebuildErrorCaptureGroup(wholeError: wholeError)
+        }
+    }
+}

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -54,254 +54,340 @@ extension String {
 
         switch pattern {
         case .analyze:
+            assert(results.count == 2)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
             return AnalyzeCaptureGroup(filePath: filePath, fileName: fileName)
         case .buildTarget:
+            assert(results.count == 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return BuildTargetCaptureGroup(target: target, project: project, configuration: configuration)
         case .aggregateTarget:
+            assert(results.count == 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return AggregateTargetCaptureGroup(target: target, project: project, configuration: configuration)
         case .analyzeTarget:
+            assert(results.count == 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return AnalyzeTargetCaptureGroup(target: target, project: project, configuration: configuration)
         case .checkDependencies:
+            assert(results.count == 0)
             return CheckDependenciesCaptureGroup()
         case .shellCommand:
+            assert(results.count == 2)
             guard let commandPath = results[safe: 0], let arguments = results[safe: 1] else { return EmptyCaptureGroup() }
             return ShellCommandCaptureGroup(commandPath: commandPath, arguments: arguments)
         case .cleanRemove:
+            assert(results.count == 0)
             return CleanRemoveCaptureGroup()
         case .cleanTarget:
+            assert(results.count == 3)
             guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
             return CleanTargetCaptureGroup(target: target, project: project, configuration: configuration)
         case .codesign:
+            assert(results.count == 1)
             guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
             return CodesignCaptureGroup(file: file)
         case .codesignFramework:
+            assert(results.count == 1)
             guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
             return CodesignFrameworkCaptureGroup(file: file)
 #if os(Linux)
         case .compile:
+            assert(results.count == 2)
             guard let fileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return CompileCaptureGroup(filename: fileName, target: target)
 #else
         case .compile:
+            assert(results.count == 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileCaptureGroup(filePath: filePath, filename: fileName, target: target)
 #endif
         case .compileCommand:
+            assert(results.count == 2)
             guard let compilerCommand = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
             return CompileCommandCaptureGroup(compilerCommand: compilerCommand, filePath: filePath)
         case .compileXib:
+            assert(results.count == 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileXibCaptureGroup(filePath: filePath, filename: fileName, target: target)
         case .compileStoryboard:
+            assert(results.count == 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileStoryboardCaptureGroup(filePath: filePath, filename: fileName, target: target)
         case .copyHeader:
+            assert(results.count == 3)
             guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
             return CopyHeaderCaptureGroup(sourceFile: sourceFile, targetFile: targetFile, target: target)
         case .copyPlist:
+            assert(results.count == 2)
             guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1] else { return EmptyCaptureGroup() }
             return CopyPlistCaptureGroup(sourceFile: sourceFile, targetFile: targetFile)
         case .copyStrings:
+            assert(results.count == 1)
             guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
             return CopyStringsCaptureGroup(file: file)
         case .cpresource:
+            assert(results.count == 1)
             guard let resource = results[safe: 0] else { return EmptyCaptureGroup() }
             return CpresourceCaptureGroup(resource: resource)
         case .executed:
+            assert(results.count == 4)
             guard let numberOfTests = results[safe: 0], let numberOfFailures = results[safe: 1], let numberOfUnexpectedFailures = results[safe: 2], let wallClockTimeInSeconds = results[safe: 3] else { return EmptyCaptureGroup() }
             return ExecutedCaptureGroup(numberOfTests: numberOfTests, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
         case .executedWithSkipped:
+            assert(results.count == 5)
             guard let numberOfTests = results[safe: 0], let numberOfSkipped = results[safe: 1], let numberOfFailures = results[safe: 2], let numberOfUnexpectedFailures = results[safe: 3], let wallClockTimeInSeconds = results[safe: 4] else { return EmptyCaptureGroup() }
             return ExecutedWithSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfSkipped: numberOfSkipped, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
         case .failingTest:
+            assert(results.count == 4)
             guard let file = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2], let reason = results[safe: 3] else { return EmptyCaptureGroup() }
             return FailingTestCaptureGroup(file: file, testSuite: testSuite, testCase: testCase, reason: reason)
         case .uiFailingTest:
+            assert(results.count == 2)
             guard let file = results[safe: 0], let reason = results[safe: 1] else { return EmptyCaptureGroup() }
             return UIFailingTestCaptureGroup(file: file, reason: reason)
         case .restartingTest:
+            assert(results.count == 3)
             guard let testSuiteAndTestCase = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2] else { return EmptyCaptureGroup() }
             return RestartingTestCaptureGroup(testSuiteAndTestCase: testSuiteAndTestCase, testSuite: testSuite, testCase: testCase)
         case .generateCoverageData:
+            assert(results.count == 0)
             return GenerateCoverageDataCaptureGroup()
         case .generatedCoverageReport:
+            assert(results.count == 1)
             guard let coverageReportFilePath = results[safe: 0] else { return EmptyCaptureGroup() }
             return GeneratedCoverageReportCaptureGroup(coverageReportFilePath: coverageReportFilePath)
         case .generateDsym:
+            assert(results.count == 2)
             guard let dsym = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return GenerateDSYMCaptureGroup(dsym: dsym, target: target)
         case .libtool:
+            assert(results.count == 2)
             guard let library = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return LibtoolCaptureGroup(library: library, target: target)
 #if os(Linux)
         case .linking:
-            guard let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            assert(results.count == 1)
+            guard let target = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkingCaptureGroup(target: target)
 #else
         case .linking:
+            assert(results.count == 2)
             guard let binaryFileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return LinkingCaptureGroup(binaryFilename: binaryFileName, target: target)
 #endif
         case .testCasePassed:
+            assert(results.count == 3)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return TestCasePassedCaptureGroup(suite: suite, testCase: testCase, time: time)
         case .testCaseStarted:
+            assert(results.count == 2)
             guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
             return TestCaseStartedCaptureGroup(suite: suite, testCase: testCase)
         case .testCasePending:
+            assert(results.count == 2)
             guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
             return TestCasePendingCaptureGroup(suite: suite, testCase: testCase)
         case .testCaseMeasured:
+            assert(results.count == 3)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return TestCaseMeasuredCaptureGroup(suite: suite, testCase: testCase, time: time)
         case .parallelTestCasePassed:
+            assert(results.count == 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingPassedCaptureGroup(device: device)
         case .parallelTestCaseAppKitPassed:
+            assert(results.count == 3)
             guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return ParallelTestCaseAppKitPassedCaptureGroup(suite: suite, testCase: testCase, time: time)
         case .parallelTestCaseFailed:
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let installedAppFileAndID = results[safe: 2], let time = results[safe: 2] else { return EmptyCaptureGroup() }
+            assert(results.count == 4)
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let installedAppFileAndID = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
             return ParallelTestCaseFailedCaptureGroup(suite: suite, testCase: testCase, installedAppFileAndID: installedAppFileAndID, time: time)
         case .parallelTestingStarted:
+            assert(results.count == 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingStartedCaptureGroup(device: device)
         case .parallelTestingPassed:
+            assert(results.count == 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingPassedCaptureGroup(device: device)
         case .parallelTestingFailed:
+            assert(results.count == 1)
             guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
             return ParallelTestingFailedCaptureGroup(device: device)
         case .parallelTestSuiteStarted:
+            assert(results.count == 2)
             guard let suite = results[safe: 0], let device = results[safe: 1] else { return EmptyCaptureGroup() }
             return ParallelTestSuiteStartedCaptureGroup(suite: suite, device: device)
         case .phaseSuccess:
+            assert(results.count == 0)
             return PhaseSuccessCaptureGroup()
         case .phaseScriptExecution:
+            assert(results.count == 2)
             guard let phaseName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return PhaseScriptExecutionCaptureGroup(phaseName: phaseName, target: target)
         case .processPch:
+            assert(results.count == 2)
             guard let file = results[safe: 0], let buildTarget = results[safe: 1] else { return EmptyCaptureGroup() }
             return ProcessPchCaptureGroup(file: file, buildTarget: buildTarget)
         case .processPchCommand:
+            assert(results.count == 1)
             guard let filePath = results[safe: 0] else { return EmptyCaptureGroup() }
             return ProcessPchCommandCaptureGroup(filePath: filePath)
         case .preprocess:
+            assert(results.count == 1)
             guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
             return PreprocessCaptureGroup(file: file)
         case .pbxcp:
+            assert(results.count == 3)
             guard let sourceFile = results[safe: 0], let targetFile = results[safe: 1], let buildTarget = results[safe: 2] else { return EmptyCaptureGroup() }
             return PbxcpCaptureGroup(sourceFile: sourceFile, targetFile: targetFile, buildTarget: buildTarget)
         case .processInfoPlist:
+            assert(results.count == 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results[safe: 2] else { return EmptyCaptureGroup() }
             return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: target)
         case .testsRunCompletion:
+            assert(results.count == 3)
             guard let suite = results[safe: 0], let result = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
             return TestsRunCompletionCaptureGroup(suite: suite, result: result, time: time)
         case .testSuiteStarted:
+            assert(results.count == 2)
             guard let suite = results[safe: 0], let time = results[safe: 1] else { return EmptyCaptureGroup() }
             return TestSuiteStartedCaptureGroup(suite: suite, time: time)
         case .testSuiteStart:
+            assert(results.count == 1)
             guard let testSuiteName = results[safe: 0] else { return EmptyCaptureGroup() }
             return TestSuiteStartCaptureGroup(testSuiteName: testSuiteName)
         case .testSuiteAllTestsPassed:
+            assert(results.count == 0)
             return TestSuiteAllTestsPassedCaptureGroup()
         case .testSuiteAllTestsFailed:
+            assert(results.count == 0)
             return TestSuiteAllTestsFailedCaptureGroup()
         case .tiffutil:
+            assert(results.count == 1)
             guard let fileName = results[safe: 0] else { return EmptyCaptureGroup() }
             return TIFFutilCaptureGroup(filename: fileName)
         case .touch:
+            assert(results.count == 2)
             guard let fileName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
             return TouchCaptureGroup(filename: fileName, target: target)
         case .writeFile:
+            assert(results.count == 1)
             guard let filePath = results[safe: 0] else { return EmptyCaptureGroup() }
             return WriteFileCaptureGroup(filePath: filePath)
         case .writeAuxiliaryFiles:
+            assert(results.count == 0)
             return WriteAuxiliaryFilesCaptureGroup()
         case .compileWarning:
+            assert(results.count == 3)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1], let reason = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileWarningCaptureGroup(filePath: filePath, filename: fileName, reason: reason)
         case .ldWarning:
-            guard let ldPrefix = results[safe: 0], let warningMessage = results[safe: 1]  else { return EmptyCaptureGroup() }
+            assert(results.count == 2)
+            guard let ldPrefix = results[safe: 0], let warningMessage = results[safe: 1] else { return EmptyCaptureGroup() }
             return LDWarningCaptureGroup(ldPrefix: ldPrefix, warningMessage: warningMessage)
         case .genericWarning:
+            assert(results.count == 1)
             guard let wholeWarning = results[safe: 0] else { return EmptyCaptureGroup() }
             return GenericWarningCaptureGroup(wholeWarning: wholeWarning)
         case .willNotBeCodeSigned:
+            assert(results.count == 1)
             guard let wholeWarning = results[safe: 0] else { return EmptyCaptureGroup() }
             return WillNotBeCodeSignedCaptureGroup(wholeWarning: wholeWarning)
         case .duplicateLocalizedStringKey:
+            assert(results.count == 1)
             guard let wholeMessage = results[safe: 0] else { return EmptyCaptureGroup() }
             return DuplicateLocalizedStringKeyCaptureGroup(warningMessage: wholeMessage)
         case .clangError:
+            assert(results.count == 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return ClangErrorCaptureGroup(wholeError: wholeError)
         case .checkDependenciesErrors:
+            assert(results.count == 0)
             return CheckDependenciesCaptureGroup()
         case .provisioningProfileRequired:
+            assert(results.count == 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return ProvisioningProfileRequiredCaptureGroup(wholeError: wholeError)
         case .noCertificate:
+            assert(results.count == 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return NoCertificateCaptureGroup(wholeError: wholeError)
         case .compileError:
+            assert(results.count == 3)
             guard let filePath = results[safe: 0], let isFatalError = results[safe: 1], let reason = results[safe: 2] else { return EmptyCaptureGroup() }
             return CompileErrorCaptureGroup(filePath: filePath, isFatalError: isFatalError, reason: reason)
         case .cursor:
+            assert(results.count == 1)
             guard let cursor = results[safe: 0] else { return EmptyCaptureGroup() }
             return CursorCaptureGroup(cursor: cursor)
         case .fatalError:
+            assert(results.count == 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return FatalErrorCaptureGroup(wholeError: wholeError)
         case .fileMissingError:
+            assert(results.count == 2)
             guard let wholeError = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
             return FileMissingErrorCaptureGroup(wholeError: wholeError, filePath: filePath)
         case .ldError:
+            assert(results.count == 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return LDErrorCaptureGroup(wholeError: wholeError)
         case .linkerDuplicateSymbolsLocation:
+            assert(results.count == 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
         case .linkerDuplicateSymbols:
+            assert(results.count == 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
         case .linkerUndefinedSymbolLocation:
+            assert(results.count == 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
         case .linkerUndefinedSymbols:
+            assert(results.count == 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
         case .podsError:
+            assert(results.count == 1)
             guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
             return PodsErrorCaptureGroup(reason: reason)
         case .symbolReferencedFrom:
+            assert(results.count == 1)
             guard let reference = results[safe: 0] else { return EmptyCaptureGroup() }
             return SymbolReferencedFromCaptureGroup(reference: reference)
         case .moduleIncludesError:
+            assert(results.count == 1)
             guard let errorReason = results[safe: 0] else { return EmptyCaptureGroup() }
             return ModuleIncludesErrorCaptureGroup(errorReason: errorReason)
         case .undefinedSymbolLocation:
+            assert(results.count == 2)
             guard let target = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
             return UndefinedSymbolLocationCaptureGroup(target: target, filename: fileName)
         case .packageFetching:
+            assert(results.count == 0)
             return PackageFetchingCaptureGroup()
         case .packageUpdating:
+            assert(results.count == 0)
             return PackageUpdatingCaptureGroup()
         case .packageCheckingOut:
+            assert(results.count == 0)
             return PackageCheckingOutCaptureGroup()
         case .packageGraphResolvingStart:
+            assert(results.count == 0)
             return PackageGraphResolvingStartCaptureGroup()
         case .packageGraphResolvingEnded:
+            assert(results.count == 0)
             return PackageGraphResolvingEndedCaptureGroup()
         case .packageGraphResolvedItem:
+            assert(results.count == 3)
             guard let packageName = results[safe: 0], let packageURL = results[safe: 1], let packageVersion = results[safe: 2] else { return EmptyCaptureGroup() }
             return PackageGraphResolvedItemCaptureGroup(packageName: packageName, packageURL: packageURL, packageVersion: packageVersion)
         case .xcodebuildError:
+            assert(results.count == 1)
             guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
             return XcodebuildErrorCaptureGroup(wholeError: wholeError)
         }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -227,7 +227,7 @@ extension String {
             return PhaseSuccessCaptureGroup()
         case .phaseScriptExecution:
             assert(results.count >= 2)
-            guard let phaseName = results[safe: 0], let target = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let phaseName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return PhaseScriptExecutionCaptureGroup(phaseName: phaseName, target: target)
         case .processPch:
             assert(results.count >= 2)

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -90,8 +90,8 @@ extension String {
             return CodesignCaptureGroup(file: file)
         case .codesignFramework:
             assert(results.count >= 1)
-            guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
-            return CodesignFrameworkCaptureGroup(file: file)
+            guard let frameworkPath = results[safe: 0] else { return EmptyCaptureGroup() }
+            return CodesignFrameworkCaptureGroup(frameworkPath: frameworkPath)
 #if os(Linux)
         case .compile:
             assert(results.count >= 2)

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -235,7 +235,7 @@ extension String {
             return ProcessPchCaptureGroup(file: file, buildTarget: buildTarget)
         case .processPchCommand:
             assert(results.count >= 1)
-            guard let filePath = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let filePath = results.last else { return EmptyCaptureGroup() }
             return ProcessPchCommandCaptureGroup(filePath: filePath)
         case .preprocess:
             assert(results.count >= 1)

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -248,9 +248,15 @@ extension String {
         case .processInfoPlist:
             assert(results.count >= 2)
             guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
-            // Xcode 10+ includes target output
+
             // TODO: Test with target included
-            return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: results.last)
+            if results.count == 2 {
+                // Xcode 9 excludes target output
+                return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: nil)
+            } else {
+                // Xcode 10+ includes target output
+                return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: results.last)
+            }
         case .testsRunCompletion:
             assert(results.count >= 3)
             guard let suite = results[safe: 0], let result = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -231,7 +231,7 @@ extension String {
             return PhaseScriptExecutionCaptureGroup(phaseName: phaseName, target: target)
         case .processPch:
             assert(results.count >= 2)
-            guard let file = results[safe: 0], let buildTarget = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0], let buildTarget = results.last else { return EmptyCaptureGroup() }
             return ProcessPchCaptureGroup(file: file, buildTarget: buildTarget)
         case .processPchCommand:
             assert(results.count >= 1)


### PR DESCRIPTION
This introduces a `CaptureGroup` protocol and the respective concrete types. By introducing this logic, we'll avoid unsafe array indexing; we'll also extract parsing logic, avoiding duplication when introducing different output renderers (the proposed approach in #107).

Introduces an `EmptyCaptureGroup` concrete type and `assert` statements to handle and catch unexpected cases and failures.