### PR TITLE
Delete EmptyCaptureGroup

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -30,8 +30,6 @@ protocol ExecutedCaptureGroup: CaptureGroup {
     var wallClockTimeInSeconds: Double { get }
 }
 
-struct EmptyCaptureGroup: CaptureGroup { }
-
 struct AnalyzeCaptureGroup: CaptureGroup {
     let filePath: String
     let fileName: String

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -46,38 +46,38 @@ public final class JunitReporter {
     }
 
     private func generateFailingTest(line: String) -> TestCase? {
-        let _group: CaptureGroup = line.captureGroup(with: .failingTest)
+        guard let _group: CaptureGroup = line.captureGroup(with: .failingTest) else { return nil }
         guard let group = _group as? FailingTestCaptureGroup else { return nil }
         return TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: "\(group.file) - \(group.reason)"))
     }
     
     private func generateRestartingTest(line: String) -> TestCase? {
-        let _group: CaptureGroup = line.captureGroup(with: .restartingTest)
+        guard let _group: CaptureGroup = line.captureGroup(with: .restartingTest) else { return nil }
         guard let group = _group as? RestartingTestCaptureGroup else { return nil }
         return TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: line))
     }
 
     private func generateParallelFailingTest(line: String) -> TestCase? {
         // Parallel tests do not provide meaningful failure messages
-        let _group: CaptureGroup = line.captureGroup(with: .parallelTestCaseFailed)
+        guard let _group: CaptureGroup = line.captureGroup(with: .parallelTestCaseFailed) else { return nil }
         guard let group = _group as? ParallelTestCaseFailedCaptureGroup else { return nil }
         return TestCase(classname: group.suite, name: group.testCase, time: nil, failure: .init(message: "Parallel test failed"))
     }
 
     private func generatePassingTest(line: String) -> TestCase? {
-        let _group: CaptureGroup = line.captureGroup(with: .testCasePassed)
+        guard let _group: CaptureGroup = line.captureGroup(with: .testCasePassed) else { return nil }
         guard let group = _group as? TestCasePassedCaptureGroup else { return nil }
         return TestCase(classname: group.suite, name: group.testCase, time: group.time, failure: nil)
     }
 
     private func generatePassingParallelTest(line: String) -> TestCase? {
-        let _group: CaptureGroup = line.captureGroup(with: .parallelTestCasePassed)
+        guard let _group: CaptureGroup = line.captureGroup(with: .parallelTestCasePassed) else { return nil }
         guard let group = _group as? ParallelTestCasePassedCaptureGroup else { return nil }
         return TestCase(classname: group.suite, name: group.testCase, time: group.time, failure: nil)
     }
   
     private func generateSuiteStart(line: String) -> String? {
-        let _group: CaptureGroup = line.captureGroup(with: .testSuiteStart)
+        guard let _group: CaptureGroup = line.captureGroup(with: .testSuiteStart) else { return nil }
         guard let group = _group as? TestSuiteStartCaptureGroup else { return nil }
         return group.testSuiteName
     }

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -174,7 +174,7 @@ public class Parser {
         guard needToRecordSummary else { return }
         defer { needToRecordSummary = false }
 
-        let _group: CaptureGroup = line.captureGroup(with: skipped ? .executedWithSkipped : .executedWithoutSkipped)
+        guard let _group: CaptureGroup = line.captureGroup(with: skipped ? .executedWithSkipped : .executedWithoutSkipped) else { return }
         guard let group = _group as? ExecutedCaptureGroup else { return }
 
         summary += TestSummary(

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -81,7 +81,10 @@ extension OutputRendering {
         pattern: Pattern,
         additionalLines: @escaping () -> (String?)
     ) -> String? {
-        let group: CaptureGroup = line.captureGroup(with: pattern)
+        guard let group: CaptureGroup = line.captureGroup(with: pattern) else {
+            assertionFailure("Expected a known CaptureGroup from the given Pattern!")
+            return nil
+        }
 
         switch (pattern, group) {
         case (.aggregateTarget, let group as AggregateTargetCaptureGroup):

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -23,28 +23,28 @@ extension String {
 }
 
 extension String {
-    func captureGroup(with pattern: Pattern) -> CaptureGroup {
+    func captureGroup(with pattern: Pattern) -> CaptureGroup? {
         let results: [String] = captureGroup(with: pattern)
 
         switch pattern {
         case .analyze:
             assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return nil }
             return AnalyzeCaptureGroup(filePath: filePath, fileName: fileName, target: target)
 
         case .buildTarget:
             assert(results.count >= 3)
-            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return nil }
             return BuildTargetCaptureGroup(target: target, project: project, configuration: configuration)
 
         case .aggregateTarget:
             assert(results.count >= 3)
-            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return nil }
             return AggregateTargetCaptureGroup(target: target, project: project, configuration: configuration)
 
         case .analyzeTarget:
             assert(results.count >= 3)
-            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return nil }
             return AnalyzeTargetCaptureGroup(target: target, project: project, configuration: configuration)
 
         case .checkDependencies:
@@ -53,100 +53,100 @@ extension String {
 
         case .shellCommand:
             assert(results.count >= 2)
-            guard let commandPath = results[safe: 0], let arguments = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let commandPath = results[safe: 0], let arguments = results[safe: 1] else { return nil }
             return ShellCommandCaptureGroup(commandPath: commandPath, arguments: arguments)
 
         case .cleanRemove:
             assert(results.count >= 1)
-            guard let directory = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let directory = results[safe: 0] else { return nil }
             return CleanRemoveCaptureGroup(directory: directory.lastPathComponent)
 
         case .cleanTarget:
             assert(results.count >= 3)
-            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return nil }
             return CleanTargetCaptureGroup(target: target, project: project, configuration: configuration)
 
         case .codesign:
             assert(results.count >= 1)
-            guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0] else { return nil }
             return CodesignCaptureGroup(file: file)
 
         case .codesignFramework:
             assert(results.count >= 1)
-            guard let frameworkPath = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let frameworkPath = results[safe: 0] else { return nil }
             return CodesignFrameworkCaptureGroup(frameworkPath: frameworkPath)
 
         case .compile:
 #if os(Linux)
             assert(results.count >= 2)
-            guard let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            guard let fileName = results[safe: 1], let target = results.last else { return nil }
             return CompileCaptureGroup(filename: fileName, target: target)
 #else
             assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return nil }
             return CompileCaptureGroup(filePath: filePath, filename: fileName, target: target)
 #endif
 
         case .compileCommand:
             assert(results.count >= 2)
-            guard let compilerCommand = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let compilerCommand = results[safe: 0], let filePath = results[safe: 1] else { return nil }
             return CompileCommandCaptureGroup(compilerCommand: compilerCommand, filePath: filePath)
 
         case .compileXib:
             assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return nil }
             return CompileXibCaptureGroup(filePath: filePath, filename: fileName, target: target)
 
         case .compileStoryboard:
             assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return nil }
             return CompileStoryboardCaptureGroup(filePath: filePath, filename: fileName, target: target)
 
         case .copyHeader:
             assert(results.count >= 3)
