### PR TITLE
Add CopyFilesCaptureGroup

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -362,6 +362,28 @@ struct CompileStoryboardCaptureGroup: CompileFileCaptureGroup {
     }
 }
 
+struct CopyFilesCaptureGroup: CaptureGroup {
+    static let outputType: OutputType = .task
+
+    static let regex = Regex(pattern: #"^Copy (\/.*) (\/.*) \(in target '(.*)' from project '.*'\)$"#)
+
+    let firstFilePath: String
+    let firstFilename: String
+    let secondFilePath: String
+    let secondFilename: String
+    let target: String
+
+    init?(groups: [String]) {
+        assert(groups.count == 3)
+        guard let firstFilePath = groups[safe: 0], let secondFilePath = groups[safe: 1], let target = groups[safe: 2] else { return nil }
+        self.firstFilePath = firstFilePath
+        firstFilename = URL(fileURLWithPath: firstFilePath).lastPathComponent
+        self.secondFilePath = secondFilePath
+        secondFilename = URL(fileURLWithPath: secondFilePath).lastPathComponent
+        self.target = target
+    }
+}
+
 struct CopyHeaderCaptureGroup: CopyCaptureGroup {
     static let outputType: OutputType = .task
 

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -365,7 +365,7 @@ struct CompileStoryboardCaptureGroup: CompileFileCaptureGroup {
 struct CopyFilesCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: #"^Copy (\/.*) (\/.*) \(in target '(.*)' from project '.*'\)$"#)
+    static let regex = Regex(pattern: #"^Copy (\S+) (\S+) \(in target '(.*)' from project '.*'\)$"#)
 
     let firstFilePath: String
     let firstFilename: String

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -365,7 +365,8 @@ struct CompileStoryboardCaptureGroup: CompileFileCaptureGroup {
 struct CopyFilesCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: #"^Copy (\S+) (\S+) \(in target '(.*)' from project '.*'\)$"#)
+    // ((?:\S|(?<=\\) )+) --> Match any non-whitespace character OR any escaped space (space in filename)
+    static let regex = Regex(pattern: #"^Copy ((?:\S|(?<=\\) )+) ((?:\S|(?<=\\) )+) \(in target '(.*)' from project '.*'\)$"#)
 
     let firstFilePath: String
     let firstFilename: String

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -377,9 +377,9 @@ struct CopyFilesCaptureGroup: CaptureGroup {
         assert(groups.count == 3)
         guard let firstFilePath = groups[safe: 0], let secondFilePath = groups[safe: 1], let target = groups[safe: 2] else { return nil }
         self.firstFilePath = firstFilePath
-        firstFilename = URL(fileURLWithPath: firstFilePath).lastPathComponent
+        firstFilename = firstFilePath.lastPathComponent
         self.secondFilePath = secondFilePath
-        secondFilename = URL(fileURLWithPath: secondFilePath).lastPathComponent
+        secondFilename = secondFilePath.lastPathComponent
         self.target = target
     }
 }

--- a/Sources/XcbeautifyLib/Formatter.swift
+++ b/Sources/XcbeautifyLib/Formatter.swift
@@ -64,6 +64,8 @@ package struct Formatter {
             return renderer.formatCompileWarning(group: group)
         case let group as CompileXibCaptureGroup:
             return renderer.formatCompile(group: group)
+        case let group as CopyFilesCaptureGroup:
+            return renderer.formatCopyFiles(group: group)
         case let group as CopyHeaderCaptureGroup:
             return renderer.formatCopy(group: group)
         case let group as CopyPlistCaptureGroup:

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -19,6 +19,7 @@ package final class Parser {
         CompileCommandCaptureGroup.self,
         CompileXibCaptureGroup.self,
         CompileStoryboardCaptureGroup.self,
+        CopyFilesCaptureGroup.self,
         CopyHeaderCaptureGroup.self,
         CopyPlistCaptureGroup.self,
         CopyStringsCaptureGroup.self,

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -21,6 +21,7 @@ protocol OutputRendering {
     func formatCompileError(group: CompileErrorCaptureGroup) -> String
     func formatCompileWarning(group: CompileWarningCaptureGroup) -> String
     func formatCopy(group: any CopyCaptureGroup) -> String
+    func formatCopyFiles(group: CopyFilesCaptureGroup) -> String
     func formatCoverageReport(group: GeneratedCoverageReportCaptureGroup) -> String
     func formatCursor(group: CursorCaptureGroup) -> String?
     func formatDuplicateLocalizedStringKey(group: DuplicateLocalizedStringKeyCaptureGroup) -> String
@@ -132,6 +133,13 @@ extension OutputRendering {
         let filename = group.file
         let target = group.target
         return colored ? "[\(target.f.Cyan)] \("Copying".s.Bold) \(filename)" : "[\(target)] Copying \(filename)"
+    }
+
+    func formatCopyFiles(group: CopyFilesCaptureGroup) -> String {
+        let target = group.target
+        let firstFilename = group.firstFilename
+        let secondFilename = group.secondFilename
+        return colored ? "[\(target.f.Cyan)] \("Copy".s.Bold) \(firstFilename) -> \(secondFilename)" : "[\(target)] Copy \(firstFilename) -> \(secondFilename)"
     }
 
     func formatCursor(group: CursorCaptureGroup) -> String? {

--- a/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
+++ b/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
@@ -27,6 +27,11 @@ final class CaptureGroupTests: XCTestCase {
         XCTAssertTrue(CompilationResultCaptureGroup.regex.match(string: input))
     }
 
+    func testMatchCopyFilesMatchingSourceAndDestinationFilenames() {
+        let input = #"Copy /path/to/some/file.swift /path/to/some/other/file.swift (in target 'Target' from project 'Project')"#
+        XCTAssertTrue(CopyFilesCaptureGroup.regex.match(string: input))
+    }
+
     func testMatchSwiftDriverJobDiscoveryEmittingModule() {
         let input = #"SwiftDriverJobDiscovery normal arm64 Emitting module for Widgets (in target 'Widgets' from project 'Backyard Birds')"#
         XCTAssertTrue(SwiftDriverJobDiscoveryEmittingModuleCaptureGroup.regex.match(string: input))

--- a/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
+++ b/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
@@ -32,6 +32,11 @@ final class CaptureGroupTests: XCTestCase {
         XCTAssertTrue(CopyFilesCaptureGroup.regex.match(string: input))
     }
 
+    func testMatchCopyFilesDifferentSourceAndDestinationFilenames() {
+        let input = #"Copy /Backyard-Birds/Build/Products/Debug/Backyard_Birds.swiftmodule/x86_64-apple-macos.abi.json /Backyard-Birds/Build/Intermediates.noindex/Backyard\ Birds.build/Debug/Backyard\ Birds.build/Objects-normal/x86_64/Backyard_Birds.abi.json (in target 'Backyard Birds' from project 'Backyard Birds')"#
+        XCTAssertTrue(CopyFilesCaptureGroup.regex.match(string: input))
+    }
+
     func testMatchSwiftDriverJobDiscoveryEmittingModule() {
         let input = #"SwiftDriverJobDiscovery normal arm64 Emitting module for Widgets (in target 'Widgets' from project 'Backyard Birds')"#
         XCTAssertTrue(SwiftDriverJobDiscoveryEmittingModuleCaptureGroup.regex.match(string: input))

--- a/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
+++ b/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
@@ -27,16 +27,6 @@ final class CaptureGroupTests: XCTestCase {
         XCTAssertTrue(CompilationResultCaptureGroup.regex.match(string: input))
     }
 
-    func testMatchCopyFilesMatchingSourceAndDestinationFilenames() {
-        let input = #"Copy /path/to/some/file.swift /path/to/some/other/file.swift (in target 'Target' from project 'Project')"#
-        XCTAssertTrue(CopyFilesCaptureGroup.regex.match(string: input))
-    }
-
-    func testMatchCopyFilesDifferentSourceAndDestinationFilenames() {
-        let input = #"Copy /Backyard-Birds/Build/Products/Debug/Backyard_Birds.swiftmodule/x86_64-apple-macos.abi.json /Backyard-Birds/Build/Intermediates.noindex/Backyard\ Birds.build/Debug/Backyard\ Birds.build/Objects-normal/x86_64/Backyard_Birds.abi.json (in target 'Backyard Birds' from project 'Backyard Birds')"#
-        XCTAssertTrue(CopyFilesCaptureGroup.regex.match(string: input))
-    }
-
     func testMatchSwiftDriverJobDiscoveryEmittingModule() {
         let input = #"SwiftDriverJobDiscovery normal arm64 Emitting module for Widgets (in target 'Widgets' from project 'Backyard Birds')"#
         XCTAssertTrue(SwiftDriverJobDiscoveryEmittingModuleCaptureGroup.regex.match(string: input))

--- a/Tests/XcbeautifyLibTests/ParserTests.swift
+++ b/Tests/XcbeautifyLibTests/ParserTests.swift
@@ -1,0 +1,45 @@
+//
+//  ParserTests.swift
+//  
+//
+//  Created by Charles Pisciotta on 8/6/24.
+//
+
+import XCTest
+@testable import XcbeautifyLib
+
+final class ParserTests: XCTestCase {
+
+    private var parser: Parser!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        self.parser = Parser()
+    }
+
+    override func tearDownWithError() throws {
+        self.parser = nil
+        try super.tearDownWithError()
+    }
+
+    func testMatchCopyFilesMatchingSourceAndDestinationFilenames() throws {
+        let input = #"Copy /path/to/some/file.swift /path/to/some/other/file.swift (in target 'Target' from project 'Project')"#
+        let captureGroup = try XCTUnwrap(parser.parse(line: input) as? CopyFilesCaptureGroup)
+        XCTAssertEqual(captureGroup.firstFilePath, "/path/to/some/file.swift")
+        XCTAssertEqual(captureGroup.firstFilename, "file.swift")
+        XCTAssertEqual(captureGroup.secondFilePath, "/path/to/some/other/file.swift")
+        XCTAssertEqual(captureGroup.secondFilename, "file.swift")
+        XCTAssertEqual(captureGroup.target, "Target")
+    }
+
+    func testMatchCopyFilesDifferentSourceAndDestinationFilenames() throws {
+        let input = #"Copy /path/to/some/first-file.swift /path/to/some/other/second-file.swift (in target 'Target' from project 'Project')"#
+        let captureGroup = try XCTUnwrap(parser.parse(line: input) as? CopyFilesCaptureGroup)
+        XCTAssertEqual(captureGroup.firstFilePath, "/path/to/some/first-file.swift")
+        XCTAssertEqual(captureGroup.firstFilename, "first-file.swift")
+        XCTAssertEqual(captureGroup.secondFilePath, "/path/to/some/other/second-file.swift")
+        XCTAssertEqual(captureGroup.secondFilename, "second-file.swift")
+        XCTAssertEqual(captureGroup.target, "Target")
+    }
+
+}

--- a/Tests/XcbeautifyLibTests/ParserTests.swift
+++ b/Tests/XcbeautifyLibTests/ParserTests.swift
@@ -1,6 +1,6 @@
 //
 //  ParserTests.swift
-//  
+//
 //
 //  Created by Charles Pisciotta on 8/6/24.
 //
@@ -9,16 +9,15 @@ import XCTest
 @testable import XcbeautifyLib
 
 final class ParserTests: XCTestCase {
-
     private var parser: Parser!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        self.parser = Parser()
+        parser = Parser()
     }
 
     override func tearDownWithError() throws {
-        self.parser = nil
+        parser = nil
         try super.tearDownWithError()
     }
 
@@ -41,5 +40,4 @@ final class ParserTests: XCTestCase {
         XCTAssertEqual(captureGroup.secondFilename, "Backyard_Birds.abi.json")
         XCTAssertEqual(captureGroup.target, "Backyard Birds")
     }
-
 }

--- a/Tests/XcbeautifyLibTests/ParserTests.swift
+++ b/Tests/XcbeautifyLibTests/ParserTests.swift
@@ -33,13 +33,13 @@ final class ParserTests: XCTestCase {
     }
 
     func testMatchCopyFilesDifferentSourceAndDestinationFilenames() throws {
-        let input = #"Copy /path/to/some/first-file.swift /path/to/some/other/second-file.swift (in target 'Target' from project 'Project')"#
+        let input = #"Copy /Backyard-Birds/Build/Products/Debug/Backyard_Birds.swiftmodule/x86_64-apple-macos.abi.json /Backyard-Birds/Build/Intermediates.noindex/Backyard\ Birds.build/Debug/Backyard\ Birds.build/Objects-normal/x86_64/Backyard_Birds.abi.json (in target 'Backyard Birds' from project 'Backyard Birds')"#
         let captureGroup = try XCTUnwrap(parser.parse(line: input) as? CopyFilesCaptureGroup)
-        XCTAssertEqual(captureGroup.firstFilePath, "/path/to/some/first-file.swift")
-        XCTAssertEqual(captureGroup.firstFilename, "first-file.swift")
-        XCTAssertEqual(captureGroup.secondFilePath, "/path/to/some/other/second-file.swift")
-        XCTAssertEqual(captureGroup.secondFilename, "second-file.swift")
-        XCTAssertEqual(captureGroup.target, "Target")
+        XCTAssertEqual(captureGroup.firstFilePath, "/Backyard-Birds/Build/Products/Debug/Backyard_Birds.swiftmodule/x86_64-apple-macos.abi.json")
+        XCTAssertEqual(captureGroup.firstFilename, "x86_64-apple-macos.abi.json")
+        XCTAssertEqual(captureGroup.secondFilePath, #"/Backyard-Birds/Build/Intermediates.noindex/Backyard\ Birds.build/Debug/Backyard\ Birds.build/Objects-normal/x86_64/Backyard_Birds.abi.json"#)
+        XCTAssertEqual(captureGroup.secondFilename, "Backyard_Birds.abi.json")
+        XCTAssertEqual(captureGroup.target, "Backyard Birds")
     }
 
 }

--- a/Tests/XcbeautifyLibTests/ParsingTests/ParsingTests.swift
+++ b/Tests/XcbeautifyLibTests/ParsingTests/ParsingTests.swift
@@ -26,9 +26,9 @@ final class ParsingTests: XCTestCase {
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
-        XCTAssertEqual(uncapturedOutput, 437)
+        XCTAssertEqual(uncapturedOutput, 381)
         #else
-        XCTAssertEqual(uncapturedOutput, 453)
+        XCTAssertEqual(uncapturedOutput, 397)
         #endif
     }
 
@@ -56,9 +56,9 @@ final class ParsingTests: XCTestCase {
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
-        XCTAssertEqual(uncapturedOutput, 14922)
+        XCTAssertEqual(uncapturedOutput, 12938)
         #else
-        XCTAssertEqual(uncapturedOutput, 15490)
+        XCTAssertEqual(uncapturedOutput, 13506)
         #endif
     }
 }

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -164,6 +164,18 @@ final class GitHubActionsRendererTests: XCTestCase {
         XCTAssertEqual(logFormatted(input), output)
     }
 
+    func testCopyMatchingSourceAndDestinationFiles() {
+        let input = "Copy /path/to/some/file.swift /path/to/some/other/file.swift (in target 'Target' from project 'Project')"
+        let output = "[Target] Copy file.swift -> file.swift"
+        XCTAssertEqual(logFormatted(input), output)
+    }
+
+    func testCopyDifferentSourceAndDestinationFiles() {
+        let input = "Copy /path/to/some/firstFile.swift /path/to/some/other/secondFile.swift (in target 'Target' from project 'Project')"
+        let output = "[Target] Copy firstFile.swift -> secondFile.swift"
+        XCTAssertEqual(logFormatted(input), output)
+    }
+
     func testCursor() { }
 
     func testExecuted() throws {

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -171,8 +171,8 @@ final class GitHubActionsRendererTests: XCTestCase {
     }
 
     func testCopyDifferentSourceAndDestinationFiles() {
-        let input = "Copy /path/to/some/firstFile.swift /path/to/some/other/secondFile.swift (in target 'Target' from project 'Project')"
-        let output = "[Target] Copy firstFile.swift -> secondFile.swift"
+        let input = #"Copy /Backyard-Birds/Build/Products/Debug/Backyard_Birds.swiftmodule/x86_64-apple-macos.abi.json /Backyard-Birds/Build/Intermediates.noindex/Backyard\ Birds.build/Debug/Backyard\ Birds.build/Objects-normal/x86_64/Backyard_Birds.abi.json (in target 'Backyard Birds' from project 'Backyard Birds')"#
+        let output = "[Backyard Birds] Copy x86_64-apple-macos.abi.json -> Backyard_Birds.abi.json"
         XCTAssertEqual(logFormatted(input), output)
     }
 

--- a/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
@@ -167,6 +167,18 @@ final class TeamCityRendererTests: XCTestCase {
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 
+    func testCopyMatchingSourceAndDestinationFiles() {
+        let input = "Copy /path/to/some/file.swift /path/to/some/other/file.swift (in target 'Target' from project 'Project')"
+        let output = "[Target] Copy file.swift -> file.swift"
+        XCTAssertEqual(noColoredFormatted(input), output)
+    }
+
+    func testCopyDifferentSourceAndDestinationFiles() {
+        let input = "Copy /path/to/some/firstFile.swift /path/to/some/other/secondFile.swift (in target 'Target' from project 'Project')"
+        let output = "[Target] Copy firstFile.swift -> secondFile.swift"
+        XCTAssertEqual(noColoredFormatted(input), output)
+    }
+
     func testCursor() { }
 
     func testExecutedWithoutSkipped() throws {

--- a/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
@@ -174,8 +174,8 @@ final class TeamCityRendererTests: XCTestCase {
     }
 
     func testCopyDifferentSourceAndDestinationFiles() {
-        let input = "Copy /path/to/some/firstFile.swift /path/to/some/other/secondFile.swift (in target 'Target' from project 'Project')"
-        let output = "[Target] Copy firstFile.swift -> secondFile.swift"
+        let input = #"Copy /Backyard-Birds/Build/Products/Debug/Backyard_Birds.swiftmodule/x86_64-apple-macos.abi.json /Backyard-Birds/Build/Intermediates.noindex/Backyard\ Birds.build/Debug/Backyard\ Birds.build/Objects-normal/x86_64/Backyard_Birds.abi.json (in target 'Backyard Birds' from project 'Backyard Birds')"#
+        let output = "[Backyard Birds] Copy x86_64-apple-macos.abi.json -> Backyard_Birds.abi.json"
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -164,6 +164,18 @@ final class TerminalRendererTests: XCTestCase {
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 
+    func testCopyMatchingSourceAndDestinationFiles() {
+        let input = "Copy /path/to/some/file.swift /path/to/some/other/file.swift (in target 'Target' from project 'Project')"
+        let output = "[Target] Copy file.swift -> file.swift"
+        XCTAssertEqual(noColoredFormatted(input), output)
+    }
+
+    func testCopyDifferentSourceAndDestinationFiles() {
+        let input = "Copy /path/to/some/firstFile.swift /path/to/some/other/secondFile.swift (in target 'Target' from project 'Project')"
+        let output = "[Target] Copy firstFile.swift -> secondFile.swift"
+        XCTAssertEqual(noColoredFormatted(input), output)
+    }
+
     func testCursor() { }
 
     func testExecutedWithoutSkipped() throws {

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -171,8 +171,8 @@ final class TerminalRendererTests: XCTestCase {
     }
 
     func testCopyDifferentSourceAndDestinationFiles() {
-        let input = "Copy /path/to/some/firstFile.swift /path/to/some/other/secondFile.swift (in target 'Target' from project 'Project')"
-        let output = "[Target] Copy firstFile.swift -> secondFile.swift"
+        let input = #"Copy /Backyard-Birds/Build/Products/Debug/Backyard_Birds.swiftmodule/x86_64-apple-macos.abi.json /Backyard-Birds/Build/Intermediates.noindex/Backyard\ Birds.build/Debug/Backyard\ Birds.build/Objects-normal/x86_64/Backyard_Birds.abi.json (in target 'Backyard Birds' from project 'Backyard Birds')"#
+        let output = "[Backyard Birds] Copy x86_64-apple-macos.abi.json -> Backyard_Birds.abi.json"
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 


### PR DESCRIPTION
## Changes

Add a `CaptureGroup` to parse and format the following example output:

```
Copy /path/to/some/file.extension /path/to/some/other/file.extension (in target 'Target' from project 'Project')
```

## Testing

- Unit tests passed
- Performance regression tests showed positive improvements
- No missed instances from example build log
