### PR TITLE
Auto-Detect GitHub Actions

### DIFF
--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -24,7 +24,7 @@ struct Xcbeautify: ParsableCommand {
     var disableColoredOutput = (ProcessInfo.processInfo.environment["NO_COLOR"] != nil)
 
     @Option(help: "Specify a renderer to format raw xcodebuild output ( options: terminal | github-actions ).")
-    var renderer: XcbeautifyLib.Renderer = .terminal
+    var renderer: Renderer = ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true" ? .gitHubActions : .terminal
 
     @Option(help: "Generate the specified reports")
     var report: [Report] = []


### PR DESCRIPTION
Automatically detect when a developer uses xcbeautify on GitHub Actions. If `renderer` isn't overridden, use the GitHub Actions renderer.