### PR TITLE
CodeSign line format

### DIFF
--- a/Sources/XcbeautifyLib/Pattern.swift
+++ b/Sources/XcbeautifyLib/Pattern.swift
@@ -41,7 +41,7 @@ enum Pattern: String {
 
     /// Regular expression captured groups:
     /// $1 = file
-    case codesign = #"^CodeSign\s(((?!.framework/Versions/A)(?:\ |[^ ]))*)$"#
+    case codesign = #"^CodeSign\s(((?!.framework/Versions/A)(?:\ |[^ ]))*?)( \(in target '.*' from project '.*' at path '.*'\))?$"#
 
     /// Regular expression captured groups:
     /// $1 = file

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -65,7 +65,7 @@ final class TerminalRendererTests: XCTestCase {
     }
 
     func testMultipleCodesigns() {
-        let formattedApp = noColoredFormatted("CodeSign build/Release/MyApp.app")
+        let formattedApp = noColoredFormatted("CodeSign build/Release/MyApp.app (in target 'X' from project 'Y' at path 'Z')")
         let formattedFramework = noColoredFormatted("CodeSign build/Release/MyFramework.framework/Versions/A (in target 'X' from project 'Y')")
         XCTAssertEqual(formattedApp, "Signing MyApp.app")
         XCTAssertEqual(formattedFramework, "Signing build/Release/MyFramework.framework")


### PR DESCRIPTION
The current version of `xcbeautify` fails to parse `CodeSign` lines correctly.

**Step(s) to reproduce.** In a modularised Xcode project (don't know if that detail matters!), `xcodebuild` produces output lines of shape:

> ```
> CodeSign .../Widget.appex (in target 'FooWidget' from project 'Foo' at path '.../FooProject.xcodeproj')
> CodeSign .../Foo.app (in target 'FooApp' from project 'Foo' at path '.../FooProject.xcodeproj')
> ```

**Expected output.** I would expect `xcbeautify` to produce output like:

> ```
> Signing Widget.appex
> Signing Foo.app
> ```

**Actual output.** Mind the special characters:

> ```
> Signing FooProject.xcodeproj')
> Signing FooProject.xcodeproj')
> ```

This PR fixes the above, while allowing the old format without any `(in target '*' ...)` suffix to parse, as well. (The existing `testCodesign()` unit test was left as is to assert that.)