-            guard let file = results[safe: 0], let targetFile = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0], let targetFile = results[safe: 1], let target = results.last else { return nil }
             return CopyHeaderCaptureGroup(file: file.lastPathComponent, targetFile: targetFile, target: target)
 
         case .copyPlist:
             assert(results.count >= 2)
-            guard let file = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0], let target = results.last else { return nil }
             return CopyPlistCaptureGroup(file: file.lastPathComponent, target: target)
 
         case .copyStrings:
             assert(results.count >= 2)
-            guard let file = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0], let target = results.last else { return nil }
             return CopyStringsCaptureGroup(file: file.lastPathComponent, target: target)
 
         case .cpresource:
             assert(results.count >= 2)
-            guard let file = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0], let target = results.last else { return nil }
             return CpresourceCaptureGroup(file: file.lastPathComponent, target: target)
 
         case .executedWithoutSkipped:
             assert(results.count >= 4)
-            guard let _numberOfTests = results[safe: 0], let _numberOfFailures = results[safe: 1], let _numberOfUnexpectedFailures = results[safe: 2], let _wallClockTimeInSeconds = results[safe: 3] else { return EmptyCaptureGroup() }
-            guard let numberOfTests = Int(_numberOfTests), let numberOfFailures = Int(_numberOfFailures), let numberOfUnexpectedFailures = Int(_numberOfUnexpectedFailures), let wallClockTimeInSeconds = Double(_wallClockTimeInSeconds) else { return EmptyCaptureGroup() }
+            guard let _numberOfTests = results[safe: 0], let _numberOfFailures = results[safe: 1], let _numberOfUnexpectedFailures = results[safe: 2], let _wallClockTimeInSeconds = results[safe: 3] else { return nil }
+            guard let numberOfTests = Int(_numberOfTests), let numberOfFailures = Int(_numberOfFailures), let numberOfUnexpectedFailures = Int(_numberOfUnexpectedFailures), let wallClockTimeInSeconds = Double(_wallClockTimeInSeconds) else { return nil }
             return ExecutedWithoutSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
 
         case .executedWithSkipped:
             assert(results.count >= 5)
