### PR TITLE
Fix LinkerDuplicateSymbolsLocationCaptureGroup

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -378,7 +378,7 @@ struct LDErrorCaptureGroup: ErrorCaptureGroup {
 }
 
 struct LinkerDuplicateSymbolsLocationCaptureGroup: CaptureGroup {
-    let filePath: String
+    let wholeError: String
 }
 
 struct LinkerDuplicateSymbolsCaptureGroup: CaptureGroup {

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -390,8 +390,8 @@ extension String {
 
         case .linkerDuplicateSymbolsLocation:
             assert(results.count >= 1)
-            guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
-            return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
+            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            return LinkerDuplicateSymbolsLocationCaptureGroup(wholeError: wholeError)
 
         case .linkerDuplicateSymbols:
             assert(results.count >= 1)


### PR DESCRIPTION
## Changes

- Fix instance where `linkerDuplicateSymbolsLocation` returned `LinkerDuplicateSymbolsCaptureGroup` instead of `LinkerDuplicateSymbolsLocationCaptureGroup`.
- Update `LinkerDuplicateSymbolsLocationCaptureGroup` property name

## References

#153 and #156