### PR TITLE
GitHub Actions Renderer: Treat warnings as errors or silence annotations for warnings

### DIFF
--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -102,16 +102,18 @@ public class Parser {
     public init(
         colored: Bool = true,
         renderer: Renderer,
+        warningsAsErrors: Bool = false,
+        quietWarnings: Bool = false,
         preserveUnbeautifiedLines: Bool = false,
         additionalLines: @escaping () -> (String?)
     ) {
         self.colored = colored
 
-        switch renderer {
-        case .terminal:
-            self.renderer = TerminalRenderer(colored: colored)
-        case .gitHubActions:
-            self.renderer = GitHubActionsRenderer()
+        self.renderer = switch (renderer) {
+            case .terminal:
+                TerminalRenderer(colored: colored)
+            case .gitHubActions:
+                GitHubActionsRenderer(warningsAsErrors: warningsAsErrors, quietWarnings: quietWarnings)
         }
 
         self.preserveUnbeautifiedLines = preserveUnbeautifiedLines

--- a/Sources/XcbeautifyLib/Renderers/GitHubActionsRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/GitHubActionsRenderer.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 struct GitHubActionsRenderer: OutputRendering {
+
+    init(warningsAsErrors: Bool, quietWarnings: Bool) {
+        self.warningsAsErrors = warningsAsErrors
+        self.quietWarnings = quietWarnings
+    }
+
     private enum AnnotationType: String {
         case notice
         case warning
@@ -9,13 +15,21 @@ struct GitHubActionsRenderer: OutputRendering {
 
     // Colored output is disallowed since GitHub Actions annotations don't properly render it.
     let colored: Bool = false
+    let warningsAsErrors: Bool
+    let quietWarnings: Bool
 
     private func outputGitHubActionsLog(
         annotationType: AnnotationType,
         fileComponents: FileComponents? = nil,
         message: String
     ) -> String {
+        if self.quietWarnings && annotationType == .warning {
+            return message
+        }
+
         let formattedFileComponents = fileComponents?.formatted ?? ""
+        let annotationType = annotationType == .warning && warningsAsErrors ? .error : annotationType
+
         return "::\(annotationType) \(formattedFileComponents)::\(message)"
     }
 

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -35,6 +35,12 @@ struct Xcbeautify: ParsableCommand {
     @Option(help: "The name of JUnit report file name")
     var junitReportFilename = "junit.xml"
 
+    @Flag(help: "Tell the renderer to treat warnings as errors (github-actions only)")
+    var renderWarningsAsErrors = false
+
+    @Flag(help: "Tell the renderer to skip annotations for warnings (github-actions only)")
+    var renderQuietWarnings = false
+
     func run() throws {
         let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCi, { print($0) })
         let junitReporter = JunitReporter()
@@ -52,6 +58,8 @@ struct Xcbeautify: ParsableCommand {
         let parser = Parser(
             colored: !disableColoredOutput,
             renderer: renderer,
+            warningsAsErrors: renderWarningsAsErrors,
+            quietWarnings: renderQuietWarnings,
             preserveUnbeautifiedLines: preserveUnbeautified,
             additionalLines: { readLine() }
         )


### PR DESCRIPTION
This adds new flags to treat warnings as errors and emit quiet (not annotated) warnings for the GitHub Actions Renderer.

I work on a fairly large project that has lots of warnings produced by clang which the bosses aren't really interested in fixing. I don't want these warnings to appear as annotations in github actions as it's way too noisy.

I added `--render-quiet-warnings` to skip the annotation for warnings but still output the warning message to log.

I also added `--render-warnings-as-errors` while I was at it, I figure it might be useful for some folks.

Not sure if this is an interesting pr for Xcbeautify, and maybe there's a better way to do this. I'm open to discussion and thanks for your time.