-            guard let _numberOfTests = results[safe: 0], let _numberOfSkipped = results[safe: 1], let _numberOfFailures = results[safe: 2], let _numberOfUnexpectedFailures = results[safe: 3], let _wallClockTimeInSeconds = results[safe: 4] else { return EmptyCaptureGroup() }
-            guard let numberOfTests = Int(_numberOfTests), let numberOfSkipped = Int(_numberOfSkipped), let numberOfFailures = Int(_numberOfFailures), let numberOfUnexpectedFailures = Int(_numberOfUnexpectedFailures), let wallClockTimeInSeconds = Double(_wallClockTimeInSeconds) else { return EmptyCaptureGroup() }
+            guard let _numberOfTests = results[safe: 0], let _numberOfSkipped = results[safe: 1], let _numberOfFailures = results[safe: 2], let _numberOfUnexpectedFailures = results[safe: 3], let _wallClockTimeInSeconds = results[safe: 4] else { return nil }
+            guard let numberOfTests = Int(_numberOfTests), let numberOfSkipped = Int(_numberOfSkipped), let numberOfFailures = Int(_numberOfFailures), let numberOfUnexpectedFailures = Int(_numberOfUnexpectedFailures), let wallClockTimeInSeconds = Double(_wallClockTimeInSeconds) else { return nil }
             return ExecutedWithSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfSkipped: numberOfSkipped, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
 
         case .failingTest:
             assert(results.count >= 4)
-            guard let file = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2], let reason = results[safe: 3] else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2], let reason = results[safe: 3] else { return nil }
             return FailingTestCaptureGroup(file: file, testSuite: testSuite, testCase: testCase, reason: reason)
 
         case .uiFailingTest:
             assert(results.count >= 2)
-            guard let file = results[safe: 0], let reason = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0], let reason = results[safe: 1] else { return nil }
             return UIFailingTestCaptureGroup(file: file, reason: reason)
 
         case .restartingTest:
             assert(results.count >= 3)
-            guard let testSuiteAndTestCase = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let testSuiteAndTestCase = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2] else { return nil }
             return RestartingTestCaptureGroup(testSuiteAndTestCase: testSuiteAndTestCase, testSuite: testSuite, testCase: testCase)
 
         case .generateCoverageData:
