### PR TITLE
Add SwiftCompile Support

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -287,6 +287,14 @@ struct SwiftCompileCaptureGroup: CompileFileCaptureGroup {
     }
 }
 
+struct SwiftCompilingCaptureGroup: CaptureGroup {
+    static let outputType: OutputType = .task
+
+    static let regex = Regex(pattern: #"^SwiftCompile \w+ \w+ Compiling\\"#)
+
+    init?(groups: [String]) { }
+}
+
 struct CompileCommandCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -265,6 +265,28 @@ struct CompileCaptureGroup: CompileFileCaptureGroup {
     }
 }
 
+struct SwiftCompileCaptureGroup: CompileFileCaptureGroup {
+    static let outputType: OutputType = .task
+
+    /// Regular expression captured groups:
+    /// $1 = file path
+    /// $2 = filename (e.g. KWNull.m)
+    /// $3 = target
+    static let regex = Regex(pattern: #"^SwiftCompile \w+ \w+ ((?:\.|[^ ])+\/((?:\.|[^ ])+\.(?:m|mm|c|cc|cpp|cxx|swift))) \((in target '(.*)' from project '.*')\)$"#)
+
+    let filePath: String
+    let filename: String
+    let target: String
+
+    init?(groups: [String]) {
+        assert(groups.count >= 3)
+        guard let filePath = groups[safe: 0], let filename = groups[safe: 1], let target = groups.last else { return nil }
+        self.filePath = filePath
+        self.filename = filename
+        self.target = target
+    }
+}
+
 struct CompileCommandCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -25,6 +25,7 @@ package class Parser {
         CodesignCaptureGroup.self,
         CompileCaptureGroup.self,
         SwiftCompileCaptureGroup.self,
+        SwiftCompilingCaptureGroup.self,
         CompileCommandCaptureGroup.self,
         CompileXibCaptureGroup.self,
         CompileStoryboardCaptureGroup.self,

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -24,6 +24,7 @@ package class Parser {
         CodesignFrameworkCaptureGroup.self,
         CodesignCaptureGroup.self,
         CompileCaptureGroup.self,
+        SwiftCompileCaptureGroup.self,
         CompileCommandCaptureGroup.self,
         CompileXibCaptureGroup.self,
         CompileStoryboardCaptureGroup.self,

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -114,6 +114,8 @@ extension OutputRendering {
             return formatCodeSignFramework(group: group)
         case let group as CompileCaptureGroup:
             return formatCompile(group: group)
+        case let group as SwiftCompileCaptureGroup:
+            return formatCompile(group: group)
         case let group as CompileCommandCaptureGroup:
             return formatCompileCommand(group: group)
         case let group as CompileErrorCaptureGroup:

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -13,6 +13,7 @@ protocol OutputRendering {
     func formatCodeSign(group: CodesignCaptureGroup) -> String
     func formatCodeSignFramework(group: CodesignFrameworkCaptureGroup) -> String
     func formatCompile(group: CompileFileCaptureGroup) -> String
+    func formatSwiftCompiling(group: SwiftCompilingCaptureGroup) -> String?
     func formatCompileCommand(group: CompileCommandCaptureGroup) -> String?
     func formatCompileError(group: CompileErrorCaptureGroup, additionalLines: @escaping () -> (String?)) -> String
     func formatCompileWarning(group: CompileWarningCaptureGroup, additionalLines: @escaping () -> (String?)) -> String
@@ -116,6 +117,8 @@ extension OutputRendering {
             return formatCompile(group: group)
         case let group as SwiftCompileCaptureGroup:
             return formatCompile(group: group)
+        case let group as SwiftCompilingCaptureGroup:
+            return formatSwiftCompiling(group: group)
         case let group as CompileCommandCaptureGroup:
             return formatCompileCommand(group: group)
         case let group as CompileErrorCaptureGroup:
@@ -301,6 +304,10 @@ extension OutputRendering {
     }
 
     func formatCompileCommand(group: CompileCommandCaptureGroup) -> String? {
+        nil
+    }
+
+    func formatSwiftCompiling(group: SwiftCompilingCaptureGroup) -> String? {
         nil
     }
 

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -14,6 +14,7 @@ extension String {
         CodesignFrameworkCaptureGroup.self,
         CompileCaptureGroup.self,
         SwiftCompileCaptureGroup.self,
+        SwiftCompilingCaptureGroup.self,
         CompileCommandCaptureGroup.self,
         CompileXibCaptureGroup.self,
         CompileStoryboardCaptureGroup.self,

--- a/Sources/XcbeautifyLib/String+CapturedGroups.swift
+++ b/Sources/XcbeautifyLib/String+CapturedGroups.swift
@@ -13,6 +13,7 @@ extension String {
         CodesignCaptureGroup.self,
         CodesignFrameworkCaptureGroup.self,
         CompileCaptureGroup.self,
+        SwiftCompileCaptureGroup.self,
         CompileCommandCaptureGroup.self,
         CompileXibCaptureGroup.self,
         CompileStoryboardCaptureGroup.self,

--- a/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
+++ b/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
@@ -1,6 +1,6 @@
 //
 //  CaptureGroupTests.swift
-//  
+//
 //
 //  Created by Charles Pisciotta on 2/25/24.
 //
@@ -9,7 +9,6 @@ import XCTest
 @testable import XcbeautifyLib
 
 final class CaptureGroupTests: XCTestCase {
-
     func testSwiftCompiling() {
         let inputs = [
             #"SwiftCompile normal x86_64 Compiling\ BackyardBirdsDataContainer.swift,\ ColorData.swift,\ DataGeneration.swift,\ DataGenerationOptions.swift /Backyard-Birds/BackyardBirdsData/General/BackyardBirdsDataContainer.swift /Backyard-Birds/BackyardBirdsData/General/ColorData.swift /Backyard-Birds/BackyardBirdsData/General/DataGeneration.swift /Backyard-Birds/BackyardBirdsData/General/DataGenerationOptions.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#,
@@ -22,5 +21,4 @@ final class CaptureGroupTests: XCTestCase {
             XCTAssertTrue(SwiftCompilingCaptureGroup.regex.match(string: input))
         }
     }
-
 }

--- a/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
+++ b/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
@@ -1,0 +1,35 @@
+//
+//  CaptureGroupTests.swift
+//  
+//
+//  Created by Charles Pisciotta on 2/25/24.
+//
+
+import XCTest
+
+final class CaptureGroupTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
+++ b/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
@@ -6,29 +6,20 @@
 //
 
 import XCTest
+@testable import XcbeautifyLib
 
 final class CaptureGroupTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
+    func testSwiftCompiling() {
+        let inputs = [
+            #"SwiftCompile normal x86_64 Compiling\ BackyardBirdsDataContainer.swift,\ ColorData.swift,\ DataGeneration.swift,\ DataGenerationOptions.swift /Backyard-Birds/BackyardBirdsData/General/BackyardBirdsDataContainer.swift /Backyard-Birds/BackyardBirdsData/General/ColorData.swift /Backyard-Birds/BackyardBirdsData/General/DataGeneration.swift /Backyard-Birds/BackyardBirdsData/General/DataGenerationOptions.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#,
+            #"SwiftCompile normal x86_64 Compiling\ BackyardSnapshot.swift,\ BackyardSupplies.swift,\ BackyardTimeOfDay.swift,\ BackyardTimeOfDayColors.swift /Backyard-Birds/BackyardBirdsData/Backyards/BackyardSnapshot.swift /Backyard-Birds/BackyardBirdsData/Backyards/BackyardSupplies.swift /Backyard-Birds/BackyardBirdsData/Backyards/BackyardTimeOfDay.swift /Backyard-Birds/BackyardBirdsData/Backyards/BackyardTimeOfDayColors.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#,
+            #"SwiftCompile normal arm64 Compiling\ PlantSpecies.swift,\ PlantSpeciesInfo.swift,\ PassIdentifiers.swift,\ GeneratedAssetSymbols.swift /Backyard-Birds/BackyardBirdsData/Plants/PlantSpecies.swift /Backyard-Birds/BackyardBirdsData/Plants/PlantSpeciesInfo.swift /Backyard-Birds/BackyardBirdsData/Store/PassIdentifiers.swift /Backyard-Birds/Build/Intermediates.noindex/BackyardBirdsData.build/Debug/BackyardBirdsData.build/DerivedSources/GeneratedAssetSymbols.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#,
+            #"SwiftCompile normal arm64 Compiling\ resource_bundle_accessor.swift,\ Account+DataGeneration.swift,\ Account.swift,\ Backyard+DataGeneration.swift,\ Backyard.swift /Backyard-Birds/Build/Intermediates.noindex/BackyardBirdsData.build/Debug/BackyardBirdsData.build/DerivedSources/resource_bundle_accessor.swift /Backyard-Birds/BackyardBirdsData/Account/Account+DataGeneration.swift /Backyard-Birds/BackyardBirdsData/Account/Account.swift /Backyard-Birds/BackyardBirdsData/Backyards/Backyard+DataGeneration.swift /Backyard-Birds/BackyardBirdsData/Backyards/Backyard.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#,
+        ]
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+        for input in inputs {
+            XCTAssertTrue(SwiftCompilingCaptureGroup.regex.match(string: input))
         }
     }
 

--- a/Tests/XcbeautifyLibTests/ParsingTests/ParsingTests.swift
+++ b/Tests/XcbeautifyLibTests/ParsingTests/ParsingTests.swift
@@ -36,7 +36,7 @@ final class ParsingTests: XCTestCase {
         // It uses `XCTAssertEqual` instead of `XCTAssertLessThanOrEqual` as a reminder.
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
-        XCTAssertEqual(uncapturedOutput, 2218)
+        XCTAssertEqual(uncapturedOutput, 2006)
     }
 
     func testLargeXcodebuildLog() throws {
@@ -73,6 +73,6 @@ final class ParsingTests: XCTestCase {
         // It uses `XCTAssertEqual` instead of `XCTAssertLessThanOrEqual` as a reminder.
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
-        XCTAssertEqual(uncapturedOutput, 77104)
+        XCTAssertEqual(uncapturedOutput, 69575)
     }
 }

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -110,9 +110,15 @@ final class GitHubActionsRendererTests: XCTestCase {
         #endif
     }
 
-    func testSwiftCompile() {
+    func testSwiftCompile_arm64() {
         let input = "SwiftCompile normal arm64 /path/to/File.swift (in target 'Target' from project 'Project')"
         let output = "[Target] Compiling File.swift"
+        XCTAssertEqual(logFormatted(input), output)
+    }
+
+    func testSwiftCompile_x86_64() {
+        let input = "SwiftCompile normal x86_64 /Backyard-Birds/Build/Intermediates.noindex/BackyardBirdsData.build/Debug/BackyardBirdsData.build/DerivedSources/resource_bundle_accessor.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"
+        let output = "[BackyardBirdsData] Compiling resource_bundle_accessor.swift"
         XCTAssertEqual(logFormatted(input), output)
     }
 

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -110,6 +110,12 @@ final class GitHubActionsRendererTests: XCTestCase {
         #endif
     }
 
+    func testSwiftCompile() {
+        let input = "SwiftCompile normal arm64 /path/to/File.swift (in target 'Target' from project 'Project')"
+        let output = "[Target] Compiling File.swift"
+        XCTAssertEqual(logFormatted(input), output)
+    }
+
     func testCompileStoryboard() {
         let formatted = logFormatted("CompileStoryboard /Users/admin/MyApp/MyApp/Main.storyboard (in target: MyApp)")
         XCTAssertEqual(formatted, "[MyApp] Compiling Main.storyboard")

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -116,6 +116,11 @@ final class GitHubActionsRendererTests: XCTestCase {
         XCTAssertEqual(logFormatted(input), output)
     }
 
+    func testSwiftCompiling() {
+        let input = #"SwiftCompile normal x86_64 Compiling\ BackyardBirdsDataContainer.swift,\ ColorData.swift,\ DataGeneration.swift,\ DataGenerationOptions.swift /Backyard-Birds/BackyardBirdsData/General/BackyardBirdsDataContainer.swift /Backyard-Birds/BackyardBirdsData/General/ColorData.swift /Backyard-Birds/BackyardBirdsData/General/DataGeneration.swift /Backyard-Birds/BackyardBirdsData/General/DataGenerationOptions.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#
+        XCTAssertNil(logFormatted(input))
+    }
+
     func testCompileStoryboard() {
         let formatted = logFormatted("CompileStoryboard /Users/admin/MyApp/MyApp/Main.storyboard (in target: MyApp)")
         XCTAssertEqual(formatted, "[MyApp] Compiling Main.storyboard")

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -97,9 +97,15 @@ final class TerminalRendererTests: XCTestCase {
         #endif
     }
 
-    func testSwiftCompile() {
+    func testSwiftCompile_arm64() {
         let input = "SwiftCompile normal arm64 /path/to/File.swift (in target 'Target' from project 'Project')"
         let output = "[Target] Compiling File.swift"
+        XCTAssertEqual(noColoredFormatted(input), output)
+    }
+
+    func testSwiftCompile_x86_64() {
+        let input = "SwiftCompile normal x86_64 /Backyard-Birds/Build/Intermediates.noindex/BackyardBirdsData.build/Debug/BackyardBirdsData.build/DerivedSources/resource_bundle_accessor.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"
+        let output = "[BackyardBirdsData] Compiling resource_bundle_accessor.swift"
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -103,6 +103,11 @@ final class TerminalRendererTests: XCTestCase {
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 
+    func testSwiftCompiling() {
+        let input = #"SwiftCompile normal x86_64 Compiling\ BackyardBirdsDataContainer.swift,\ ColorData.swift,\ DataGeneration.swift,\ DataGenerationOptions.swift /Backyard-Birds/BackyardBirdsData/General/BackyardBirdsDataContainer.swift /Backyard-Birds/BackyardBirdsData/General/ColorData.swift /Backyard-Birds/BackyardBirdsData/General/DataGeneration.swift /Backyard-Birds/BackyardBirdsData/General/DataGenerationOptions.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#
+        XCTAssertNil(noColoredFormatted(input))
+    }
+
     func testCompileStoryboard() {
         let formatted = noColoredFormatted("CompileStoryboard /Users/admin/MyApp/MyApp/Main.storyboard (in target: MyApp)")
         XCTAssertEqual(formatted, "[MyApp] Compiling Main.storyboard")

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -97,6 +97,12 @@ final class TerminalRendererTests: XCTestCase {
         #endif
     }
 
+    func testSwiftCompile() {
+        let input = "SwiftCompile normal arm64 /path/to/File.swift (in target 'Target' from project 'Project')"
+        let output = "[Target] Compiling File.swift"
+        XCTAssertEqual(noColoredFormatted(input), output)
+    }
+
     func testCompileStoryboard() {
         let formatted = noColoredFormatted("CompileStoryboard /Users/admin/MyApp/MyApp/Main.storyboard (in target: MyApp)")
         XCTAssertEqual(formatted, "[MyApp] Compiling Main.storyboard")


### PR DESCRIPTION
## Changes

- Add `SwiftCompileCaptureGroup` 
- Add `SwiftCompilingCaptureGroup`

## Testing

Average results after formatting **large_xcodebuild_log.txt** (99.9 MB xcodebuild log).

| Measurement | Before | After | Absolute Difference | Percentage Difference |
| --- | --- | --- | --- | --- |
| Time | 5.98 seconds | 4.66 seconds | -1.32 seconds | -22.07% seconds |