### PR TITLE
Make --report-path support absolute paths

### DIFF
--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -66,8 +66,9 @@ struct Xcbeautify: ParsableCommand {
         }
 
         if !report.isEmpty {
-            let outputPath = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-                .appendingPathComponent(reportPath)
+            let outputPath = URL(fileURLWithPath: reportPath,
+                                 relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
+
             try FileManager.default.createDirectory(at: outputPath, withIntermediateDirectories: true)
 
             for reportType in Set(report) {


### PR DESCRIPTION
Hey folks, first of all, thank you for this tool!

I'm raising this PR to add support for absolute report paths. In some setups it's crucial, for example when your CI provider expects the files that you'd like to publish as build artifacts in a particular directory, and provides this directory to you as an absolute path in an environment variable.