@@ -155,118 +155,118 @@ extension String {
 
         case .generatedCoverageReport:
             assert(results.count >= 1)
-            guard let coverageReportFilePath = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let coverageReportFilePath = results[safe: 0] else { return nil }
             return GeneratedCoverageReportCaptureGroup(coverageReportFilePath: coverageReportFilePath)
 
         case .generateDsym:
             assert(results.count >= 2)
-            guard let dsym = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            guard let dsym = results[safe: 0], let target = results.last else { return nil }
             return GenerateDSYMCaptureGroup(dsym: dsym, target: target)
 
         case .libtool:
             assert(results.count >= 2)
-            guard let fileName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            guard let fileName = results[safe: 0], let target = results.last else { return nil }
             return LibtoolCaptureGroup(fileName: fileName, target: target)
 
         case .linking:
 #if os(Linux)
             assert(results.count >= 1)
-            guard let target = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let target = results[safe: 0] else { return nil }
             return LinkingCaptureGroup(target: target)
 #else
             assert(results.count >= 2)
-            guard let binaryFileName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            guard let binaryFileName = results[safe: 0], let target = results.last else { return nil }
             return LinkingCaptureGroup(binaryFilename: binaryFileName.lastPathComponent, target: target)
 #endif
 
         case .testCasePassed:
             assert(results.count >= 3)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return nil }
             return TestCasePassedCaptureGroup(suite: suite, testCase: testCase, time: time)
 
         case .testCaseStarted:
             assert(results.count >= 2)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return nil }
             return TestCaseStartedCaptureGroup(suite: suite, testCase: testCase)
 
         case .testCasePending:
             assert(results.count >= 2)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return nil }
             return TestCasePendingCaptureGroup(suite: suite, testCase: testCase)
 
         case .testCaseMeasured:
             assert(results.count >= 6)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let name = results[safe: 2], let unitName = results[safe: 3], let value = results[safe: 4], let deviation = results[safe: 5] else { return EmptyCaptureGroup() }
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let name = results[safe: 2], let unitName = results[safe: 3], let value = results[safe: 4], let deviation = results[safe: 5] else { return nil }
             return TestCaseMeasuredCaptureGroup(suite: suite, testCase: testCase, name: name, unitName: unitName, value: value, deviation: deviation)
 
         case .parallelTestCasePassed:
             assert(results.count >= 4)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let device = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let device = results[safe: 2], let time = results[safe: 3] else { return nil }
             return ParallelTestCasePassedCaptureGroup(suite: suite, testCase: testCase, device: device, time: time)
 
         case .parallelTestCaseAppKitPassed:
             assert(results.count >= 3)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return nil }
             return ParallelTestCaseAppKitPassedCaptureGroup(suite: suite, testCase: testCase, time: time)
 
         case .parallelTestCaseFailed:
             assert(results.count >= 4)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let device = results[safe: 2], let time = results[safe: 3] else { return EmptyCaptureGroup() }
+            guard let suite = results[safe: 0], let testCase = results[safe: 1], let device = results[safe: 2], let time = results[safe: 3] else { return nil }
             return ParallelTestCaseFailedCaptureGroup(suite: suite, testCase: testCase, device: device, time: time)
 
         case .parallelTestingStarted:
             assert(results.count >= 1)
-            guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let device = results[safe: 0] else { return nil }
             return ParallelTestingStartedCaptureGroup(device: device)
 
         case .parallelTestingPassed:
             assert(results.count >= 1)
-            guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let device = results[safe: 0] else { return nil }
             return ParallelTestingPassedCaptureGroup(device: device)
 
         case .parallelTestingFailed:
             assert(results.count >= 1)
-            guard let device = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let device = results[safe: 0] else { return nil }
             return ParallelTestingFailedCaptureGroup(device: device)
 
         case .parallelTestSuiteStarted:
             assert(results.count >= 2)
-            guard let suite = results[safe: 0], let device = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let suite = results[safe: 0], let device = results[safe: 1] else { return nil }
             return ParallelTestSuiteStartedCaptureGroup(suite: suite, device: device)
 
         case .phaseSuccess:
             assert(results.count >= 1)
-            guard let phase = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let phase = results[safe: 0] else { return nil }
             return PhaseSuccessCaptureGroup(phase: phase)
 
         case .phaseScriptExecution:
             assert(results.count >= 2)
-            guard let phaseName = results[safe: 0], let target = results.last else { return EmptyCaptureGroup() }
+            guard let phaseName = results[safe: 0], let target = results.last else { return nil }
             return PhaseScriptExecutionCaptureGroup(phaseName: phaseName, target: target)
 
         case .processPch:
             assert(results.count >= 2)
-            guard let file = results[safe: 0], let buildTarget = results.last else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0], let buildTarget = results.last else { return nil }
             return ProcessPchCaptureGroup(file: file, buildTarget: buildTarget)
 
         case .processPchCommand:
             assert(results.count >= 1)
-            guard let filePath = results.last else { return EmptyCaptureGroup() }
+            guard let filePath = results.last else { return nil }
             return ProcessPchCommandCaptureGroup(filePath: filePath)
 
         case .preprocess:
             assert(results.count >= 1)
-            guard let file = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0] else { return nil }
             return PreprocessCaptureGroup(file: file)
 
         case .pbxcp:
             assert(results.count >= 3)
