### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you use macOS 10.14.3 or earlier, install Swift 5 Runtime Support for
 Command Line Tools first:
 
 ```bash
-brew cask install thii/swift-runtime/swift-runtime
+brew install thii/swift-runtime/swift-runtime --cask
 ```
 
 ### Homebrew


### PR DESCRIPTION
The installation instructions in the README are no longer valid. Doing the brew cask command generates an error.

> Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.

Updated the readme to provide the new correct command.