### PR TITLE
Add Version Logging

### DIFF
--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -22,6 +22,9 @@ struct Xcbeautify: ParsableCommand {
 
     @Flag(name: .long, help: "Disable the colored output")
     var disableColoredOutput = (ProcessInfo.processInfo.environment["NO_COLOR"] != nil)
+    
+    @Flag(name: .long,  help: "Disables the version logging when xcbeautify starts.")
+    var disableVersionLogging = false
 
     // swiftformat:disable redundantReturn
 
@@ -56,6 +59,10 @@ struct Xcbeautify: ParsableCommand {
             print("Took \(diff) seconds")
         }
         #endif
+        
+        if !disableVersionLogging {
+            print("Version: \(version)")
+        }
 
         let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCi) { print($0) }
         let junitReporter = JunitReporter()

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -22,8 +22,8 @@ struct Xcbeautify: ParsableCommand {
 
     @Flag(name: .long, help: "Disable the colored output")
     var disableColoredOutput = (ProcessInfo.processInfo.environment["NO_COLOR"] != nil)
-    
-    @Flag(name: .long,  help: "Disables the version logging when xcbeautify starts.")
+
+    @Flag(name: .long, help: "Disables the version logging when xcbeautify starts.")
     var disableVersionLogging = false
 
     // swiftformat:disable redundantReturn
@@ -59,15 +59,15 @@ struct Xcbeautify: ParsableCommand {
             print("Took \(diff) seconds")
         }
         #endif
-        
+
         if !disableVersionLogging {
             print(
                 """
-                  
+
                 ----- xcbeautify -----
                 Version: \(version)
                 ----------------------
-                  
+
                 """
             )
         }

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -61,7 +61,15 @@ struct Xcbeautify: ParsableCommand {
         #endif
         
         if !disableVersionLogging {
-            print("Version: \(version)")
+            print(
+                """
+                  
+                ----- xcbeautify -----
+                Version: \(version)
+                ----------------------
+                  
+                """
+            )
         }
 
         let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCi) { print($0) }


### PR DESCRIPTION
Adresses #280.

When `xcbeautify` starts, the semantic version is logged to the console. It uses the semantic version found in [Version.swift](https://github.com/cpisciotta/xcbeautify/blob/3eceadb5d0f5b3dd99c333356fc85394cab696b3/Sources/xcbeautify/Version.swift). It is suppressible via the CLI argument `--disable-version-logging`.

Should I also make it suppressible via an environment variable?

