### PR TITLE
Use Package Access Modifier

### DIFF
--- a/Sources/XcbeautifyLib/Constants.swift
+++ b/Sources/XcbeautifyLib/Constants.swift
@@ -20,7 +20,7 @@ enum Symbol {
 
 /// Specifies the xcodebuild console output type.
 /// As an example, a compiler warning, a compiler error, a test case, etc.
-public enum OutputType {
+package enum OutputType {
     case undefined
     case task
     case test

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -6,16 +6,16 @@
 import Foundation
 import XMLCoder
 
-public final class JunitReporter {
+package final class JunitReporter {
     private var components: [JunitComponent] = []
     // Parallel output does not guarantee order - so it is _very_ hard
     // to match to the parent suite. We can still capture test success/failure
     // and output a generic result file.
     private var parallelComponents: [JunitComponent] = []
 
-    public init() { }
+    package init() { }
 
-    public func add(line: String) {
+    package func add(line: String) {
         // Remove any preceding or excessive spaces
         let line = line.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -80,7 +80,7 @@ public final class JunitReporter {
         return group.testSuiteName
     }
 
-    public func generateReport() throws -> Data {
+    package func generateReport() throws -> Data {
         let parser = JunitComponentParser()
         components.forEach { parser.parse(component: $0) }
         // Prefix a fake test suite start for the parallel tests.

--- a/Sources/XcbeautifyLib/OutputHandler.swift
+++ b/Sources/XcbeautifyLib/OutputHandler.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class OutputHandler {
+package class OutputHandler {
     let quiet: Bool
     let quieter: Bool
     let isCI: Bool
@@ -16,14 +16,14 @@ public class OutputHandler {
     /// Ref: https://github.com/cpisciotta/xcbeautify/pull/15
     private var lastFormatted: String?
 
-    public init(quiet: Bool, quieter: Bool, isCI: Bool = false, _ writer: @escaping (String) -> Void) {
+    package init(quiet: Bool, quieter: Bool, isCI: Bool = false, _ writer: @escaping (String) -> Void) {
         self.quiet = quiet
         self.quieter = quieter
         self.isCI = isCI
         self.writer = writer
     }
 
-    public func write(_ type: OutputType, _ content: String?) {
+    package func write(_ type: OutputType, _ content: String?) {
         guard let content else { return }
 
         if !quiet, !quieter {

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -1,4 +1,4 @@
-public class Parser {
+package class Parser {
     private let colored: Bool
 
     private let renderer: OutputRendering
@@ -9,9 +9,9 @@ public class Parser {
 
     private(set) var needToRecordSummary = false
 
-    public var preserveUnbeautifiedLines = false
+    private let preserveUnbeautifiedLines: Bool
 
-    public var outputType = OutputType.undefined
+    package private(set) var outputType = OutputType.undefined
 
     private lazy var captureGroupTypes: [CaptureGroup.Type] = [
         AnalyzeCaptureGroup.self,
@@ -98,7 +98,7 @@ public class Parser {
 
     // MARK: - Init
 
-    public init(
+    package init(
         colored: Bool = true,
         renderer: Renderer,
         preserveUnbeautifiedLines: Bool = false,
@@ -117,7 +117,7 @@ public class Parser {
         self.additionalLines = additionalLines
     }
 
-    public func parse(line: String) -> String? {
+    package func parse(line: String) -> String? {
         // Find first parser that can parse specified string
         guard let idx = captureGroupTypes.firstIndex(where: { $0.regex.match(string: line) }) else {
             // Some uncommon cases, which have additional logic and don't follow default flow
@@ -168,7 +168,7 @@ public class Parser {
         return formattedOutput
     }
 
-    public func formattedSummary() -> String? {
+    package func formattedSummary() -> String? {
         guard let summary else { return nil }
         return renderer.format(testSummary: summary)
     }


### PR DESCRIPTION
Downgrade existing types to use the `package` access level modifier. In a future PR, introduce a public type for `XCBeautifyLib` consumers.