### PR TITLE
Treat Warnings as Errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           swift-version: ${{ matrix.swift_version }}
       - uses: actions/checkout@v4
-      - run: swift build --disable-sandbox --configuration release
+      - run: swift build --disable-sandbox --configuration release -Xswiftc -warnings-as-errors
 
   test:
     name: Test (${{ matrix.platform}})


### PR DESCRIPTION
On CI, check that the release configuration compiles without compiler warnings.