### PR TITLE
Don't Automatically Close Stale Issues and Pull Requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -49,4 +49,4 @@ jobs:
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
           days-before-stale: 30
-          days-before-close: 5
+          days-before-close: -1


### PR DESCRIPTION
Mark issues and pull requests as stale without closing them. 