### PR TITLE
Fix SwiftCompileCaptureGroup Bug

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -274,20 +274,22 @@ struct SwiftCompileCaptureGroup: CompileFileCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = file path
-    /// $2 = filename (e.g. KWNull.m)
-    /// $3 = target
-    static let regex = Regex(pattern: #"^SwiftCompile \w+ \w+ ((?:\.|[^ ])+\/((?:\.|[^ ])+\.(?:m|mm|c|cc|cpp|cxx|swift))) \((in target '(.*)' from project '.*')\)$"#)
+    /// $2 = target
+    /// $3 = project
+    static let regex = Regex(pattern: #"^SwiftCompile \w+ \w+ ((?:\S|(?<=\\) )+) \(in target '(.*)' from project '(.*)'\)$"#)
 
     let filePath: String
     let filename: String
     let target: String
+    let project: String
 
     init?(groups: [String]) {
-        assert(groups.count >= 3)
-        guard let filePath = groups[safe: 0], let filename = groups[safe: 1], let target = groups.last else { return nil }
+        assert(groups.count == 3)
+        guard let filePath = groups[safe: 0], let target = groups[safe: 1], let project = groups[safe: 2] else { return nil }
         self.filePath = filePath
-        self.filename = filename
+        filename = filePath.lastPathComponent
         self.target = target
+        self.project = project
     }
 }
 

--- a/Tests/XcbeautifyLibTests/ParserTests.swift
+++ b/Tests/XcbeautifyLibTests/ParserTests.swift
@@ -60,4 +60,12 @@ final class ParserTests: XCTestCase {
         XCTAssertEqual(captureGroup.target, "BackyardBirdsDataTarget")
         XCTAssertEqual(captureGroup.project, "BackyardBirdsDataProject")
     }
+
+    func testMatchSwiftCompile() throws {
+        let input = #"SwiftCompile normal arm64 /Backyard-Birds/BackyardBirdsData/Food\ &\ Drink/BirdFood+DataGeneration.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#
+        let captureGroup = try XCTUnwrap(parser.parse(line: input) as? SwiftCompileCaptureGroup)
+        XCTAssertEqual(captureGroup.filePath, #"/Backyard-Birds/BackyardBirdsData/Food\ &\ Drink/BirdFood+DataGeneration.swift"#)
+        XCTAssertEqual(captureGroup.filename, #"BirdFood+DataGeneration.swift"#)
+        XCTAssertEqual(captureGroup.target, "BackyardBirdsData")
+    }
 }

--- a/Tests/XcbeautifyLibTests/ParsingTests/ParsingTests.swift
+++ b/Tests/XcbeautifyLibTests/ParsingTests/ParsingTests.swift
@@ -26,9 +26,9 @@ final class ParsingTests: XCTestCase {
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
-        XCTAssertEqual(uncapturedOutput, 289)
+        XCTAssertEqual(uncapturedOutput, 277)
         #else
-        XCTAssertEqual(uncapturedOutput, 305)
+        XCTAssertEqual(uncapturedOutput, 293)
         #endif
     }
 
@@ -56,9 +56,9 @@ final class ParsingTests: XCTestCase {
         // Update this magic number whenever `uncapturedOutput` is less than the current magic number.
         // There's a regression whenever `uncapturedOutput` is greater than the current magic number.
         #if os(macOS)
-        XCTAssertEqual(uncapturedOutput, 9639)
+        XCTAssertEqual(uncapturedOutput, 9223)
         #else
-        XCTAssertEqual(uncapturedOutput, 10207)
+        XCTAssertEqual(uncapturedOutput, 9791)
         #endif
     }
 }


### PR DESCRIPTION
Fix a bug in the `SwiftCompileCaptureGroup` where it missed files with escaped spaces. Add a unit test that considers the  previously missed output, and simplify the regex to more exhaustively consider filenames. As part of this change, update the regex's capturing groups, and use `lastPathComponent` to extract `filename` from the already captured `filePath`.