### PR TITLE
Prefix parallel test results with test suite name

### DIFF
--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -585,7 +585,7 @@ extension OutputRendering {
         let device = group.device
         let time = group.time
 
-        return formatParallelTestCase(result: TestStatus.pass, resultColor: \.Green, suite: suite, testCase: testCase, device: device, time: time)
+        return formatParallelTestCase(result: TestStatus.pass, suite: suite, testCase: testCase, device: device, time: time)
     }
 
     func formatParallelTestCaseSkipped(group: ParallelTestCaseSkippedCaptureGroup) -> String {
@@ -594,7 +594,7 @@ extension OutputRendering {
         let device = group.device
         let time = group.time
 
-        return formatParallelTestCase(result: TestStatus.skipped, resultColor: \.Yellow, suite: suite, testCase: testCase, device: device, time: time)
+        return formatParallelTestCase(result: TestStatus.skipped, suite: suite, testCase: testCase, device: device, time: time)
     }
 
     func formatParallelTestCaseAppKitPassed(group: ParallelTestCaseAppKitPassedCaptureGroup) -> String {
@@ -602,7 +602,7 @@ extension OutputRendering {
         let testCase = group.testCase
         let time = group.time
 
-        return formatParallelTestCase(result: TestStatus.pass, resultColor: \.Green, suite: suite, testCase: testCase, device: nil, time: time)
+        return formatParallelTestCase(result: TestStatus.pass, suite: suite, testCase: testCase, device: nil, time: time)
     }
 
     func formatParallelTestCaseFailed(group: ParallelTestCaseFailedCaptureGroup) -> String {
@@ -611,13 +611,33 @@ extension OutputRendering {
         let device = group.device
         let time = group.time
 
-        return formatParallelTestCase(result: TestStatus.fail, resultColor: \.Red, suite: suite, testCase: testCase, device: device, time: time)
+        return formatParallelTestCase(result: TestStatus.fail, suite: suite, testCase: testCase, device: device, time: time)
     }
 
-    private func formatParallelTestCase(result: String, resultColor: KeyPath<String.StringForegroundColorizer, String>, suite: String, testCase: String, device: String?, time: String) -> String {
+    private func formatParallelTestCase(
+        result: String,
+        suite: String,
+        testCase: String,
+        device: String?,
+        time: String
+    ) -> String {
         let deviceString = device.map { " on '\($0)'" } ?? ""
+        
+        let styledResult: String
+        switch result {
+        case TestStatus.pass:
+            styledResult = result.f.Green
+        case TestStatus.fail:
+            styledResult = result.f.Red
+        case TestStatus.skipped:
+            styledResult = result.f.Yellow
+        default:
+            assertionFailure("Unexpected result: \(result)")
+            styledResult = result
+        }
+        
         return colored
-            ? Format.indent + result.f[keyPath: resultColor] + " [" + suite.f.Cyan + "] " + testCase + deviceString + " (\(time.coloredTime()) seconds)"
+            ? Format.indent + styledResult + " [" + suite.f.Cyan + "] " + testCase + deviceString + " (\(time.coloredTime()) seconds)"
             : Format.indent + result + " [" + suite + "] " + testCase + deviceString + " (\(time) seconds)"
     }
 

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -580,30 +580,45 @@ extension OutputRendering {
     }
 
     func formatParallelTestCasePassed(group: ParallelTestCasePassedCaptureGroup) -> String {
+        let suite = group.suite
         let testCase = group.testCase
         let device = group.device
         let time = group.time
-        return colored ? Format.indent + TestStatus.pass.foreground.Green + " " + testCase + " on '\(device)' (\(time.coloredTime()) seconds)" : Format.indent + TestStatus.pass + " " + testCase + " on '\(device)' (\(time) seconds)"
+
+        return formatParallelTestCase(result: TestStatus.pass, resultColor: \.Green, suite: suite, testCase: testCase, device: device, time: time)
     }
 
     func formatParallelTestCaseSkipped(group: ParallelTestCaseSkippedCaptureGroup) -> String {
+        let suite = group.suite
         let testCase = group.testCase
         let device = group.device
         let time = group.time
-        return colored ? Format.indent + TestStatus.skipped.foreground.Yellow + " " + testCase + " on '\(device)' (\(time.coloredTime()) seconds)" : Format.indent + TestStatus.skipped + " " + testCase + " on '\(device)' (\(time) seconds)"
+
+        return formatParallelTestCase(result: TestStatus.skipped, resultColor: \.Yellow, suite: suite, testCase: testCase, device: device, time: time)
     }
 
     func formatParallelTestCaseAppKitPassed(group: ParallelTestCaseAppKitPassedCaptureGroup) -> String {
+        let suite = group.suite
         let testCase = group.testCase
         let time = group.time
-        return colored ? Format.indent + TestStatus.pass.foreground.Green + " " + testCase + " (\(time.coloredTime()) seconds)" : Format.indent + TestStatus.pass + " " + testCase + " (\(time)) seconds)"
+
+        return formatParallelTestCase(result: TestStatus.pass, resultColor: \.Green, suite: suite, testCase: testCase, device: nil, time: time)
     }
 
     func formatParallelTestCaseFailed(group: ParallelTestCaseFailedCaptureGroup) -> String {
+        let suite = group.suite
         let testCase = group.testCase
         let device = group.device
         let time = group.time
-        return colored ? "    \(TestStatus.fail.f.Red) \(testCase) on '\(device)' (\(time.coloredTime()) seconds)" : "    \(TestStatus.fail) \(testCase) on '\(device)' (\(time) seconds)"
+
+        return formatParallelTestCase(result: TestStatus.fail, resultColor: \.Red, suite: suite, testCase: testCase, device: device, time: time)
+    }
+
+    private func formatParallelTestCase(result: String, resultColor: KeyPath<String.StringForegroundColorizer, String>, suite: String, testCase: String, device: String?, time: String) -> String {
+        let deviceString = device.map { " on '\($0)'" } ?? ""
+        return colored
+            ? Format.indent + result.f[keyPath: resultColor] + " [" + suite.f.Cyan + "] " + testCase + deviceString + " (\(time.coloredTime()) seconds)"
+            : Format.indent + result + " [" + suite + "] " + testCase + deviceString + " (\(time) seconds)"
     }
 
     func formatError(group: ErrorCaptureGroup) -> String {

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -622,7 +622,7 @@ extension OutputRendering {
         time: String
     ) -> String {
         let deviceString = device.map { " on '\($0)'" } ?? ""
-        
+
         let styledResult: String
         switch result {
         case TestStatus.pass:
@@ -635,7 +635,7 @@ extension OutputRendering {
             assertionFailure("Unexpected result: \(result)")
             styledResult = result
         }
-        
+
         return colored
             ? Format.indent + styledResult + " [" + suite.f.Cyan + "] " + testCase + deviceString + " (\(time.coloredTime()) seconds)"
             : Format.indent + result + " [" + suite + "] " + testCase + deviceString + " (\(time) seconds)"

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -364,7 +364,7 @@ final class GitHubActionsRendererTests: XCTestCase {
 
     func testParallelTestCasePassed() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'xctest (49438)' (0.131 seconds)")
-        XCTAssertEqual(formatted, "    ✔ testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
     func testParallelTestCaseSkipped() {
@@ -385,13 +385,13 @@ final class GitHubActionsRendererTests: XCTestCase {
 
     func testConcurrentDestinationTestCasePassed() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'iPhone X' (77.158 seconds)")
-        XCTAssertEqual(formatted, "    ✔ testBuildTarget on 'iPhone X' (77.158 seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
         XCTAssertEqual(parser.outputType, .testCase)
     }
 
     func testParallelTestCaseAppKitPassed() {
         let formatted = logFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed on 'xctest (49438)' (0.131 seconds).")
-        XCTAssertEqual(formatted, "    ✔ testBuildTarget (0.131) seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
         XCTAssertEqual(parser.outputType, .testCase)
     }
 

--- a/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
@@ -344,12 +344,12 @@ final class TeamCityRendererTests: XCTestCase {
 
     func testParallelTestCaseFailed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'xctest (49438)' (0.131 seconds)")
-        XCTAssertEqual(formatted, "    ✖ testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, "    ✖ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
     func testParallelTestCasePassed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'xctest (49438)' (0.131 seconds)")
-        XCTAssertEqual(formatted, "    ✔ testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
     func testConcurrentDestinationTestSuiteStarted() {
@@ -359,22 +359,22 @@ final class TeamCityRendererTests: XCTestCase {
 
     func testConcurrentDestinationTestCaseFailed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'iPhone X' (77.158 seconds)")
-        XCTAssertEqual(formatted, "    ✖ testBuildTarget on 'iPhone X' (77.158 seconds)")
+        XCTAssertEqual(formatted, "    ✖ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
     }
 
     func testConcurrentDestinationTestCasePassed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'iPhone X' (77.158 seconds)")
-        XCTAssertEqual(formatted, "    ✔ testBuildTarget on 'iPhone X' (77.158 seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
     }
 
     func testParallelTestCaseAppKitPassed() {
         let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed on 'xctest (49438)' (0.131 seconds).")
-        XCTAssertEqual(formatted, "    ✔ testBuildTarget (0.131) seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
     }
 
     func testParallelTestCaseAppKitWithSpacesPassed() {
         let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests test build target]' passed on 'xctest (49438)' (0.131 seconds).")
-        XCTAssertEqual(formatted, "    ✔ test build target (0.131) seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] test build target (0.131 seconds)")
     }
 
     func testParallelTestingStarted() {

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -341,17 +341,17 @@ final class TerminalRendererTests: XCTestCase {
 
     func testParallelTestCaseFailed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'xctest (49438)' (0.131 seconds)")
-        XCTAssertEqual(formatted, "    ✖ testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, "    ✖ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
     func testParallelTestCasePassed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'xctest (49438)' (0.131 seconds)")
-        XCTAssertEqual(formatted, "    ✔ testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
     func testParallelTestCaseSkipped() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' skipped on 'xctest (49438)' (0.131 seconds)")
-        XCTAssertEqual(formatted, "    ⊘ testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, "    ⊘ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
     func testConcurrentDestinationTestSuiteStarted() {
@@ -361,22 +361,22 @@ final class TerminalRendererTests: XCTestCase {
 
     func testConcurrentDestinationTestCaseFailed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'iPhone X' (77.158 seconds)")
-        XCTAssertEqual(formatted, "    ✖ testBuildTarget on 'iPhone X' (77.158 seconds)")
+        XCTAssertEqual(formatted, "    ✖ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
     }
 
     func testConcurrentDestinationTestCasePassed() {
         let formatted = noColoredFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'iPhone X' (77.158 seconds)")
-        XCTAssertEqual(formatted, "    ✔ testBuildTarget on 'iPhone X' (77.158 seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
     }
 
     func testParallelTestCaseAppKitPassed() {
         let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed on 'xctest (49438)' (0.131 seconds).")
-        XCTAssertEqual(formatted, "    ✔ testBuildTarget (0.131) seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
     }
 
     func testParallelTestCaseAppKitWithSpacesPassed() {
         let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests test build target]' passed on 'xctest (49438)' (0.131 seconds).")
-        XCTAssertEqual(formatted, "    ✔ test build target (0.131) seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] test build target (0.131 seconds)")
     }
 
     func testParallelTestingStarted() {


### PR DESCRIPTION
Output from parallel tests can end up interspersed between different `Test Suite X started ...` headings, which can be quite confusing.

This PR prefixes parallel test results with the suite name to help users tell which suite a test failure came from.