### PR TITLE
Capture Group Refactor: Part 2

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -22,6 +22,14 @@ protocol CopyCaptureGroup: CaptureGroup {
     var target: String { get }
 }
 
+protocol ExecutedCaptureGroup: CaptureGroup {
+    var numberOfTests: String { get }
+    var numberOfSkipped: String { get }
+    var numberOfFailures: String { get }
+    var numberOfUnexpectedFailures: String { get }
+    var wallClockTimeInSeconds: String { get }
+}
+
 struct EmptyCaptureGroup: CaptureGroup { }
 
 struct AnalyzeCaptureGroup: CaptureGroup {
@@ -120,14 +128,15 @@ struct CpresourceCaptureGroup: CopyCaptureGroup {
     let target: String
 }
 
-struct ExecutedCaptureGroup: CaptureGroup {
+struct ExecutedWithoutSkippedCaptureGroup: ExecutedCaptureGroup {
     let numberOfTests: String
+    let numberOfSkipped = ""
     let numberOfFailures: String
     let numberOfUnexpectedFailures: String
     let wallClockTimeInSeconds: String
 }
 
-struct ExecutedWithSkippedCaptureGroup: CaptureGroup {
+struct ExecutedWithSkippedCaptureGroup: ExecutedCaptureGroup {
     let numberOfTests: String
     let numberOfSkipped: String
     let numberOfFailures: String

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -23,11 +23,11 @@ protocol CopyCaptureGroup: CaptureGroup {
 }
 
 protocol ExecutedCaptureGroup: CaptureGroup {
-    var numberOfTests: String { get }
-    var numberOfSkipped: String { get }
-    var numberOfFailures: String { get }
-    var numberOfUnexpectedFailures: String { get }
-    var wallClockTimeInSeconds: String { get }
+    var numberOfTests: Int { get }
+    var numberOfSkipped: Int { get }
+    var numberOfFailures: Int { get }
+    var numberOfUnexpectedFailures: Int { get }
+    var wallClockTimeInSeconds: Double { get }
 }
 
 struct EmptyCaptureGroup: CaptureGroup { }
@@ -129,19 +129,19 @@ struct CpresourceCaptureGroup: CopyCaptureGroup {
 }
 
 struct ExecutedWithoutSkippedCaptureGroup: ExecutedCaptureGroup {
-    let numberOfTests: String
-    let numberOfSkipped = ""
-    let numberOfFailures: String
-    let numberOfUnexpectedFailures: String
-    let wallClockTimeInSeconds: String
+    let numberOfTests: Int
+    let numberOfSkipped = 0
+    let numberOfFailures: Int
+    let numberOfUnexpectedFailures: Int
+    let wallClockTimeInSeconds: Double
 }
 
 struct ExecutedWithSkippedCaptureGroup: ExecutedCaptureGroup {
-    let numberOfTests: String
-    let numberOfSkipped: String
-    let numberOfFailures: String
-    let numberOfUnexpectedFailures: String
-    let wallClockTimeInSeconds: String
+    let numberOfTests: Int
+    let numberOfSkipped: Int
+    let numberOfFailures: Int
+    let numberOfUnexpectedFailures: Int
+    let wallClockTimeInSeconds: Double
 }
 
 struct FailingTestCaptureGroup: CaptureGroup {

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -21,25 +21,31 @@ public final class JunitReporter {
         switch line {
         // Capture standard output
         case Regex.failingTest:
-            components.append(.failingTest(generateFailingTest(line: line)))
+            guard let testCase = generateFailingTest(line: line) else { break }
+            components.append(.failingTest(testCase))
         case Regex.restartingTest:
-            components.append(.failingTest(generateRestartingTest(line: line)))
+            guard let testCase = generateRestartingTest(line: line) else { break }
+            components.append(.failingTest(testCase))
         case Regex.testCasePassed:
-            components.append(.testCasePassed(generatePassingTest(line: line)))
+            guard let testCase = generatePassingTest(line: line) else { break }
+            components.append(.testCasePassed(testCase))
         case Regex.testSuiteStart:
-            components.append(.testSuiteStart(generateSuiteStart(line: line)))
+            guard let testStart = generateSuiteStart(line: line) else { break }
+            components.append(.testSuiteStart(testStart))
         // Capture parallel output
         case Regex.parallelTestCaseFailed:
-            parallelComponents.append(.failingTest(generateParallelFailingTest(line: line)))
+            guard let testCase = generateParallelFailingTest(line: line) else { break }
+            parallelComponents.append(.failingTest(testCase))
         case Regex.parallelTestCasePassed:
-            parallelComponents.append(.testCasePassed(generatePassingParallelTest(line: line)))
+            guard let testCase = generatePassingParallelTest(line: line) else { break }
+            parallelComponents.append(.testCasePassed(testCase))
         default:
             // Not needed for generating a junit report
             break
         }
     }
 
-    private func generateFailingTest(line: String) -> TestCase {
+    private func generateFailingTest(line: String) -> TestCase? {
         let group: [String] = line.captureGroup(with: .failingTest)
         return TestCase(
             classname: group[1],
@@ -49,7 +55,7 @@ public final class JunitReporter {
         )
     }
     
-    private func generateRestartingTest(line: String) -> TestCase {
+    private func generateRestartingTest(line: String) -> TestCase? {
         let group: [String] = line.captureGroup(with: .restartingTest)
         return TestCase(
             classname: group[1],
@@ -59,7 +65,7 @@ public final class JunitReporter {
         )
     }
 
-    private func generateParallelFailingTest(line: String) -> TestCase {
+    private func generateParallelFailingTest(line: String) -> TestCase? {
         // Parallel tests do not provide meaningful failure messages
         let group: [String] = line.captureGroup(with: .parallelTestCaseFailed)
         return TestCase(
@@ -70,17 +76,17 @@ public final class JunitReporter {
         )
     }
 
-    private func generatePassingTest(line: String) -> TestCase {
+    private func generatePassingTest(line: String) -> TestCase? {
         let group: [String] = line.captureGroup(with: .testCasePassed)
         return TestCase(classname: group[0], name: group[1], time: group[2], failure: nil)
     }
 
-    private func generatePassingParallelTest(line: String) -> TestCase {
+    private func generatePassingParallelTest(line: String) -> TestCase? {
         let group: [String] = line.captureGroup(with: .parallelTestCasePassed)
         return TestCase(classname: group[0], name: group[1], time: group[3], failure: nil)
     }
   
-    private func generateSuiteStart(line: String) -> String {
+    private func generateSuiteStart(line: String) -> String? {
         let group: [String] = line.captureGroup(with: .testSuiteStart)
         return group[0]
     }

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -39,9 +39,9 @@ public final class JunitReporter {
         }
     }
 
-    private func generateFailingTest(line: String) -> Testcase {
+    private func generateFailingTest(line: String) -> TestCase {
         let group: [String] = line.captureGroup(with: .failingTest)
-        return Testcase(
+        return TestCase(
             classname: group[1],
             name: group[2],
             time: nil,
@@ -49,9 +49,9 @@ public final class JunitReporter {
         )
     }
     
-    private func generateRestartingTest(line: String) -> Testcase {
+    private func generateRestartingTest(line: String) -> TestCase {
         let group: [String] = line.captureGroup(with: .restartingTest)
-        return Testcase(
+        return TestCase(
             classname: group[1],
             name: group[2],
             time: nil,
@@ -59,10 +59,10 @@ public final class JunitReporter {
         )
     }
 
-    private func generateParallelFailingTest(line: String) -> Testcase {
+    private func generateParallelFailingTest(line: String) -> TestCase {
         // Parallel tests do not provide meaningful failure messages
         let group: [String] = line.captureGroup(with: .parallelTestCaseFailed)
-        return Testcase(
+        return TestCase(
             classname: group[0],
             name: group[1],
             time: nil,
@@ -70,14 +70,14 @@ public final class JunitReporter {
         )
     }
 
-    private func generatePassingTest(line: String) -> Testcase {
+    private func generatePassingTest(line: String) -> TestCase {
         let group: [String] = line.captureGroup(with: .testCasePassed)
-        return Testcase(classname: group[0], name: group[1], time: group[2], failure: nil)
+        return TestCase(classname: group[0], name: group[1], time: group[2], failure: nil)
     }
 
-    private func generatePassingParallelTest(line: String) -> Testcase {
+    private func generatePassingParallelTest(line: String) -> TestCase {
         let group: [String] = line.captureGroup(with: .parallelTestCasePassed)
-        return Testcase(classname: group[0], name: group[1], time: group[3], failure: nil)
+        return TestCase(classname: group[0], name: group[1], time: group[3], failure: nil)
     }
   
     private func generateSuiteStart(line: String) -> String {
@@ -101,7 +101,7 @@ public final class JunitReporter {
 
 private final class JunitComponentParser {
     private var mainTestSuiteName: String?
-    private var testCases: [Testcase] = []
+    private var testCases: [TestCase] = []
 
     func parse(component: JunitComponent) {
         switch component {
@@ -139,8 +139,8 @@ private final class JunitComponentParser {
 
 private enum JunitComponent {
     case testSuiteStart(String)
-    case failingTest(Testcase)
-    case testCasePassed(Testcase)
+    case failingTest(TestCase)
+    case testCasePassed(TestCase)
 }
 
 private struct Testsuites: Encodable, DynamicNodeEncoding {
@@ -176,7 +176,7 @@ private struct Testsuites: Encodable, DynamicNodeEncoding {
 
 private struct Testsuite: Encodable, DynamicNodeEncoding {
     let name: String
-    var testcases: [Testcase]
+    var testcases: [TestCase]
 
     enum CodingKeys: String, CodingKey {
         case name
@@ -205,7 +205,7 @@ private struct Testsuite: Encodable, DynamicNodeEncoding {
     }
 }
 
-private struct Testcase: Codable, DynamicNodeEncoding {
+private struct TestCase: Codable, DynamicNodeEncoding {
     let classname: String
     let name: String
     let time: String?
@@ -223,7 +223,7 @@ private struct Testcase: Codable, DynamicNodeEncoding {
     }
 }
 
-private extension Testcase {
+private extension TestCase {
     struct Failure: Codable, DynamicNodeEncoding {
         let message: String
         

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -48,38 +48,20 @@ public final class JunitReporter {
     private func generateFailingTest(line: String) -> TestCase? {
         let group: CaptureGroup = line.captureGroup(with: .failingTest)
         guard let group = group as? FailingTestCaptureGroup else { return nil }
-
-        return TestCase(
-            classname: group.testSuite,
-            name: group.testCase,
-            time: nil,
-            failure: .init(message: "\(group.file) - \(group.reason)")
-        )
+        return TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: "\(group.file) - \(group.reason)"))
     }
     
     private func generateRestartingTest(line: String) -> TestCase? {
         let group: CaptureGroup = line.captureGroup(with: .restartingTest)
         guard let group = group as? RestartingTestCaptureGroup else { return nil }
-
-        return TestCase(
-            classname: group.testSuite,
-            name: group.testCase,
-            time: nil,
-            failure: .init(message: line)
-        )
+        return TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: line))
     }
 
     private func generateParallelFailingTest(line: String) -> TestCase? {
         // Parallel tests do not provide meaningful failure messages
         let group: CaptureGroup = line.captureGroup(with: .parallelTestCaseFailed)
         guard let group = group as? ParallelTestCaseFailedCaptureGroup else { return nil }
-
-        return TestCase(
-            classname: group.suite,
-            name: group.testCase,
-            time: nil,
-            failure: .init(message: "Parallel test failed")
-        )
+        return TestCase(classname: group.suite, name: group.testCase, time: nil, failure: .init(message: "Parallel test failed"))
     }
 
     private func generatePassingTest(line: String) -> TestCase? {

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -19,23 +19,23 @@ public final class JunitReporter {
         // Remove any preceding or excessive spaces
         let line = line.trimmingCharacters(in: .whitespacesAndNewlines)
         switch line {
-            // Capture standard output
-            case Regex.failingTest:
-                components.append(.failingTest(generateFailingTest(line: line)))
-            case Regex.restartingTest:
-                components.append(.failingTest(generateRestartingTest(line: line)))
-            case Regex.testCasePassed:
-                components.append(.testCasePassed(generatePassingTest(line: line)))
-            case Regex.testSuiteStart:
-                components.append(.testSuiteStart(generateSuiteStart(line: line)))
-            // Capture parallel output
-            case Regex.parallelTestCaseFailed:
-                parallelComponents.append(.failingTest(generateParallelFailingTest(line: line)))
-            case Regex.parallelTestCasePassed:
-                parallelComponents.append(.testCasePassed(generatePassingParallelTest(line: line)))
-            default:
-                // Not needed for generating a junit report
-                break
+        // Capture standard output
+        case Regex.failingTest:
+            components.append(.failingTest(generateFailingTest(line: line)))
+        case Regex.restartingTest:
+            components.append(.failingTest(generateRestartingTest(line: line)))
+        case Regex.testCasePassed:
+            components.append(.testCasePassed(generatePassingTest(line: line)))
+        case Regex.testSuiteStart:
+            components.append(.testSuiteStart(generateSuiteStart(line: line)))
+        // Capture parallel output
+        case Regex.parallelTestCaseFailed:
+            parallelComponents.append(.failingTest(generateParallelFailingTest(line: line)))
+        case Regex.parallelTestCasePassed:
+            parallelComponents.append(.testCasePassed(generatePassingParallelTest(line: line)))
+        default:
+            // Not needed for generating a junit report
+            break
         }
     }
 

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -46,39 +46,39 @@ public final class JunitReporter {
     }
 
     private func generateFailingTest(line: String) -> TestCase? {
-        let group: CaptureGroup = line.captureGroup(with: .failingTest)
-        guard let group = group as? FailingTestCaptureGroup else { return nil }
+        let _group: CaptureGroup = line.captureGroup(with: .failingTest)
+        guard let group = _group as? FailingTestCaptureGroup else { return nil }
         return TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: "\(group.file) - \(group.reason)"))
     }
     
     private func generateRestartingTest(line: String) -> TestCase? {
-        let group: CaptureGroup = line.captureGroup(with: .restartingTest)
-        guard let group = group as? RestartingTestCaptureGroup else { return nil }
+        let _group: CaptureGroup = line.captureGroup(with: .restartingTest)
+        guard let group = _group as? RestartingTestCaptureGroup else { return nil }
         return TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: line))
     }
 
     private func generateParallelFailingTest(line: String) -> TestCase? {
         // Parallel tests do not provide meaningful failure messages
-        let group: CaptureGroup = line.captureGroup(with: .parallelTestCaseFailed)
-        guard let group = group as? ParallelTestCaseFailedCaptureGroup else { return nil }
+        let _group: CaptureGroup = line.captureGroup(with: .parallelTestCaseFailed)
+        guard let group = _group as? ParallelTestCaseFailedCaptureGroup else { return nil }
         return TestCase(classname: group.suite, name: group.testCase, time: nil, failure: .init(message: "Parallel test failed"))
     }
 
     private func generatePassingTest(line: String) -> TestCase? {
-        let group: CaptureGroup = line.captureGroup(with: .testCasePassed)
-        guard let group = group as? TestCasePassedCaptureGroup else { return nil }
+        let _group: CaptureGroup = line.captureGroup(with: .testCasePassed)
+        guard let group = _group as? TestCasePassedCaptureGroup else { return nil }
         return TestCase(classname: group.suite, name: group.testCase, time: group.time, failure: nil)
     }
 
     private func generatePassingParallelTest(line: String) -> TestCase? {
-        let group: CaptureGroup = line.captureGroup(with: .parallelTestCasePassed)
-        guard let group = group as? ParallelTestCasePassedCaptureGroup else { return nil }
+        let _group: CaptureGroup = line.captureGroup(with: .parallelTestCasePassed)
+        guard let group = _group as? ParallelTestCasePassedCaptureGroup else { return nil }
         return TestCase(classname: group.suite, name: group.testCase, time: group.time, failure: nil)
     }
   
     private func generateSuiteStart(line: String) -> String? {
-        let group: CaptureGroup = line.captureGroup(with: .testSuiteStart)
-        guard let group = group as? TestSuiteStartCaptureGroup else { return nil }
+        let _group: CaptureGroup = line.captureGroup(with: .testSuiteStart)
+        guard let group = _group as? TestSuiteStartCaptureGroup else { return nil }
         return group.testSuiteName
     }
     

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -158,8 +158,8 @@ public class Parser {
         guard needToRecordSummary else { return }
         defer { needToRecordSummary = false }
 
-        let group: CaptureGroup = line.captureGroup(with: skipped ? .executedWithSkipped : .executedWithoutSkipped)
-        guard let group = group as? ExecutedCaptureGroup else { return }
+        let _group: CaptureGroup = line.captureGroup(with: skipped ? .executedWithSkipped : .executedWithoutSkipped)
+        guard let group = _group as? ExecutedCaptureGroup else { return }
 
         summary = TestSummary(
             testsCount: group.numberOfTests,

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -155,39 +155,39 @@ public class Parser {
     // MARK: Private
 
     private func parseSummary(line: String, colored: Bool) {
-        guard needToRecordSummary else {
-            return
-        }
-        
-        let group: [String] = line.captureGroup(with: .executed)
+        guard needToRecordSummary else { return }
+        defer { needToRecordSummary = false }
+
+        let group: CaptureGroup = line.captureGroup(with: .executed)
+        guard let group = group as? ExecutedWithoutSkippedCaptureGroup else { return }
+
         summary = TestSummary(
-            testsCount: Int(group[0]) ?? 0,
-            skippedCount: 0,
-            failuresCount: Int(group[1]) ?? 0,
-            unexpectedCount: Int(group[2]) ?? 0,
-            time: Double(group[3]) ?? 0,
+            testsCount: group.numberOfTests,
+            skippedCount: group.numberOfSkipped,
+            failuresCount: group.numberOfFailures,
+            unexpectedCount: group.numberOfUnexpectedFailures,
+            time: group.wallClockTimeInSeconds,
             colored: colored,
-            testSummary: summary)
-        
-        needToRecordSummary = false
+            testSummary: summary
+        )
     }
     
     private func parseSummarySkipped(line: String, colored: Bool) {
-        if !needToRecordSummary {
-            return
-        }
-        
-        let group: [String] = line.captureGroup(with: .executedWithSkipped)
+        guard needToRecordSummary else { return }
+        defer { needToRecordSummary = false }
+
+        let group: CaptureGroup = line.captureGroup(with: .executedWithSkipped)
+        guard let group = group as? ExecutedWithSkippedCaptureGroup else { return }
+
         summary = TestSummary(
-            testsCount: Int(group[0]) ?? 0,
-            skippedCount: Int(group[1]) ?? 0,
-            failuresCount: Int(group[2]) ?? 0,
-            unexpectedCount: Int(group[3]) ?? 0,
-            time: Double(group[4]) ?? 0,
+            testsCount: group.numberOfTests,
+            skippedCount: group.numberOfSkipped,
+            failuresCount: group.numberOfFailures,
+            unexpectedCount: group.numberOfUnexpectedFailures,
+            time: group.wallClockTimeInSeconds,
             colored: colored,
-            testSummary: summary)
-        
-        needToRecordSummary = false
+            testSummary: summary
+        )
     }
     
     private func innerParser(_ regex: Regex, outputType: OutputType) -> InnerParser {

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -113,7 +113,7 @@ public class Parser {
             
             // Some uncommon cases, which have additional logic and don't follow default flow
             
-            if Regex.executed.match(string: line) {
+            if Regex.executedWithoutSkipped.match(string: line) {
                 outputType = OutputType.task
                 parseSummary(line: line, colored: colored, skipped: false)
                 return nil
@@ -158,7 +158,7 @@ public class Parser {
         guard needToRecordSummary else { return }
         defer { needToRecordSummary = false }
 
-        let group: CaptureGroup = line.captureGroup(with: skipped ? .executedWithSkipped : .executed)
+        let group: CaptureGroup = line.captureGroup(with: skipped ? .executedWithSkipped : .executedWithoutSkipped)
         guard let group = group as? ExecutedCaptureGroup else { return }
 
         summary = TestSummary(

--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -101,7 +101,7 @@ enum Pattern: String {
     /// $2 = number of failures
     /// $3 = number of unexpected failures
     /// $4 = wall clock time in seconds (e.g. 0.295)
-    case executed = #"^\s*Executed\s(\d+)\stest[s]?,\swith\s(\d+)\sfailure[s]?\s\((\d+)\sunexpected\)\sin\s\d+\.\d{3}\s\((\d+\.\d{3})\)\sseconds"#
+    case executedWithoutSkipped = #"^\s*Executed\s(\d+)\stest[s]?,\swith\s(\d+)\sfailure[s]?\s\((\d+)\sunexpected\)\sin\s\d+\.\d{3}\s\((\d+\.\d{3})\)\sseconds"#
     
     /// Regular expression captured groups:
     /// $1 = number of tests

--- a/Sources/XcbeautifyLib/Regex.swift
+++ b/Sources/XcbeautifyLib/Regex.swift
@@ -41,7 +41,7 @@ extension Regex {
     static let cpresource = Regex(pattern: .cpresource)
     static let cursor = Regex(pattern: .cursor)
     static let duplicateLocalizedStringKey = Regex(pattern: .duplicateLocalizedStringKey)
-    static let executed = Regex(pattern: .executed)
+    static let executedWithoutSkipped = Regex(pattern: .executedWithoutSkipped)
     static let executedWithSkipped = Regex(pattern: .executedWithSkipped)
     static let failingTest = Regex(pattern: .failingTest)
     static let fatalError = Regex(pattern: .fatalError)

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -112,7 +112,7 @@ extension String {
             return nil
         case (.cleanRemove, let group as CleanRemoveCaptureGroup):
             return formatCleanRemove(group: group)
-        case (.executed, _ as ExecutedCaptureGroup):
+        case (.executed, _ as ExecutedWithoutSkippedCaptureGroup):
             return nil
         case (.executedWithSkipped, _ as ExecutedWithSkippedCaptureGroup):
             return nil

--- a/Sources/XcbeautifyLib/String+Beautify.swift
+++ b/Sources/XcbeautifyLib/String+Beautify.swift
@@ -112,7 +112,7 @@ extension String {
             return nil
         case (.cleanRemove, let group as CleanRemoveCaptureGroup):
             return formatCleanRemove(group: group)
-        case (.executed, _ as ExecutedWithoutSkippedCaptureGroup):
+        case (.executedWithoutSkipped, _ as ExecutedWithoutSkippedCaptureGroup):
             return nil
         case (.executedWithSkipped, _ as ExecutedWithSkippedCaptureGroup):
             return nil

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -2,29 +2,28 @@ import Foundation
 
 extension String {
     private func captureGroup(with pattern: Pattern) -> [String] {
-        var results = [String]()
-
-        var regex: NSRegularExpression
         do {
-            regex = try NSRegularExpression(pattern: pattern.rawValue, options: [.caseInsensitive])
-        } catch {
+            let regex = try NSRegularExpression(pattern: pattern.rawValue, options: [.caseInsensitive])
+
+            let matches = regex.matches(in: self, range: NSRange(location:0, length: self.utf16.count))
+            guard let match = matches.first else { return [] }
+
+            let lastRangeIndex = match.numberOfRanges - 1
+            guard lastRangeIndex >= 1 else { return [] }
+
+            var results = [String]()
+
+            for i in 1...lastRangeIndex {
+                let capturedGroupIndex = match.range(at: i)
+                guard let matchedString = substring(with: capturedGroupIndex) else { continue }
+                results.append(matchedString)
+            }
+
             return results
+        } catch {
+            assertionFailure(error.localizedDescription)
+            return []
         }
-
-        let matches = regex.matches(in: self, range: NSRange(location:0, length: self.utf16.count))
-
-        guard let match = matches.first else { return results }
-
-        let lastRangeIndex = match.numberOfRanges - 1
-        guard lastRangeIndex >= 1 else { return results }
-
-        for i in 1...lastRangeIndex {
-            let capturedGroupIndex = match.range(at: i)
-            guard let matchedString = substring(with: capturedGroupIndex) else { continue }
-            results.append(matchedString)
-        }
-
-        return results
     }
 }
 

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension String {
-    func captureGroup(with pattern: Pattern) -> [String] {
+    private func captureGroup(with pattern: Pattern) -> [String] {
         var results = [String]()
 
         var regex: NSRegularExpression

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -122,7 +122,7 @@ extension String {
             guard let file = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
             return CpresourceCaptureGroup(file: file.lastPathComponent, target: target)
 
-        case .executed:
+        case .executedWithoutSkipped:
             assert(results.count >= 4)
             guard let _numberOfTests = results[safe: 0], let _numberOfFailures = results[safe: 1], let _numberOfUnexpectedFailures = results[safe: 2], let _wallClockTimeInSeconds = results[safe: 3] else { return EmptyCaptureGroup() }
             guard let numberOfTests = Int(_numberOfTests), let numberOfFailures = Int(_numberOfFailures), let numberOfUnexpectedFailures = Int(_numberOfUnexpectedFailures), let wallClockTimeInSeconds = Double(_wallClockTimeInSeconds) else { return EmptyCaptureGroup() }

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -130,12 +130,14 @@ extension String {
 
         case .executed:
             assert(results.count >= 4)
-            guard let numberOfTests = results[safe: 0], let numberOfFailures = results[safe: 1], let numberOfUnexpectedFailures = results[safe: 2], let wallClockTimeInSeconds = results[safe: 3] else { return EmptyCaptureGroup() }
+            guard let _numberOfTests = results[safe: 0], let _numberOfFailures = results[safe: 1], let _numberOfUnexpectedFailures = results[safe: 2], let _wallClockTimeInSeconds = results[safe: 3] else { return EmptyCaptureGroup() }
+            guard let numberOfTests = Int(_numberOfTests), let numberOfFailures = Int(_numberOfFailures), let numberOfUnexpectedFailures = Int(_numberOfUnexpectedFailures), let wallClockTimeInSeconds = Double(_wallClockTimeInSeconds) else { return EmptyCaptureGroup() }
             return ExecutedWithoutSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
 
         case .executedWithSkipped:
             assert(results.count >= 5)
-            guard let numberOfTests = results[safe: 0], let numberOfSkipped = results[safe: 1], let numberOfFailures = results[safe: 2], let numberOfUnexpectedFailures = results[safe: 3], let wallClockTimeInSeconds = results[safe: 4] else { return EmptyCaptureGroup() }
+            guard let _numberOfTests = results[safe: 0], let _numberOfSkipped = results[safe: 1], let _numberOfFailures = results[safe: 2], let _numberOfUnexpectedFailures = results[safe: 3], let _wallClockTimeInSeconds = results[safe: 4] else { return EmptyCaptureGroup() }
+            guard let numberOfTests = Int(_numberOfTests), let numberOfSkipped = Int(_numberOfSkipped), let numberOfFailures = Int(_numberOfFailures), let numberOfUnexpectedFailures = Int(_numberOfUnexpectedFailures), let wallClockTimeInSeconds = Double(_wallClockTimeInSeconds) else { return EmptyCaptureGroup() }
             return ExecutedWithSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfSkipped: numberOfSkipped, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
 
         case .failingTest:

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -131,7 +131,7 @@ extension String {
         case .executed:
             assert(results.count >= 4)
             guard let numberOfTests = results[safe: 0], let numberOfFailures = results[safe: 1], let numberOfUnexpectedFailures = results[safe: 2], let wallClockTimeInSeconds = results[safe: 3] else { return EmptyCaptureGroup() }
-            return ExecutedCaptureGroup(numberOfTests: numberOfTests, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
+            return ExecutedWithoutSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
 
         case .executedWithSkipped:
             assert(results.count >= 5)

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -11,15 +11,10 @@ extension String {
             let lastRangeIndex = match.numberOfRanges - 1
             guard lastRangeIndex >= 1 else { return [] }
 
-            var results = [String]()
-
-            for i in 1...lastRangeIndex {
-                let capturedGroupIndex = match.range(at: i)
-                guard let matchedString = substring(with: capturedGroupIndex) else { continue }
-                results.append(matchedString)
+            return (1...lastRangeIndex).compactMap { index in
+                let capturedGroupIndex = match.range(at: index)
+                return substring(with: capturedGroupIndex)
             }
-
-            return results
         } catch {
             assertionFailure(error.localizedDescription)
             return []

--- a/Tests/XcbeautifyLibTests/XCTestManifests.swift
+++ b/Tests/XcbeautifyLibTests/XCTestManifests.swift
@@ -54,7 +54,7 @@ extension XcbeautifyLibTests {
         ("testCopyStrings", testCopyStrings),
         ("testCpresource", testCpresource),
         ("testCursor", testCursor),
-        ("testExecuted", testExecuted),
+        ("testExecutedWithoutSkipped", testExecutedWithoutSkipped),
         ("testFailingTest", testFailingTest),
         ("testFatalError", testFatalError),
         ("testFileMissingError", testFileMissingError),

--- a/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
+++ b/Tests/XcbeautifyLibTests/XcbeautifyLibTests.swift
@@ -140,7 +140,7 @@ final class XcbeautifyLibTests: XCTestCase {
     func testCursor() {
     }
 
-    func testExecuted() throws {
+    func testExecutedWithoutSkipped() throws {
         let input1 = "Test Suite 'All tests' failed at 2022-01-15 21:31:49.073."
         let input2 = "Executed 3 tests, with 2 failures (1 unexpected) in 0.112 (0.112) seconds"
 


### PR DESCRIPTION
## Changes

- Refactor remaining `captureGroup` call sites to use type-safe return value
- Mark `func captureGroup(with pattern: Pattern) -> [String]` as a `private` method to enforce usage of type-safe version
- Refactor `func captureGroup(with pattern: Pattern) -> [String]`
- Introduce an `ExecutedCaptureGroup` protocol with appropriate types and consolidate test summary methods
- Rename `executed` to `executedWithoutSkipped`
- Rename `Testcase` to `TestCase`