-            guard let file = results[safe: 0], let targetFile = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            guard let file = results[safe: 0], let targetFile = results[safe: 1], let target = results.last else { return nil }
             return PbxcpCaptureGroup(file: file.lastPathComponent, targetFile: targetFile, target: target)
 
         case .processInfoPlist:
             assert(results.count >= 2)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return nil }
 
             // TODO: Test with target included
             if results.count == 2 {
@@ -279,17 +279,17 @@ extension String {
 
         case .testsRunCompletion:
             assert(results.count >= 3)
-            guard let suite = results[safe: 0], let result = results[safe: 1], let time = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let suite = results[safe: 0], let result = results[safe: 1], let time = results[safe: 2] else { return nil }
             return TestsRunCompletionCaptureGroup(suite: suite, result: result, time: time)
 
         case .testSuiteStarted:
             assert(results.count >= 2)
-            guard let suite = results[safe: 0], let time = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let suite = results[safe: 0], let time = results[safe: 1] else { return nil }
             return TestSuiteStartedCaptureGroup(suite: suite, time: time)
 
         case .testSuiteStart:
             assert(results.count >= 1)
-            guard let testSuiteName = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let testSuiteName = results[safe: 0] else { return nil }
             return TestSuiteStartCaptureGroup(testSuiteName: testSuiteName)
 
         case .testSuiteAllTestsPassed:
@@ -302,17 +302,17 @@ extension String {
 
         case .tiffutil:
             assert(results.count >= 1)
-            guard let fileName = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let fileName = results[safe: 0] else { return nil }
             return TIFFutilCaptureGroup(filename: fileName)
 
         case .touch:
             assert(results.count >= 3)
-            guard let fileName = results[safe: 1], let target = results.last else { return EmptyCaptureGroup() }
+            guard let fileName = results[safe: 1], let target = results.last else { return nil }
             return TouchCaptureGroup(filename: fileName, target: target)
 
         case .writeFile:
             assert(results.count >= 1)
-            guard let filePath = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0] else { return nil }
             return WriteFileCaptureGroup(filePath: filePath)
 
         case .writeAuxiliaryFiles:
@@ -321,32 +321,32 @@ extension String {
 
         case .compileWarning:
             assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let reason = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let reason = results[safe: 2] else { return nil }
             return CompileWarningCaptureGroup(filePath: filePath, filename: fileName, reason: reason)
 
         case .ldWarning:
             assert(results.count >= 2)
-            guard let ldPrefix = results[safe: 0], let warningMessage = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let ldPrefix = results[safe: 0], let warningMessage = results[safe: 1] else { return nil }
             return LDWarningCaptureGroup(ldPrefix: ldPrefix, warningMessage: warningMessage)
 
         case .genericWarning:
             assert(results.count >= 1)
-            guard let wholeWarning = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeWarning = results[safe: 0] else { return nil }
             return GenericWarningCaptureGroup(wholeWarning: wholeWarning)
 
         case .willNotBeCodeSigned:
             assert(results.count >= 1)
-            guard let wholeWarning = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeWarning = results[safe: 0] else { return nil }
             return WillNotBeCodeSignedCaptureGroup(wholeWarning: wholeWarning)
 
         case .duplicateLocalizedStringKey:
             assert(results.count >= 1)
-            guard let wholeMessage = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeMessage = results[safe: 0] else { return nil }
             return DuplicateLocalizedStringKeyCaptureGroup(warningMessage: wholeMessage)
 
         case .clangError:
             assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeError = results[safe: 0] else { return nil }
             return ClangErrorCaptureGroup(wholeError: wholeError)
 
         case .checkDependenciesErrors:
@@ -355,92 +355,92 @@ extension String {
 
         case .provisioningProfileRequired:
             assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeError = results[safe: 0] else { return nil }
             return ProvisioningProfileRequiredCaptureGroup(wholeError: wholeError)
 
         case .noCertificate:
             assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeError = results[safe: 0] else { return nil }
             return NoCertificateCaptureGroup(wholeError: wholeError)
 
         case .compileError:
             assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let isFatalError = results[safe: 1], let reason = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let filePath = results[safe: 0], let isFatalError = results[safe: 1], let reason = results[safe: 2] else { return nil }
             return CompileErrorCaptureGroup(filePath: filePath, isFatalError: isFatalError, reason: reason)
 
         case .cursor:
             assert(results.count >= 1)
-            guard let cursor = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let cursor = results[safe: 0] else { return nil }
             return CursorCaptureGroup(cursor: cursor)
 
         case .fatalError:
             assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeError = results[safe: 0] else { return nil }
             return FatalErrorCaptureGroup(wholeError: wholeError)
 
         case .fileMissingError:
             assert(results.count >= 2)
-            guard let reason = results[safe: 0], let filePath = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let reason = results[safe: 0], let filePath = results[safe: 1] else { return nil }
             return FileMissingErrorCaptureGroup(reason: reason, filePath: filePath)
 
         case .ldError:
             assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeError = results[safe: 0] else { return nil }
             return LDErrorCaptureGroup(wholeError: wholeError)
 
         case .linkerDuplicateSymbolsLocation:
             assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeError = results[safe: 0] else { return nil }
             return LinkerDuplicateSymbolsLocationCaptureGroup(wholeError: wholeError)
 
         case .linkerDuplicateSymbols:
             assert(results.count >= 1)
-            guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let reason = results[safe: 0] else { return nil }
             return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
 
         case .linkerUndefinedSymbolLocation:
             assert(results.count >= 1)
-            guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let reason = results[safe: 0] else { return nil }
             return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
 
         case .linkerUndefinedSymbols:
             assert(results.count >= 1)
-            guard let reason = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let reason = results[safe: 0] else { return nil }
             return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
 
         case .podsError:
             assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeError = results[safe: 0] else { return nil }
             return PodsErrorCaptureGroup(wholeError: wholeError)
 
         case .symbolReferencedFrom:
             assert(results.count >= 1)
-            guard let reference = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let reference = results[safe: 0] else { return nil }
             return SymbolReferencedFromCaptureGroup(reference: reference)
 
         case .moduleIncludesError:
             assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeError = results[safe: 0] else { return nil }
             return ModuleIncludesErrorCaptureGroup(wholeError: wholeError)
 
         case .undefinedSymbolLocation:
             assert(results.count >= 2)
-            guard let target = results[safe: 0], let fileName = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let target = results[safe: 0], let fileName = results[safe: 1] else { return nil }
             return UndefinedSymbolLocationCaptureGroup(target: target, filename: fileName)
 
         case .packageFetching:
             assert(results.count >= 1)
-            guard let source = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let source = results[safe: 0] else { return nil }
             return PackageFetchingCaptureGroup(source: source)
 
         case .packageUpdating:
             assert(results.count >= 1)
-            guard let source = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let source = results[safe: 0] else { return nil }
             return PackageUpdatingCaptureGroup(source: source)
 
         case .packageCheckingOut:
             assert(results.count >= 2)
-            guard let version = results[safe: 0], let package = results[safe: 1] else { return EmptyCaptureGroup() }
+            guard let version = results[safe: 0], let package = results[safe: 1] else { return nil }
             return PackageCheckingOutCaptureGroup(version: version, package: package)
 
         case .packageGraphResolvingStart:
@@ -453,12 +453,12 @@ extension String {
 
         case .packageGraphResolvedItem:
             assert(results.count >= 3)
-            guard let packageName = results[safe: 0], let packageURL = results[safe: 1], let packageVersion = results[safe: 2] else { return EmptyCaptureGroup() }
+            guard let packageName = results[safe: 0], let packageURL = results[safe: 1], let packageVersion = results[safe: 2] else { return nil }
             return PackageGraphResolvedItemCaptureGroup(packageName: packageName, packageURL: packageURL, packageVersion: packageVersion)
 
         case .xcodebuildError:
             assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return EmptyCaptureGroup() }
+            guard let wholeError = results[safe: 0] else { return nil }
             return XcodebuildErrorCaptureGroup(wholeError: wholeError)
         }
     }


### PR DESCRIPTION
`EmptyCaptureGroup` originally existed to handle unknown cases. However, this is never actually used and can be handled by a `nil` value. Removing this `CaptureGroup` will also help make the planned changes to `CaptureGroup` properties.