### PR TITLE
Add failable init to CaptureGroup

### DIFF
--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -27,439 +27,257 @@ extension String {
         let results: [String] = captureGroup(with: pattern)
 
         switch pattern {
-        case AnalyzeCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return nil }
-            return AnalyzeCaptureGroup(filePath: filePath, fileName: fileName, target: target)
-
-        case BuildTargetCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return nil }
-            return BuildTargetCaptureGroup(target: target, project: project, configuration: configuration)
-
-        case AggregateTargetCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return nil }
-            return AggregateTargetCaptureGroup(target: target, project: project, configuration: configuration)
-
-        case AnalyzeTargetCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return nil }
-            return AnalyzeTargetCaptureGroup(target: target, project: project, configuration: configuration)
-
-        case CheckDependenciesCaptureGroup.pattern:
-            assert(results.count >= 0)
-            return CheckDependenciesCaptureGroup()
-
-        case ShellCommandCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let commandPath = results[safe: 0], let arguments = results[safe: 1] else { return nil }
-            return ShellCommandCaptureGroup(commandPath: commandPath, arguments: arguments)
-
-        case CleanRemoveCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let directory = results[safe: 0] else { return nil }
-            return CleanRemoveCaptureGroup(directory: directory.lastPathComponent)
-
-        case CleanTargetCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let target = results[safe: 0], let project = results[safe: 1], let configuration = results[safe: 2] else { return nil }
-            return CleanTargetCaptureGroup(target: target, project: project, configuration: configuration)
-
-        case CodesignCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let file = results[safe: 0] else { return nil }
-            return CodesignCaptureGroup(file: file)
-
-        case CodesignFrameworkCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let frameworkPath = results[safe: 0] else { return nil }
-            return CodesignFrameworkCaptureGroup(frameworkPath: frameworkPath)
-
-        case CompileCaptureGroup.pattern:
-#if os(Linux)
-            assert(results.count >= 2)
-            guard let fileName = results[safe: 1], let target = results.last else { return nil }
-            return CompileCaptureGroup(filename: fileName, target: target)
-#else
-            assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return nil }
-            return CompileCaptureGroup(filePath: filePath, filename: fileName, target: target)
-#endif
-
-        case CompileCommandCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let compilerCommand = results[safe: 0], let filePath = results[safe: 1] else { return nil }
-            return CompileCommandCaptureGroup(compilerCommand: compilerCommand, filePath: filePath)
-
-        case CompileXibCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return nil }
-            return CompileXibCaptureGroup(filePath: filePath, filename: fileName, target: target)
-
-        case CompileStoryboardCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let target = results.last else { return nil }
-            return CompileStoryboardCaptureGroup(filePath: filePath, filename: fileName, target: target)
-
-        case CopyHeaderCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let file = results[safe: 0], let targetFile = results[safe: 1], let target = results.last else { return nil }
-            return CopyHeaderCaptureGroup(file: file.lastPathComponent, targetFile: targetFile, target: target)
-
-        case CopyPlistCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let file = results[safe: 0], let target = results.last else { return nil }
-            return CopyPlistCaptureGroup(file: file.lastPathComponent, target: target)
-
-        case CopyStringsCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let file = results[safe: 0], let target = results.last else { return nil }
-            return CopyStringsCaptureGroup(file: file.lastPathComponent, target: target)
-
-        case CpresourceCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let file = results[safe: 0], let target = results.last else { return nil }
-            return CpresourceCaptureGroup(file: file.lastPathComponent, target: target)
-
-        case ExecutedWithoutSkippedCaptureGroup.pattern:
-            assert(results.count >= 4)
-            guard let _numberOfTests = results[safe: 0], let _numberOfFailures = results[safe: 1], let _numberOfUnexpectedFailures = results[safe: 2], let _wallClockTimeInSeconds = results[safe: 3] else { return nil }
-            guard let numberOfTests = Int(_numberOfTests), let numberOfFailures = Int(_numberOfFailures), let numberOfUnexpectedFailures = Int(_numberOfUnexpectedFailures), let wallClockTimeInSeconds = Double(_wallClockTimeInSeconds) else { return nil }
-            return ExecutedWithoutSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
-
-        case ExecutedWithSkippedCaptureGroup.pattern:
-            assert(results.count >= 5)
-            guard let _numberOfTests = results[safe: 0], let _numberOfSkipped = results[safe: 1], let _numberOfFailures = results[safe: 2], let _numberOfUnexpectedFailures = results[safe: 3], let _wallClockTimeInSeconds = results[safe: 4] else { return nil }
-            guard let numberOfTests = Int(_numberOfTests), let numberOfSkipped = Int(_numberOfSkipped), let numberOfFailures = Int(_numberOfFailures), let numberOfUnexpectedFailures = Int(_numberOfUnexpectedFailures), let wallClockTimeInSeconds = Double(_wallClockTimeInSeconds) else { return nil }
-            return ExecutedWithSkippedCaptureGroup(numberOfTests: numberOfTests, numberOfSkipped: numberOfSkipped, numberOfFailures: numberOfFailures, numberOfUnexpectedFailures: numberOfUnexpectedFailures, wallClockTimeInSeconds: wallClockTimeInSeconds)
-
-        case FailingTestCaptureGroup.pattern:
-            assert(results.count >= 4)
-            guard let file = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2], let reason = results[safe: 3] else { return nil }
-            return FailingTestCaptureGroup(file: file, testSuite: testSuite, testCase: testCase, reason: reason)
-
-        case UIFailingTestCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let file = results[safe: 0], let reason = results[safe: 1] else { return nil }
-            return UIFailingTestCaptureGroup(file: file, reason: reason)
-
-        case RestartingTestCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let testSuiteAndTestCase = results[safe: 0], let testSuite = results[safe: 1], let testCase = results[safe: 2] else { return nil }
-            return RestartingTestCaptureGroup(testSuiteAndTestCase: testSuiteAndTestCase, testSuite: testSuite, testCase: testCase)
-
-        case GenerateCoverageDataCaptureGroup.pattern:
-            assert(results.count >= 0)
-            return GenerateCoverageDataCaptureGroup()
-
-        case GeneratedCoverageReportCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let coverageReportFilePath = results[safe: 0] else { return nil }
-            return GeneratedCoverageReportCaptureGroup(coverageReportFilePath: coverageReportFilePath)
-
-        case GenerateDSYMCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let dsym = results[safe: 0], let target = results.last else { return nil }
-            return GenerateDSYMCaptureGroup(dsym: dsym, target: target)
-
-        case LibtoolCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let fileName = results[safe: 0], let target = results.last else { return nil }
-            return LibtoolCaptureGroup(fileName: fileName, target: target)
-
-        case LinkingCaptureGroup.pattern:
-#if os(Linux)
-            assert(results.count >= 1)
-            guard let target = results[safe: 0] else { return nil }
-            return LinkingCaptureGroup(target: target)
-#else
-            assert(results.count >= 2)
-            guard let binaryFileName = results[safe: 0], let target = results.last else { return nil }
-            return LinkingCaptureGroup(binaryFilename: binaryFileName.lastPathComponent, target: target)
-#endif
-
-        case TestCasePassedCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return nil }
-            return TestCasePassedCaptureGroup(suite: suite, testCase: testCase, time: time)
-
-        case TestCaseStartedCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return nil }
-            return TestCaseStartedCaptureGroup(suite: suite, testCase: testCase)
-
-        case TestCasePendingCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1] else { return nil }
-            return TestCasePendingCaptureGroup(suite: suite, testCase: testCase)
-
-        case TestCaseMeasuredCaptureGroup.pattern:
-            assert(results.count >= 6)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let name = results[safe: 2], let unitName = results[safe: 3], let value = results[safe: 4], let deviation = results[safe: 5] else { return nil }
-            return TestCaseMeasuredCaptureGroup(suite: suite, testCase: testCase, name: name, unitName: unitName, value: value, deviation: deviation)
-
-        case ParallelTestCasePassedCaptureGroup.pattern:
-            assert(results.count >= 4)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let device = results[safe: 2], let time = results[safe: 3] else { return nil }
-            return ParallelTestCasePassedCaptureGroup(suite: suite, testCase: testCase, device: device, time: time)
-
-        case ParallelTestCaseAppKitPassedCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let time = results[safe: 2] else { return nil }
-            return ParallelTestCaseAppKitPassedCaptureGroup(suite: suite, testCase: testCase, time: time)
-
-        case ParallelTestCaseFailedCaptureGroup.pattern:
-            assert(results.count >= 4)
-            guard let suite = results[safe: 0], let testCase = results[safe: 1], let device = results[safe: 2], let time = results[safe: 3] else { return nil }
-            return ParallelTestCaseFailedCaptureGroup(suite: suite, testCase: testCase, device: device, time: time)
-
-        case ParallelTestingStartedCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let device = results[safe: 0] else { return nil }
-            return ParallelTestingStartedCaptureGroup(device: device)
-
-        case ParallelTestingPassedCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let device = results[safe: 0] else { return nil }
-            return ParallelTestingPassedCaptureGroup(device: device)
-
-        case ParallelTestingFailedCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let device = results[safe: 0] else { return nil }
-            return ParallelTestingFailedCaptureGroup(device: device)
-
-        case ParallelTestSuiteStartedCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let suite = results[safe: 0], let device = results[safe: 1] else { return nil }
-            return ParallelTestSuiteStartedCaptureGroup(suite: suite, device: device)
-
-        case PhaseSuccessCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let phase = results[safe: 0] else { return nil }
-            return PhaseSuccessCaptureGroup(phase: phase)
-
-        case PhaseScriptExecutionCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let phaseName = results[safe: 0], let target = results.last else { return nil }
-            return PhaseScriptExecutionCaptureGroup(phaseName: phaseName, target: target)
-
-        case ProcessPchCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let file = results[safe: 0], let buildTarget = results.last else { return nil }
-            return ProcessPchCaptureGroup(file: file, buildTarget: buildTarget)
-
-        case ProcessPchCommandCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let filePath = results.last else { return nil }
-            return ProcessPchCommandCaptureGroup(filePath: filePath)
-
-        case PreprocessCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let file = results[safe: 0] else { return nil }
-            return PreprocessCaptureGroup(file: file)
-
-        case PbxcpCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let file = results[safe: 0], let targetFile = results[safe: 1], let target = results.last else { return nil }
-            return PbxcpCaptureGroup(file: file.lastPathComponent, targetFile: targetFile, target: target)
-
-        case ProcessInfoPlistCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1] else { return nil }
-
-            // TODO: Test with target included
-            if results.count == 2 {
-                // Xcode 9 excludes target output
-                return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: nil)
-            } else {
-                // Xcode 10+ includes target output
-                return ProcessInfoPlistCaptureGroup(filePath: filePath, filename: fileName, target: results.last)
-            }
-
-        case TestsRunCompletionCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let suite = results[safe: 0], let result = results[safe: 1], let time = results[safe: 2] else { return nil }
-            return TestsRunCompletionCaptureGroup(suite: suite, result: result, time: time)
-
-        case TestSuiteStartedCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let suite = results[safe: 0], let time = results[safe: 1] else { return nil }
-            return TestSuiteStartedCaptureGroup(suite: suite, time: time)
-
-        case TestSuiteStartCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let testSuiteName = results[safe: 0] else { return nil }
-            return TestSuiteStartCaptureGroup(testSuiteName: testSuiteName)
-
-        case TestSuiteAllTestsPassedCaptureGroup.pattern:
-            assert(results.count >= 0)
-            return TestSuiteAllTestsPassedCaptureGroup()
-
-        case TestSuiteAllTestsFailedCaptureGroup.pattern:
-            assert(results.count >= 0)
-            return TestSuiteAllTestsFailedCaptureGroup()
-
-        case TIFFutilCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let fileName = results[safe: 0] else { return nil }
-            return TIFFutilCaptureGroup(filename: fileName)
-
-        case TouchCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let fileName = results[safe: 1], let target = results.last else { return nil }
-            return TouchCaptureGroup(filename: fileName, target: target)
-
-        case WriteFileCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let filePath = results[safe: 0] else { return nil }
-            return WriteFileCaptureGroup(filePath: filePath)
-
-        case WriteAuxiliaryFilesCaptureGroup.pattern:
-            assert(results.count >= 0)
-            return WriteAuxiliaryFilesCaptureGroup()
-
-        case CompileWarningCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let fileName = results[safe: 1], let reason = results[safe: 2] else { return nil }
-            return CompileWarningCaptureGroup(filePath: filePath, filename: fileName, reason: reason)
-
-        case LDWarningCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let ldPrefix = results[safe: 0], let warningMessage = results[safe: 1] else { return nil }
-            return LDWarningCaptureGroup(ldPrefix: ldPrefix, warningMessage: warningMessage)
-
-        case GenericWarningCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeWarning = results[safe: 0] else { return nil }
-            return GenericWarningCaptureGroup(wholeWarning: wholeWarning)
-
-        case WillNotBeCodeSignedCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeWarning = results[safe: 0] else { return nil }
-            return WillNotBeCodeSignedCaptureGroup(wholeWarning: wholeWarning)
-
-        case DuplicateLocalizedStringKeyCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeMessage = results[safe: 0] else { return nil }
-            return DuplicateLocalizedStringKeyCaptureGroup(warningMessage: wholeMessage)
-
-        case ClangErrorCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return nil }
-            return ClangErrorCaptureGroup(wholeError: wholeError)
-
-        case CheckDependenciesErrorsCaptureGroup.pattern:
-            assert(results.count >= 0)
-            return CheckDependenciesCaptureGroup()
-
-        case ProvisioningProfileRequiredCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return nil }
-            return ProvisioningProfileRequiredCaptureGroup(wholeError: wholeError)
-
-        case NoCertificateCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return nil }
-            return NoCertificateCaptureGroup(wholeError: wholeError)
-
-        case CompileErrorCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let filePath = results[safe: 0], let isFatalError = results[safe: 1], let reason = results[safe: 2] else { return nil }
-            return CompileErrorCaptureGroup(filePath: filePath, isFatalError: isFatalError, reason: reason)
-
-        case CursorCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let cursor = results[safe: 0] else { return nil }
-            return CursorCaptureGroup(cursor: cursor)
-
-        case FatalErrorCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return nil }
-            return FatalErrorCaptureGroup(wholeError: wholeError)
-
-        case FileMissingErrorCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let reason = results[safe: 0], let filePath = results[safe: 1] else { return nil }
-            return FileMissingErrorCaptureGroup(reason: reason, filePath: filePath)
-
-        case LDErrorCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return nil }
-            return LDErrorCaptureGroup(wholeError: wholeError)
-
-        case LinkerDuplicateSymbolsLocationCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return nil }
-            return LinkerDuplicateSymbolsLocationCaptureGroup(wholeError: wholeError)
-
-        case LinkerDuplicateSymbolsCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let reason = results[safe: 0] else { return nil }
-            return LinkerDuplicateSymbolsCaptureGroup(reason: reason)
-
-        case LinkerUndefinedSymbolLocationCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let reason = results[safe: 0] else { return nil }
-            return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
-
-        case LinkerUndefinedSymbolsCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let reason = results[safe: 0] else { return nil }
-            return LinkerUndefinedSymbolsCaptureGroup(reason: reason)
-
-        case PodsErrorCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return nil }
-            return PodsErrorCaptureGroup(wholeError: wholeError)
-
-        case SymbolReferencedFromCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let reference = results[safe: 0] else { return nil }
-            return SymbolReferencedFromCaptureGroup(reference: reference)
-
-        case ModuleIncludesErrorCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return nil }
-            return ModuleIncludesErrorCaptureGroup(wholeError: wholeError)
-
-        case UndefinedSymbolLocationCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let target = results[safe: 0], let fileName = results[safe: 1] else { return nil }
-            return UndefinedSymbolLocationCaptureGroup(target: target, filename: fileName)
-
-        case PackageFetchingCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let source = results[safe: 0] else { return nil }
-            return PackageFetchingCaptureGroup(source: source)
-
-        case PackageUpdatingCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let source = results[safe: 0] else { return nil }
-            return PackageUpdatingCaptureGroup(source: source)
-
-        case PackageCheckingOutCaptureGroup.pattern:
-            assert(results.count >= 2)
-            guard let version = results[safe: 0], let package = results[safe: 1] else { return nil }
-            return PackageCheckingOutCaptureGroup(version: version, package: package)
-
-        case PackageGraphResolvingStartCaptureGroup.pattern:
-            assert(results.count >= 0)
-            return PackageGraphResolvingStartCaptureGroup()
-
-        case PackageGraphResolvingEndedCaptureGroup.pattern:
-            assert(results.count >= 0)
-            return PackageGraphResolvingEndedCaptureGroup()
-
-        case PackageGraphResolvedItemCaptureGroup.pattern:
-            assert(results.count >= 3)
-            guard let packageName = results[safe: 0], let packageURL = results[safe: 1], let packageVersion = results[safe: 2] else { return nil }
-            return PackageGraphResolvedItemCaptureGroup(packageName: packageName, packageURL: packageURL, packageVersion: packageVersion)
+        case AnalyzeCaptureGroup.pattern:            
+            return AnalyzeCaptureGroup(groups: results)
+
+        case BuildTargetCaptureGroup.pattern:            
+            return BuildTargetCaptureGroup(groups: results)
+
+        case AggregateTargetCaptureGroup.pattern:            
+            return AggregateTargetCaptureGroup(groups: results)
+
+        case AnalyzeTargetCaptureGroup.pattern:            
+            return AnalyzeTargetCaptureGroup(groups: results)
+
+        case CheckDependenciesCaptureGroup.pattern:            
+            return CheckDependenciesCaptureGroup(groups: results)
+
+        case ShellCommandCaptureGroup.pattern:            
+            return ShellCommandCaptureGroup(groups: results)
+
+        case CleanRemoveCaptureGroup.pattern:            
+            return CleanRemoveCaptureGroup(groups: results)
+
+        case CleanTargetCaptureGroup.pattern:            
+            return CleanTargetCaptureGroup(groups: results)
+
+        case CodesignCaptureGroup.pattern:            
+            return CodesignCaptureGroup(groups: results)
+
+        case CodesignFrameworkCaptureGroup.pattern:            
+            return CodesignFrameworkCaptureGroup(groups: results)
+
+        case CompileCaptureGroup.pattern:            
+            return CompileCaptureGroup(groups: results)
+
+        case CompileCommandCaptureGroup.pattern:            
+            return CompileCommandCaptureGroup(groups: results)
+
+        case CompileXibCaptureGroup.pattern:            
+            return CompileXibCaptureGroup(groups: results)
+
+        case CompileStoryboardCaptureGroup.pattern:            
+            return CompileStoryboardCaptureGroup(groups: results)
+
+        case CopyHeaderCaptureGroup.pattern:            
+            return CopyHeaderCaptureGroup(groups: results)
+
+        case CopyPlistCaptureGroup.pattern:            
+            return CopyPlistCaptureGroup(groups: results)
+
+        case CopyStringsCaptureGroup.pattern:            
+            return CopyStringsCaptureGroup(groups: results)
+
+        case CpresourceCaptureGroup.pattern:            
+            return CpresourceCaptureGroup(groups: results)
+
+        case ExecutedWithoutSkippedCaptureGroup.pattern:            
+            return ExecutedWithoutSkippedCaptureGroup(groups: results)
+
+        case ExecutedWithSkippedCaptureGroup.pattern:            
+            return ExecutedWithSkippedCaptureGroup(groups: results)
+
+        case FailingTestCaptureGroup.pattern:            
+            return FailingTestCaptureGroup(groups: results)
+
+        case UIFailingTestCaptureGroup.pattern:            
+            return UIFailingTestCaptureGroup(groups: results)
+
+        case RestartingTestCaptureGroup.pattern:            
+            return RestartingTestCaptureGroup(groups: results)
+
+        case GenerateCoverageDataCaptureGroup.pattern:            
+            return GenerateCoverageDataCaptureGroup(groups: results)
+
+        case GeneratedCoverageReportCaptureGroup.pattern:            
+            return GeneratedCoverageReportCaptureGroup(groups: results)
+
+        case GenerateDSYMCaptureGroup.pattern:            
+            return GenerateDSYMCaptureGroup(groups: results)
+
+        case LibtoolCaptureGroup.pattern:            
+            return LibtoolCaptureGroup(groups: results)
+            
+        case LinkingCaptureGroup.pattern:            
+            return LinkingCaptureGroup(groups: results)
+
+        case TestCasePassedCaptureGroup.pattern:            
+            return TestCasePassedCaptureGroup(groups: results)
+
+        case TestCaseStartedCaptureGroup.pattern:            
+            return TestCaseStartedCaptureGroup(groups: results)
+
+        case TestCasePendingCaptureGroup.pattern:            
+            return TestCasePendingCaptureGroup(groups: results)
+
+        case TestCaseMeasuredCaptureGroup.pattern:            
+            return TestCaseMeasuredCaptureGroup(groups: results)
+
+        case ParallelTestCasePassedCaptureGroup.pattern:            
+            return ParallelTestCasePassedCaptureGroup(groups: results)
+
+        case ParallelTestCaseAppKitPassedCaptureGroup.pattern:            
+            return ParallelTestCaseAppKitPassedCaptureGroup(groups: results)
+
+        case ParallelTestCaseFailedCaptureGroup.pattern:            
+            return ParallelTestCaseFailedCaptureGroup(groups: results)
+
+        case ParallelTestingStartedCaptureGroup.pattern:            
+            return ParallelTestingStartedCaptureGroup(groups: results)
+
+        case ParallelTestingPassedCaptureGroup.pattern:            
+            return ParallelTestingPassedCaptureGroup(groups: results)
+
+        case ParallelTestingFailedCaptureGroup.pattern:            
+            return ParallelTestingFailedCaptureGroup(groups: results)
+
+        case ParallelTestSuiteStartedCaptureGroup.pattern:            
+            return ParallelTestSuiteStartedCaptureGroup(groups: results)
+
+        case PhaseSuccessCaptureGroup.pattern:            
+            return PhaseSuccessCaptureGroup(groups: results)
+
+        case PhaseScriptExecutionCaptureGroup.pattern:            
+            return PhaseScriptExecutionCaptureGroup(groups: results)
+
+        case ProcessPchCaptureGroup.pattern:            
+            return ProcessPchCaptureGroup(groups: results)
+
+        case ProcessPchCommandCaptureGroup.pattern:            
+            return ProcessPchCommandCaptureGroup(groups: results)
+
+        case PreprocessCaptureGroup.pattern:            
+            return PreprocessCaptureGroup(groups: results)
+
+        case PbxcpCaptureGroup.pattern:            
+            return PbxcpCaptureGroup(groups: results)
+
+        case ProcessInfoPlistCaptureGroup.pattern:            
+            return ProcessInfoPlistCaptureGroup(groups: results)
+
+        case TestsRunCompletionCaptureGroup.pattern:            
+            return TestsRunCompletionCaptureGroup(groups: results)
+
+        case TestSuiteStartedCaptureGroup.pattern:            
+            return TestSuiteStartedCaptureGroup(groups: results)
+
+        case TestSuiteStartCaptureGroup.pattern:            
+            return TestSuiteStartCaptureGroup(groups: results)
+
+        case TestSuiteAllTestsPassedCaptureGroup.pattern:            
+            return TestSuiteAllTestsPassedCaptureGroup(groups: results)
+
+        case TestSuiteAllTestsFailedCaptureGroup.pattern:            
+            return TestSuiteAllTestsFailedCaptureGroup(groups: results)
+
+        case TIFFutilCaptureGroup.pattern:            
+            return TIFFutilCaptureGroup(groups: results)
+
+        case TouchCaptureGroup.pattern:            
+            return TouchCaptureGroup(groups: results)
+
+        case WriteFileCaptureGroup.pattern:            
+            return WriteFileCaptureGroup(groups: results)
+
+        case WriteAuxiliaryFilesCaptureGroup.pattern:            
+            return WriteAuxiliaryFilesCaptureGroup(groups: results)
+
+        case CompileWarningCaptureGroup.pattern:            
+            return CompileWarningCaptureGroup(groups: results)
+
+        case LDWarningCaptureGroup.pattern:            
+            return LDWarningCaptureGroup(groups: results)
+
+        case GenericWarningCaptureGroup.pattern:            
+            return GenericWarningCaptureGroup(groups: results)
+
+        case WillNotBeCodeSignedCaptureGroup.pattern:            
+            return WillNotBeCodeSignedCaptureGroup(groups: results)
+
+        case DuplicateLocalizedStringKeyCaptureGroup.pattern:            
+            return DuplicateLocalizedStringKeyCaptureGroup(groups: results)
+
+        case ClangErrorCaptureGroup.pattern:            
+            return ClangErrorCaptureGroup(groups: results)
+
+        case CheckDependenciesErrorsCaptureGroup.pattern:            
+            return CheckDependenciesErrorsCaptureGroup(groups: results)
+
+        case ProvisioningProfileRequiredCaptureGroup.pattern:            
+            return ProvisioningProfileRequiredCaptureGroup(groups: results)
+
+        case NoCertificateCaptureGroup.pattern:            
+            return NoCertificateCaptureGroup(groups: results)
+
+        case CompileErrorCaptureGroup.pattern:            
+            return CompileErrorCaptureGroup(groups: results)
+
+        case CursorCaptureGroup.pattern:            
+            return CursorCaptureGroup(groups: results)
+
+        case FatalErrorCaptureGroup.pattern:            
+            return FatalErrorCaptureGroup(groups: results)
+
+        case FileMissingErrorCaptureGroup.pattern:            
+            return FileMissingErrorCaptureGroup(groups: results)
+
+        case LDErrorCaptureGroup.pattern:            
+            return LDErrorCaptureGroup(groups: results)
+
+        case LinkerDuplicateSymbolsLocationCaptureGroup.pattern:            
+            return LinkerDuplicateSymbolsLocationCaptureGroup(groups: results)
+
+        case LinkerDuplicateSymbolsCaptureGroup.pattern:            
+            return LinkerDuplicateSymbolsCaptureGroup(groups: results)
+
+        case LinkerUndefinedSymbolLocationCaptureGroup.pattern:            
+            return LinkerUndefinedSymbolLocationCaptureGroup(groups: results)
+
+        case LinkerUndefinedSymbolsCaptureGroup.pattern:            
+            return LinkerUndefinedSymbolsCaptureGroup(groups: results)
+
+        case PodsErrorCaptureGroup.pattern:            
+            return PodsErrorCaptureGroup(groups: results)
+
+        case SymbolReferencedFromCaptureGroup.pattern:            
+            return SymbolReferencedFromCaptureGroup(groups: results)
+
+        case ModuleIncludesErrorCaptureGroup.pattern:            
+            return ModuleIncludesErrorCaptureGroup(groups: results)
+
+        case UndefinedSymbolLocationCaptureGroup.pattern:            
+            return UndefinedSymbolLocationCaptureGroup(groups: results)
+
+        case PackageFetchingCaptureGroup.pattern:            
+            return PackageFetchingCaptureGroup(groups: results)
+
+        case PackageUpdatingCaptureGroup.pattern:            
+            return PackageUpdatingCaptureGroup(groups: results)
+
+        case PackageCheckingOutCaptureGroup.pattern:            
+            return PackageCheckingOutCaptureGroup(groups: results)
+
+        case PackageGraphResolvingStartCaptureGroup.pattern:            
+            return PackageGraphResolvingStartCaptureGroup(groups: results)
+
+        case PackageGraphResolvingEndedCaptureGroup.pattern:            
+            return PackageGraphResolvingEndedCaptureGroup(groups: results)
+
+        case PackageGraphResolvedItemCaptureGroup.pattern:            
+            return PackageGraphResolvedItemCaptureGroup(groups: results)
 
         case XcodebuildErrorCaptureGroup.pattern:
-            assert(results.count >= 1)
-            guard let wholeError = results[safe: 0] else { return nil }
-            return XcodebuildErrorCaptureGroup(wholeError: wholeError)
+            return XcodebuildErrorCaptureGroup(groups: results)
 
         default:
             assertionFailure()

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -26,262 +26,104 @@ extension String {
     func captureGroup(with pattern: String) -> CaptureGroup? {
         let results: [String] = captureGroup(with: pattern)
 
-        switch pattern {
-        case AnalyzeCaptureGroup.pattern:            
-            return AnalyzeCaptureGroup(groups: results)
-
-        case BuildTargetCaptureGroup.pattern:            
-            return BuildTargetCaptureGroup(groups: results)
-
-        case AggregateTargetCaptureGroup.pattern:            
-            return AggregateTargetCaptureGroup(groups: results)
-
-        case AnalyzeTargetCaptureGroup.pattern:            
-            return AnalyzeTargetCaptureGroup(groups: results)
-
-        case CheckDependenciesCaptureGroup.pattern:            
-            return CheckDependenciesCaptureGroup(groups: results)
-
-        case ShellCommandCaptureGroup.pattern:            
-            return ShellCommandCaptureGroup(groups: results)
-
-        case CleanRemoveCaptureGroup.pattern:            
-            return CleanRemoveCaptureGroup(groups: results)
-
-        case CleanTargetCaptureGroup.pattern:            
-            return CleanTargetCaptureGroup(groups: results)
-
-        case CodesignCaptureGroup.pattern:            
-            return CodesignCaptureGroup(groups: results)
-
-        case CodesignFrameworkCaptureGroup.pattern:            
-            return CodesignFrameworkCaptureGroup(groups: results)
-
-        case CompileCaptureGroup.pattern:            
-            return CompileCaptureGroup(groups: results)
-
-        case CompileCommandCaptureGroup.pattern:            
-            return CompileCommandCaptureGroup(groups: results)
-
-        case CompileXibCaptureGroup.pattern:            
-            return CompileXibCaptureGroup(groups: results)
-
-        case CompileStoryboardCaptureGroup.pattern:            
-            return CompileStoryboardCaptureGroup(groups: results)
-
-        case CopyHeaderCaptureGroup.pattern:            
-            return CopyHeaderCaptureGroup(groups: results)
-
-        case CopyPlistCaptureGroup.pattern:            
-            return CopyPlistCaptureGroup(groups: results)
-
-        case CopyStringsCaptureGroup.pattern:            
-            return CopyStringsCaptureGroup(groups: results)
-
-        case CpresourceCaptureGroup.pattern:            
-            return CpresourceCaptureGroup(groups: results)
-
-        case ExecutedWithoutSkippedCaptureGroup.pattern:            
-            return ExecutedWithoutSkippedCaptureGroup(groups: results)
-
-        case ExecutedWithSkippedCaptureGroup.pattern:            
-            return ExecutedWithSkippedCaptureGroup(groups: results)
-
-        case FailingTestCaptureGroup.pattern:            
-            return FailingTestCaptureGroup(groups: results)
-
-        case UIFailingTestCaptureGroup.pattern:            
-            return UIFailingTestCaptureGroup(groups: results)
-
-        case RestartingTestCaptureGroup.pattern:            
-            return RestartingTestCaptureGroup(groups: results)
-
-        case GenerateCoverageDataCaptureGroup.pattern:            
-            return GenerateCoverageDataCaptureGroup(groups: results)
-
-        case GeneratedCoverageReportCaptureGroup.pattern:            
-            return GeneratedCoverageReportCaptureGroup(groups: results)
-
-        case GenerateDSYMCaptureGroup.pattern:            
-            return GenerateDSYMCaptureGroup(groups: results)
-
-        case LibtoolCaptureGroup.pattern:            
-            return LibtoolCaptureGroup(groups: results)
-            
-        case LinkingCaptureGroup.pattern:            
-            return LinkingCaptureGroup(groups: results)
-
-        case TestCasePassedCaptureGroup.pattern:            
-            return TestCasePassedCaptureGroup(groups: results)
-
-        case TestCaseStartedCaptureGroup.pattern:            
-            return TestCaseStartedCaptureGroup(groups: results)
-
-        case TestCasePendingCaptureGroup.pattern:            
-            return TestCasePendingCaptureGroup(groups: results)
-
-        case TestCaseMeasuredCaptureGroup.pattern:            
-            return TestCaseMeasuredCaptureGroup(groups: results)
-
-        case ParallelTestCasePassedCaptureGroup.pattern:            
-            return ParallelTestCasePassedCaptureGroup(groups: results)
-
-        case ParallelTestCaseAppKitPassedCaptureGroup.pattern:            
-            return ParallelTestCaseAppKitPassedCaptureGroup(groups: results)
-
-        case ParallelTestCaseFailedCaptureGroup.pattern:            
-            return ParallelTestCaseFailedCaptureGroup(groups: results)
-
-        case ParallelTestingStartedCaptureGroup.pattern:            
-            return ParallelTestingStartedCaptureGroup(groups: results)
-
-        case ParallelTestingPassedCaptureGroup.pattern:            
-            return ParallelTestingPassedCaptureGroup(groups: results)
-
-        case ParallelTestingFailedCaptureGroup.pattern:            
-            return ParallelTestingFailedCaptureGroup(groups: results)
-
-        case ParallelTestSuiteStartedCaptureGroup.pattern:            
-            return ParallelTestSuiteStartedCaptureGroup(groups: results)
-
-        case PhaseSuccessCaptureGroup.pattern:            
-            return PhaseSuccessCaptureGroup(groups: results)
-
-        case PhaseScriptExecutionCaptureGroup.pattern:            
-            return PhaseScriptExecutionCaptureGroup(groups: results)
-
-        case ProcessPchCaptureGroup.pattern:            
-            return ProcessPchCaptureGroup(groups: results)
-
-        case ProcessPchCommandCaptureGroup.pattern:            
-            return ProcessPchCommandCaptureGroup(groups: results)
-
-        case PreprocessCaptureGroup.pattern:            
-            return PreprocessCaptureGroup(groups: results)
-
-        case PbxcpCaptureGroup.pattern:            
-            return PbxcpCaptureGroup(groups: results)
-
-        case ProcessInfoPlistCaptureGroup.pattern:            
-            return ProcessInfoPlistCaptureGroup(groups: results)
-
-        case TestsRunCompletionCaptureGroup.pattern:            
-            return TestsRunCompletionCaptureGroup(groups: results)
-
-        case TestSuiteStartedCaptureGroup.pattern:            
-            return TestSuiteStartedCaptureGroup(groups: results)
-
-        case TestSuiteStartCaptureGroup.pattern:            
-            return TestSuiteStartCaptureGroup(groups: results)
-
-        case TestSuiteAllTestsPassedCaptureGroup.pattern:            
-            return TestSuiteAllTestsPassedCaptureGroup(groups: results)
-
-        case TestSuiteAllTestsFailedCaptureGroup.pattern:            
-            return TestSuiteAllTestsFailedCaptureGroup(groups: results)
-
-        case TIFFutilCaptureGroup.pattern:            
-            return TIFFutilCaptureGroup(groups: results)
-
-        case TouchCaptureGroup.pattern:            
-            return TouchCaptureGroup(groups: results)
-
-        case WriteFileCaptureGroup.pattern:            
-            return WriteFileCaptureGroup(groups: results)
-
-        case WriteAuxiliaryFilesCaptureGroup.pattern:            
-            return WriteAuxiliaryFilesCaptureGroup(groups: results)
-
-        case CompileWarningCaptureGroup.pattern:            
-            return CompileWarningCaptureGroup(groups: results)
-
-        case LDWarningCaptureGroup.pattern:            
-            return LDWarningCaptureGroup(groups: results)
-
-        case GenericWarningCaptureGroup.pattern:            
-            return GenericWarningCaptureGroup(groups: results)
-
-        case WillNotBeCodeSignedCaptureGroup.pattern:            
-            return WillNotBeCodeSignedCaptureGroup(groups: results)
-
-        case DuplicateLocalizedStringKeyCaptureGroup.pattern:            
-            return DuplicateLocalizedStringKeyCaptureGroup(groups: results)
-
-        case ClangErrorCaptureGroup.pattern:            
-            return ClangErrorCaptureGroup(groups: results)
-
-        case CheckDependenciesErrorsCaptureGroup.pattern:            
-            return CheckDependenciesErrorsCaptureGroup(groups: results)
-
-        case ProvisioningProfileRequiredCaptureGroup.pattern:            
-            return ProvisioningProfileRequiredCaptureGroup(groups: results)
-
-        case NoCertificateCaptureGroup.pattern:            
-            return NoCertificateCaptureGroup(groups: results)
-
-        case CompileErrorCaptureGroup.pattern:            
-            return CompileErrorCaptureGroup(groups: results)
-
-        case CursorCaptureGroup.pattern:            
-            return CursorCaptureGroup(groups: results)
-
-        case FatalErrorCaptureGroup.pattern:            
-            return FatalErrorCaptureGroup(groups: results)
-
-        case FileMissingErrorCaptureGroup.pattern:            
-            return FileMissingErrorCaptureGroup(groups: results)
-
-        case LDErrorCaptureGroup.pattern:            
-            return LDErrorCaptureGroup(groups: results)
-
-        case LinkerDuplicateSymbolsLocationCaptureGroup.pattern:            
-            return LinkerDuplicateSymbolsLocationCaptureGroup(groups: results)
-
-        case LinkerDuplicateSymbolsCaptureGroup.pattern:            
-            return LinkerDuplicateSymbolsCaptureGroup(groups: results)
-
-        case LinkerUndefinedSymbolLocationCaptureGroup.pattern:            
-            return LinkerUndefinedSymbolLocationCaptureGroup(groups: results)
-
-        case LinkerUndefinedSymbolsCaptureGroup.pattern:            
-            return LinkerUndefinedSymbolsCaptureGroup(groups: results)
-
-        case PodsErrorCaptureGroup.pattern:            
-            return PodsErrorCaptureGroup(groups: results)
-
-        case SymbolReferencedFromCaptureGroup.pattern:            
-            return SymbolReferencedFromCaptureGroup(groups: results)
-
-        case ModuleIncludesErrorCaptureGroup.pattern:            
-            return ModuleIncludesErrorCaptureGroup(groups: results)
-
-        case UndefinedSymbolLocationCaptureGroup.pattern:            
-            return UndefinedSymbolLocationCaptureGroup(groups: results)
-
-        case PackageFetchingCaptureGroup.pattern:            
-            return PackageFetchingCaptureGroup(groups: results)
-
-        case PackageUpdatingCaptureGroup.pattern:            
-            return PackageUpdatingCaptureGroup(groups: results)
-
-        case PackageCheckingOutCaptureGroup.pattern:            
-            return PackageCheckingOutCaptureGroup(groups: results)
-
-        case PackageGraphResolvingStartCaptureGroup.pattern:            
-            return PackageGraphResolvingStartCaptureGroup(groups: results)
-
-        case PackageGraphResolvingEndedCaptureGroup.pattern:            
-            return PackageGraphResolvingEndedCaptureGroup(groups: results)
-
-        case PackageGraphResolvedItemCaptureGroup.pattern:            
-            return PackageGraphResolvedItemCaptureGroup(groups: results)
-
-        case XcodebuildErrorCaptureGroup.pattern:
-            return XcodebuildErrorCaptureGroup(groups: results)
-
-        default:
+        let captureGroups: [any CaptureGroup.Type] = [
+            AnalyzeCaptureGroup.self,
+            BuildTargetCaptureGroup.self,
+            AggregateTargetCaptureGroup.self,
+            AnalyzeTargetCaptureGroup.self,
+            CheckDependenciesCaptureGroup.self,
+            ShellCommandCaptureGroup.self,
+            CleanRemoveCaptureGroup.self,
+            CleanTargetCaptureGroup.self,
+            CodesignCaptureGroup.self,
+            CodesignFrameworkCaptureGroup.self,
+            CompileCaptureGroup.self,
+            CompileCommandCaptureGroup.self,
+            CompileXibCaptureGroup.self,
+            CompileStoryboardCaptureGroup.self,
+            CopyHeaderCaptureGroup.self,
+            CopyPlistCaptureGroup.self,
+            CopyStringsCaptureGroup.self,
+            CpresourceCaptureGroup.self,
+            ExecutedWithoutSkippedCaptureGroup.self,
+            ExecutedWithSkippedCaptureGroup.self,
+            FailingTestCaptureGroup.self,
+            UIFailingTestCaptureGroup.self,
+            RestartingTestCaptureGroup.self,
+            GenerateCoverageDataCaptureGroup.self,
+            GeneratedCoverageReportCaptureGroup.self,
+            GenerateDSYMCaptureGroup.self,
+            LibtoolCaptureGroup.self,
+            LinkingCaptureGroup.self,
+            TestCasePassedCaptureGroup.self,
+            TestCaseStartedCaptureGroup.self,
+            TestCasePendingCaptureGroup.self,
+            TestCaseMeasuredCaptureGroup.self,
+            ParallelTestCasePassedCaptureGroup.self,
+            ParallelTestCaseAppKitPassedCaptureGroup.self,
+            ParallelTestCaseFailedCaptureGroup.self,
+            ParallelTestingStartedCaptureGroup.self,
+            ParallelTestingPassedCaptureGroup.self,
+            ParallelTestingFailedCaptureGroup.self,
+            ParallelTestSuiteStartedCaptureGroup.self,
+            PhaseSuccessCaptureGroup.self,
+            PhaseScriptExecutionCaptureGroup.self,
+            ProcessPchCaptureGroup.self,
+            ProcessPchCommandCaptureGroup.self,
+            PreprocessCaptureGroup.self,
+            PbxcpCaptureGroup.self,
+            ProcessInfoPlistCaptureGroup.self,
+            TestsRunCompletionCaptureGroup.self,
+            TestSuiteStartedCaptureGroup.self,
+            TestSuiteStartCaptureGroup.self,
+            TestSuiteAllTestsPassedCaptureGroup.self,
+            TestSuiteAllTestsFailedCaptureGroup.self,
+            TIFFutilCaptureGroup.self,
+            TouchCaptureGroup.self,
+            WriteFileCaptureGroup.self,
+            WriteAuxiliaryFilesCaptureGroup.self,
+            CompileWarningCaptureGroup.self,
+            LDWarningCaptureGroup.self,
+            GenericWarningCaptureGroup.self,
+            WillNotBeCodeSignedCaptureGroup.self,
+            DuplicateLocalizedStringKeyCaptureGroup.self,
+            ClangErrorCaptureGroup.self,
+            CheckDependenciesErrorsCaptureGroup.self,
+            ProvisioningProfileRequiredCaptureGroup.self,
+            NoCertificateCaptureGroup.self,
+            CompileErrorCaptureGroup.self,
+            CursorCaptureGroup.self,
+            FatalErrorCaptureGroup.self,
+            FileMissingErrorCaptureGroup.self,
+            LDErrorCaptureGroup.self,
+            LinkerDuplicateSymbolsLocationCaptureGroup.self,
+            LinkerDuplicateSymbolsCaptureGroup.self,
+            LinkerUndefinedSymbolLocationCaptureGroup.self,
+            LinkerUndefinedSymbolsCaptureGroup.self,
+            PodsErrorCaptureGroup.self,
+            SymbolReferencedFromCaptureGroup.self,
+            ModuleIncludesErrorCaptureGroup.self,
+            UndefinedSymbolLocationCaptureGroup.self,
+            PackageFetchingCaptureGroup.self,
+            PackageUpdatingCaptureGroup.self,
+            PackageCheckingOutCaptureGroup.self,
+            PackageGraphResolvingStartCaptureGroup.self,
+            PackageGraphResolvingEndedCaptureGroup.self,
+            PackageGraphResolvedItemCaptureGroup.self,
+            XcodebuildErrorCaptureGroup.self,
+        ]
+
+        let captureGroupType: CaptureGroup.Type? = captureGroups.first { captureGroup in
+            captureGroup.pattern == pattern
+        }
+
+        guard let captureGroupType else {
             assertionFailure()
             return nil
         }
+
+        let captureGroup = captureGroupType.init(groups: results)
+        assert(captureGroup != nil)
+        return captureGroup
     }
 }


### PR DESCRIPTION
This is one step of a larger effort to simplify xcbeautify. This PR moves the logic to initialize CaptureGroups from captured regex groups to their respective CaptureGroups.