### PR TITLE
Refactor TestSummary

### DIFF
--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -6,9 +6,9 @@ public class Parser {
     
     private let additionalLines: () -> String?
 
-    public var summary: TestSummary? = nil
+    private(set) var summary: TestSummary? = nil
 
-    public var needToRecordSummary = false
+    private(set) var needToRecordSummary = false
 
     public var preserveUnbeautifiedLines = false
 
@@ -161,7 +161,11 @@ public class Parser {
         return result.value
     }
 
-    
+    public func formattedSummary() -> String? {
+        guard let summary = summary else { return nil }
+        return renderer.format(testSummary: summary)
+    }
+
     // MARK: Private
 
     private func parseSummary(line: String, colored: Bool, skipped: Bool) {
@@ -176,8 +180,7 @@ public class Parser {
             skippedCount: group.numberOfSkipped,
             failuresCount: group.numberOfFailures,
             unexpectedCount: group.numberOfUnexpectedFailures,
-            time: group.wallClockTimeInSeconds,
-            colored: colored
+            time: group.wallClockTimeInSeconds
         )
     }
 

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -5,6 +5,8 @@ protocol OutputRendering {
 
     func beautify(line: String, pattern: Pattern, additionalLines: @escaping () -> (String?)) -> String?
 
+    func format(testSummary: TestSummary) -> String
+
     func format(line: String, command: String, pattern: Pattern, arguments: String) -> String?
     func formatAnalyze(group: AnalyzeCaptureGroup) -> String
     func formatCleanRemove(group: CleanRemoveCaptureGroup) -> String

--- a/Sources/XcbeautifyLib/Renderers/TerminalRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/TerminalRenderer.swift
@@ -363,6 +363,14 @@ struct TerminalRenderer: OutputRendering {
         let message = group.warningMessage
         return colored ? Symbol.warning + " " + message.f.Yellow : Symbol.asciiWarning + " " + message
     }
+
+    func format(testSummary: TestSummary) -> String {
+        if testSummary.isSuccess() {
+            return colored ? "Tests Passed: \(testSummary.description)".s.Bold.f.Green : "Tests Passed: \(testSummary.description)"
+        } else {
+            return colored ? "Tests Failed: \(testSummary.description)".s.Bold.f.Red : "Tests Failed: \(testSummary.description)"
+        }
+    }
 }
 
 private extension String {

--- a/Sources/XcbeautifyLib/TestSummary.swift
+++ b/Sources/XcbeautifyLib/TestSummary.swift
@@ -1,10 +1,9 @@
-public struct TestSummary {
+struct TestSummary {
     let testsCount: Int
     let skippedCount: Int
     let failuresCount: Int
     let unexpectedCount: Int
     let time: Double
-    let colored: Bool
 
     static func += (_left: inout TestSummary?, right: TestSummary) {
         guard let left = _left else {
@@ -17,8 +16,7 @@ public struct TestSummary {
             skippedCount: left.skippedCount + right.skippedCount,
             failuresCount: left.failuresCount + right.failuresCount,
             unexpectedCount: left.unexpectedCount + right.unexpectedCount,
-            time: left.time + right.time,
-            colored: left.colored || right.colored
+            time: left.time + right.time
         )
     }
 }
@@ -31,13 +29,5 @@ extension TestSummary {
     var description: String {
         let timeFormatted = String(format: "%.3f", time)
         return "\(failuresCount) failed, \(skippedCount) skipped, \(testsCount) total (\(timeFormatted) seconds)"
-    }
-
-    public func format() -> String {
-        if isSuccess() {
-            return colored ? "Tests Passed: \(description)".s.Bold.f.Green : "Tests Passed: \(description)"
-        } else {
-            return colored ? "Tests Failed: \(description)".s.Bold.f.Red : "Tests Failed: \(description)"
-        }
     }
 }

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -61,8 +61,8 @@ struct Xcbeautify: ParsableCommand {
             output.write(parser.outputType, formatted)
         }
         
-        if let summary = parser.summary {
-            print(summary.format())
+        if let formattedSummary = parser.formattedSummary() {
+            output.write(.result, formattedSummary)
         }
 
         if !report.isEmpty {


### PR DESCRIPTION
Migrate `TestSummary` formatting logic from an `extension` on `TestSummary` to the concrete `OutputRendering` types.