### PR TITLE
Removed Symbol Capture and Relaxed Test/Suite Name Matching for Better Compatibility 

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -1867,7 +1867,6 @@ struct SwiftDriverJobDiscoveryCompilingCaptureGroup: CaptureGroup {
     }
 }
 
-
 struct SwiftTestingRunStartedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .result
 
@@ -1897,7 +1896,7 @@ struct SwiftTestingRunCompletionCaptureGroup: CaptureGroup {
 
     init?(groups: [String]) {
         assert(groups.count >= 2)
-              guard let numberOfTests = groups[safe: 0].flatMap(Int.init),
+        guard let numberOfTests = groups[safe: 0].flatMap(Int.init),
               let totalTime = groups[safe: 1] else { return nil }
         self.numberOfTests = numberOfTests
         self.totalTime = totalTime

--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -1867,22 +1867,19 @@ struct SwiftDriverJobDiscoveryCompilingCaptureGroup: CaptureGroup {
     }
 }
 
+
 struct SwiftTestingRunStartedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .result
 
     /// Regular expression to capture the start of a test run.
-    /// $1 = symbol
-    /// $2 = message
-    static let regex = Regex(pattern: #"^(􀟈)\s*(Test run started\.)$"#)
+    /// $1 = message
+    static let regex = Regex(pattern: #"^.\s+(Test run started\.)$"#)
 
-    let symbol: String
     let message: String
 
     init?(groups: [String]) {
-        assert(groups.count >= 2)
-        guard let symbol = groups[safe: 0],
-              let message = groups[safe: 1] else { return nil }
-        self.symbol = symbol
+        assert(groups.count >= 1)
+        guard let message = groups[safe: 0] else { return nil }
         self.message = message
     }
 }
@@ -1891,21 +1888,17 @@ struct SwiftTestingRunCompletionCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .result
 
     /// Regular expression to capture the number of tests and total time.
-    /// $1 = symbol
-    /// $2 = number of tests
-    /// $3 = total time in seconds
-    static let regex = Regex(pattern: #"^(􁁛)\s*Test run with (\d+) tests passed after ([\d.]+) seconds\.$"#)
+    /// $1 = number of tests
+    /// $2 = total time in seconds
+    static let regex = Regex(pattern: #"^.\s+Test run with (\d+) test(?:s)? passed after ([\d.]+) seconds\.$"#)
 
-    let symbol: String
     let numberOfTests: Int
     let totalTime: String
 
     init?(groups: [String]) {
-        assert(groups.count >= 3)
-        guard let symbol = groups[safe: 0],
-              let numberOfTests = groups[safe: 1].flatMap(Int.init),
-              let totalTime = groups[safe: 2] else { return nil }
-        self.symbol = symbol
+        assert(groups.count >= 2)
+              guard let numberOfTests = groups[safe: 0].flatMap(Int.init),
+              let totalTime = groups[safe: 1] else { return nil }
         self.numberOfTests = numberOfTests
         self.totalTime = totalTime
     }
@@ -1915,24 +1908,20 @@ struct SwiftTestingRunFailedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .result
 
     /// Regular expression to capture the number of tests, total time, and the number of issues.
-    /// $1 = symbol
-    /// $2 = number of tests
-    /// $3 = total time in seconds
-    /// $4 = number of issues
-    static let regex = Regex(pattern: #"^(􀢄)\s*Test run with (\d+) tests failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
+    /// $1 = number of tests
+    /// $2 = total time in seconds
+    /// $3 = number of issues
+    static let regex = Regex(pattern: #"^.\s+Test run with (\d+) test(?:s)? failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
 
-    let symbol: String
     let numberOfTests: Int
     let totalTime: String
     let numberOfIssues: Int
 
     init?(groups: [String]) {
-        assert(groups.count >= 4)
-        guard let symbol = groups[safe: 0],
-              let numberOfTests = groups[safe: 1].flatMap(Int.init),
-              let totalTime = groups[safe: 2],
-              let numberOfIssues = groups[safe: 3].flatMap(Int.init) else { return nil }
-        self.symbol = symbol
+        assert(groups.count >= 3)
+        guard let numberOfTests = groups[safe: 0].flatMap(Int.init),
+              let totalTime = groups[safe: 1],
+              let numberOfIssues = groups[safe: 2].flatMap(Int.init) else { return nil }
         self.numberOfTests = numberOfTests
         self.totalTime = totalTime
         self.numberOfIssues = numberOfIssues
@@ -1943,18 +1932,14 @@ struct SwiftTestingSuiteStartedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .test
 
     /// Regular expression to capture the start of a test suite.
-    /// $1 = symbol
-    /// $2 = suite name
-    static let regex = Regex(pattern: #"^(􀟈)\s*Suite (.*) started\.$"#)
+    /// $1 = suite name
+    static let regex = Regex(pattern: #"^.\s+Suite (.*) started\.$"#)
 
-    let symbol: String
     let suiteName: String
 
     init?(groups: [String]) {
-        assert(groups.count >= 2)
-        guard let symbol = groups[safe: 0],
-              let suiteName = groups[safe: 1] else { return nil }
-        self.symbol = symbol
+        assert(groups.count >= 1)
+        guard let suiteName = groups[safe: 0] else { return nil }
         self.suiteName = suiteName
     }
 }
@@ -1963,19 +1948,15 @@ struct SwiftTestingTestStartedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture the start of a test case.
-    /// $1 = symbol
-    /// $2 = test name
-    static let regex = Regex(pattern: #"^\s*(􀟈)\s*Test (.*) started\.$"#)
+    /// $1 = test name
+    static let regex = Regex(pattern: #"^.\s+Test\s+(.*) started\.$"#)
 
-    let symbol: String
     let testName: String
     let wholeMessage: String
 
     init?(groups: [String]) {
-        assert(groups.count >= 2)
-        guard let symbol = groups[safe: 0],
-              let testName = groups[safe: 1] else { return nil }
-        self.symbol = symbol
+        assert(groups.count >= 1)
+        guard let testName = groups[safe: 0] else { return nil }
         self.testName = testName
         wholeMessage = "Test \(testName) started."
     }
@@ -1985,21 +1966,17 @@ struct SwiftTestingSuitePassedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .warning
 
     /// Regular expression to capture the successful completion of a test suite.
-    /// $1 = symbol
-    /// $2 = suite name
-    /// $3 = total time taken in seconds
-    static let regex = Regex(pattern: #"^(􁁛)\s*Suite (.*) passed after ([\d.]+) seconds\.$"#)
+    /// $1 = suite name
+    /// $2 = total time taken in seconds
+    static let regex = Regex(pattern: #"^.\s+Suite (.*) passed after ([\d.]+) seconds\.$"#)
 
-    let symbol: String
     let suiteName: String
     let timeTaken: String
 
     init?(groups: [String]) {
-        assert(groups.count >= 3)
-        guard let symbol = groups[safe: 0],
-              let suiteName = groups[safe: 1],
-              let timeTaken = groups[safe: 2] else { return nil }
-        self.symbol = symbol
+        assert(groups.count >= 2)
+        guard let suiteName = groups[safe: 0],
+              let timeTaken = groups[safe: 1] else { return nil }
         self.suiteName = suiteName
         self.timeTaken = timeTaken
     }
@@ -2009,24 +1986,20 @@ struct SwiftTestingSuiteFailedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .result
 
     /// Regular expression to capture the failure of a test suite.
-    /// $1 = symbol
-    /// $2 = suite name
-    /// $3 = total time taken in seconds
-    /// $4 = number of issues
-    static let regex = Regex(pattern: #"^(􀢄)\s*Suite "(.*)" failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
+    /// $1 = suite name
+    /// $2 = total time taken in seconds
+    /// $3 = number of issues
+    static let regex = Regex(pattern: #"^.\s+Suite (.*) failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
 
-    let symbol: String
     let suiteName: String
     let timeTaken: String
     let numberOfIssues: Int
 
     init?(groups: [String]) {
         assert(groups.count >= 3)
-        guard let symbol = groups[safe: 0],
-              let suiteName = groups[safe: 1],
-              let timeTaken = groups[safe: 2],
-              let numberOfIssues = groups[safe: 3].flatMap(Int.init) else { return nil }
-        self.symbol = symbol
+        guard let suiteName = groups[safe: 0],
+              let timeTaken = groups[safe: 1],
+              let numberOfIssues = groups[safe: 2].flatMap(Int.init) else { return nil }
         self.suiteName = suiteName
         self.timeTaken = timeTaken
         self.numberOfIssues = numberOfIssues
@@ -2037,24 +2010,20 @@ struct SwiftTestingTestFailedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture the failure of a test case.
-    /// $1 = symbol
-    /// $2 = test name
-    /// $3 = time taken in seconds
-    /// $4 = number of issues
-    static let regex = Regex(pattern: #"^(􀢄)\s*Test "(.*)" failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
+    /// $1 = test name
+    /// $2 = time taken in seconds
+    /// $3 = number of issues
+    static let regex = Regex(pattern: #"^.\s+Test (?!run\s)(.*) failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
 
-    let symbol: String
     let testName: String
     let timeTaken: String
     let numberOfIssues: Int
 
     init?(groups: [String]) {
         assert(groups.count >= 3)
-        guard let symbol = groups[safe: 0],
-              let testName = groups[safe: 1],
-              let timeTaken = groups[safe: 2],
-              let numberOfIssues = groups[safe: 3].flatMap(Int.init) else { return nil }
-        self.symbol = symbol
+        guard let testName = groups[safe: 0],
+              let timeTaken = groups[safe: 1],
+              let numberOfIssues = groups[safe: 2].flatMap(Int.init) else { return nil }
         self.testName = testName
         self.timeTaken = timeTaken
         self.numberOfIssues = numberOfIssues
@@ -2065,21 +2034,17 @@ struct SwiftTestingTestPassedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture the successful completion of a test case.
-    /// $1 = symbol
-    /// $2 = test name
-    /// $3 = time taken in seconds
-    static let regex = Regex(pattern: #"^(􁁛)\s*Test (.*) passed after ([\d.]+) seconds\.$"#)
+    /// $1 = test name
+    /// $2 = time taken in seconds
+    static let regex = Regex(pattern: #"^.*Test (?!run\s)(.*) passed after ([\d.]+) seconds\.$"#)
 
-    let symbol: String
     let testName: String
     let timeTaken: String
 
     init?(groups: [String]) {
-        assert(groups.count >= 3)
-        guard let symbol = groups[safe: 0],
-              let testName = groups[safe: 1],
-              let timeTaken = groups[safe: 2] else { return nil }
-        self.symbol = symbol
+        assert(groups.count >= 2)
+        guard let testName = groups[safe: 0],
+              let timeTaken = groups[safe: 1] else { return nil }
         self.testName = testName
         self.timeTaken = timeTaken
     }
@@ -2089,18 +2054,14 @@ struct SwiftTestingTestSkippedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture a skipped test case.
-    /// $1 = symbol
-    /// $2 = test name
-    static let regex = Regex(pattern: #"^(􀙟)\s*Test "(.*)" skipped\.$"#)
+    /// $1 = test name
+    static let regex = Regex(pattern: #"^.\s+Test (.*) skipped\.$"#)
 
-    let symbol: String
     let testName: String
 
     init?(groups: [String]) {
-        assert(groups.count >= 2)
-        guard let symbol = groups[safe: 0],
-              let testName = groups[safe: 1] else { return nil }
-        self.symbol = symbol
+        assert(groups.count >= 1)
+        guard let testName = groups[safe: 0] else { return nil }
         self.testName = testName
     }
 }
@@ -2109,22 +2070,18 @@ struct SwiftTestingTestSkippedReasonCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture a skipped test case with a reason.
-    /// $1 = symbol
-    /// $2 = test name
-    /// $3 = optional reason
-    static let regex = Regex(pattern: #"^(􀙟)\s*Test "(.*)" skipped(?:\s*:\s*"(.*)")?$"#)
+    /// $1 = test name
+    /// $2 = optional reason
+    static let regex = Regex(pattern: #"^.\s+Test (.*) skipped(?:\s*:\s*"(.*)")?$"#)
 
-    let symbol: String
     let testName: String
     let reason: String?
 
     init?(groups: [String]) {
-        assert(groups.count >= 2)
-        guard let symbol = groups[safe: 0],
-              let testName = groups[safe: 1] else { return nil }
-        self.symbol = symbol
+        assert(groups.count >= 1)
+        guard let testName = groups[safe: 0] else { return nil }
         self.testName = testName
-        reason = groups[safe: 2]
+        reason = groups[safe: 1]
     }
 }
 
@@ -2132,23 +2089,19 @@ struct SwiftTestingIssueCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture the symbol, test description, and issue details.
-    /// $1 = symbol
-    /// $2 = test description
-    /// $3 = issue details
-    static let regex = Regex(pattern: #"^(􀢄)\s*Test "(.*?)" recorded an issue(?: at (.*))?$"#)
+    /// $1 = test description
+    /// $2 = issue details
+    static let regex = Regex(pattern: #"^.\s+Test (.*?) recorded an issue(?: at (.*))?$"#)
 
-    let symbol: String
     let testDescription: String
     let issueDetails: String?
 
     init?(groups: [String]) {
-        assert(groups.count >= 2)
-        guard let symbol = groups[safe: 0],
-              let testDescription = groups[safe: 1] else { return nil }
+        assert(groups.count >= 1)
+        guard let testDescription = groups[safe: 0] else { return nil }
 
-        self.symbol = symbol
         self.testDescription = testDescription
-        issueDetails = groups[safe: 2]
+        issueDetails = groups[safe: 1]
     }
 }
 
@@ -2156,23 +2109,19 @@ struct SwiftTestingIssueArgumentCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture the symbol, test description, and optional number of arguments.
-    /// $1 = symbol
-    /// $2 = test description
-    /// $3 = number of arguments (optional)
-    static let regex = Regex(pattern: #"^(􀢄)\s*Test "(.*?)" recorded an issue(?: with (\d+) arguments?)?"#)
+    /// $1 = test description
+    /// $2 = number of arguments (optional)
+    static let regex = Regex(pattern: #"^.\s+Test (.*?) recorded an issue(?: with (\d+) arguments?)?"#)
 
-    let symbol: String
     let testDescription: String
     let numberOfArguments: Int?
 
     init?(groups: [String]) {
-        assert(groups.count >= 2)
-        guard let symbol = groups[safe: 0],
-              let testDescription = groups[safe: 1] else { return nil }
+        assert(groups.count >= 1)
+        guard let testDescription = groups[safe: 0] else { return nil }
 
-        self.symbol = symbol
         self.testDescription = testDescription
-        numberOfArguments = groups[safe: 2].flatMap(Int.init)
+        numberOfArguments = groups[safe: 1].flatMap(Int.init)
     }
 }
 
@@ -2180,69 +2129,15 @@ struct SwiftTestingPassingArgumentCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .testCase
 
     /// Regular expression to capture the symbol and number of arguments.
-    /// $1 = symbol
-    /// $2 = number of arguments
-    static let regex = Regex(pattern: #"^(􀟈)\s*Passing (\d+) argument[s]?.*$"#)
+    /// $1 = number of arguments
+    static let regex = Regex(pattern: #"^.\s+Passing (\d+) argument[s]?.*$"#)
 
-    let symbol: String
     let numberOfArguments: Int
 
     init?(groups: [String]) {
-        assert(groups.count >= 2)
-        guard let symbol = groups[safe: 0],
-              let numberOfArguments = groups[safe: 1].flatMap(Int.init) else { return nil }
+        assert(groups.count >= 1)
+        guard let numberOfArguments = groups[safe: 0].flatMap(Int.init) else { return nil }
 
-        self.symbol = symbol
         self.numberOfArguments = numberOfArguments
-    }
-}
-
-struct SwiftTestingPassingArgumentMultipleCaptureGroup: CaptureGroup {
-    static let outputType: OutputType = .testCase
-
-    /// Regular expression to capture the symbol, number of arguments, and input.
-    /// $1 = symbol
-    /// $2 = number of arguments
-    /// $3 = input
-    static let regex = Regex(pattern: #"^(􀟈)\s*Passing (\d+) argument[s]? input → "(.*)"(?:,.*)? to .*$"#)
-
-    let symbol: String
-    let numberOfArguments: Int
-    let input: String
-
-    init?(groups: [String]) {
-        assert(groups.count >= 3)
-        guard let symbol = groups[safe: 0],
-              let numberOfArguments = groups[safe: 1].flatMap(Int.init),
-              let input = groups[safe: 2] else { return nil }
-
-        self.symbol = symbol
-        self.numberOfArguments = numberOfArguments
-        self.input = input
-    }
-}
-
-struct SwiftTestingAttributeCaptureGroup: CaptureGroup {
-    static let outputType: OutputType = .testCase
-
-    /// Regular expression to capture the symbol, input type, and input value.
-    /// $1 = symbol
-    /// $2 = input type (tagExpr or input)
-    /// $3 = input value
-    static let regex = Regex(pattern: #"^(􀟈)\s*Passing (\d+) argument[s]? (tagExpr|input) → "(.*)"(?:,.*)? to .*$"#)
-
-    let symbol: String
-    let inputType: String
-    let inputValue: String
-
-    init?(groups: [String]) {
-        assert(groups.count >= 3)
-        guard let symbol = groups[safe: 0],
-              let inputType = groups[safe: 1],
-              let inputValue = groups[safe: 2] else { return nil }
-
-        self.symbol = symbol
-        self.inputType = inputType
-        self.inputValue = inputValue
     }
 }

--- a/Sources/XcbeautifyLib/Formatter.swift
+++ b/Sources/XcbeautifyLib/Formatter.swift
@@ -240,10 +240,6 @@ package struct Formatter {
             return renderer.formatSwiftTestingIssueArguments(group: group)
         case let group as SwiftTestingPassingArgumentCaptureGroup:
             return renderer.formatSwiftTestingPassingArgument(group: group)
-        case let group as SwiftTestingPassingArgumentMultipleCaptureGroup:
-            return renderer.formatSwiftTestingPassingArgumentMultiple(group: group)
-        case let group as SwiftTestingAttributeCaptureGroup:
-            return renderer.formatSwiftTestingAttribute(group: group)
         default:
             assertionFailure()
             return nil

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -116,8 +116,6 @@ package final class Parser {
         SwiftTestingIssueCaptureGroup.self,
         SwiftTestingIssueArgumentCaptureGroup.self,
         SwiftTestingPassingArgumentCaptureGroup.self,
-        SwiftTestingPassingArgumentMultipleCaptureGroup.self,
-        SwiftTestingAttributeCaptureGroup.self,
     ]
 
     // MARK: - Init

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -99,8 +99,6 @@ protocol OutputRendering {
     func formatSwiftTestingIssue(group: SwiftTestingIssueCaptureGroup) -> String
     func formatSwiftTestingIssueArguments(group: SwiftTestingIssueArgumentCaptureGroup) -> String
     func formatSwiftTestingPassingArgument(group: SwiftTestingPassingArgumentCaptureGroup) -> String?
-    func formatSwiftTestingPassingArgumentMultiple(group: SwiftTestingPassingArgumentMultipleCaptureGroup) -> String?
-    func formatSwiftTestingAttribute(group: SwiftTestingAttributeCaptureGroup) -> String?
 }
 
 extension OutputRendering {
@@ -635,25 +633,17 @@ extension OutputRendering {
 
     func formatSwiftTestingIssue(group: SwiftTestingIssueCaptureGroup) -> String {
         let issueDetails = group.issueDetails.map { " at \($0)" } ?? ""
-        let message = " Test [\(group.testDescription)] recorded an issue\(issueDetails)"
+        let message = " Test \(group.testDescription) recorded an issue\(issueDetails)"
         return colored ? Format.indent + Symbol.warning.f.Yellow + " " + message : Format.indent + Symbol.asciiWarning + " " + message
     }
 
     func formatSwiftTestingIssueArguments(group: SwiftTestingIssueArgumentCaptureGroup) -> String {
         let argumentsInfo = group.numberOfArguments.map { " with \($0) argument(s)" } ?? ""
-        let message = " Test [\(group.testDescription)] recorded an issue\(argumentsInfo)"
+        let message = " Test \(group.testDescription) recorded an issue\(argumentsInfo)"
         return colored ? Format.indent + Symbol.warning.f.Yellow + " " + message : Format.indent + Symbol.asciiWarning + " " + message
     }
 
     func formatSwiftTestingPassingArgument(group: SwiftTestingPassingArgumentCaptureGroup) -> String? {
-        nil
-    }
-
-    func formatSwiftTestingPassingArgumentMultiple(group: SwiftTestingPassingArgumentMultipleCaptureGroup) -> String? {
-        nil
-    }
-
-    func formatSwiftTestingAttribute(group: SwiftTestingAttributeCaptureGroup) -> String? {
         nil
     }
 }

--- a/Tests/XcbeautifyLibTests/ParserTests.swift
+++ b/Tests/XcbeautifyLibTests/ParserTests.swift
@@ -130,7 +130,7 @@ final class ParserTests: XCTestCase {
     func testMatchSwiftTestingSuiteFailed() throws {
         let input = #"􀢄 Suite "AnotherTestSuite" failed after 6.4 seconds with 3 issues."#
         let captureGroup = try XCTUnwrap(parser.parse(line: input) as? SwiftTestingSuiteFailedCaptureGroup)
-        XCTAssertEqual(captureGroup.suiteName, "AnotherTestSuite")
+        XCTAssertEqual(captureGroup.suiteName, "\"AnotherTestSuite\"")
         XCTAssertEqual(captureGroup.timeTaken, "6.4")
         XCTAssertEqual(captureGroup.numberOfIssues, 3)
     }
@@ -138,7 +138,7 @@ final class ParserTests: XCTestCase {
     func testMatchSwiftTestingTestFailed() throws {
         let input = #"􀢄 Test "SomeTest" failed after 2.5 seconds with 1 issue."#
         let captureGroup = try XCTUnwrap(parser.parse(line: input) as? SwiftTestingTestFailedCaptureGroup)
-        XCTAssertEqual(captureGroup.testName, "SomeTest")
+        XCTAssertEqual(captureGroup.testName, "\"SomeTest\"")
         XCTAssertEqual(captureGroup.timeTaken, "2.5")
         XCTAssertEqual(captureGroup.numberOfIssues, 1)
     }
@@ -153,20 +153,20 @@ final class ParserTests: XCTestCase {
     func testMatchSwiftTestingTestSkipped() throws {
         let input = #"􀙟 Test "SkippedTest" skipped."#
         let captureGroup = try XCTUnwrap(parser.parse(line: input) as? SwiftTestingTestSkippedCaptureGroup)
-        XCTAssertEqual(captureGroup.testName, "SkippedTest")
+        XCTAssertEqual(captureGroup.testName, "\"SkippedTest\"")
     }
 
     func testMatchSwiftTestingTestSkippedWithReason() throws {
         let input = #"􀙟 Test "SkippedTest" skipped: "Not relevant for this platform.""#
         let captureGroup = try XCTUnwrap(parser.parse(line: input) as? SwiftTestingTestSkippedReasonCaptureGroup)
-        XCTAssertEqual(captureGroup.testName, "SkippedTest")
+        XCTAssertEqual(captureGroup.testName, "\"SkippedTest\"")
         XCTAssertEqual(captureGroup.reason, "Not relevant for this platform.")
     }
 
     func testMatchSwiftTestingIssue() throws {
         let input = #"􀢄  Test "Selected tests by ID" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
         let captureGroup = try XCTUnwrap(parser.parse(line: input) as? SwiftTestingIssueCaptureGroup)
-        XCTAssertEqual(captureGroup.testDescription, "Selected tests by ID")
+        XCTAssertEqual(captureGroup.testDescription, "\"Selected tests by ID\"")
         XCTAssertEqual(captureGroup.issueDetails, "PlanTests.swift:43:5: Expectation failed")
     }
 

--- a/Tests/XcbeautifyLibTests/ParsingTests/ParsingTests.swift
+++ b/Tests/XcbeautifyLibTests/ParsingTests/ParsingTests.swift
@@ -72,6 +72,7 @@ final class ParsingTests: XCTestCase {
         while !buildLog.isEmpty {
             let line = buildLog.removeFirst()
             if !line.isEmpty, parser.parse(line: line) == nil {
+                print(line)
                 uncapturedOutput += 1
             }
         }

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -625,28 +625,28 @@ final class GitHubActionsRendererTests: XCTestCase {
     func testSwiftTestingSuiteFailed() {
         let input = #"􀢄 Suite "MyTestSuite" failed after 8.456 seconds with 2 issues."#
         let formatted = logFormatted(input)
-        let expectedOutput = "::error ::Suite MyTestSuite failed after 8.456 seconds with 2 issue(s)"
+        let expectedOutput = "::error ::Suite \"MyTestSuite\" failed after 8.456 seconds with 2 issue(s)"
         XCTAssertEqual(formatted, expectedOutput)
     }
 
     func testSwiftTestingTestFailed() {
         let input = #"􀢄 Test "myTest" failed after 1.234 seconds with 1 issue."#
         let formatted = logFormatted(input)
-        let expectedOutput = "::error ::myTest (1.234 seconds) 1 issue(s)"
+        let expectedOutput = "::error ::\"myTest\" (1.234 seconds) 1 issue(s)"
         XCTAssertEqual(formatted, expectedOutput)
     }
 
     func testSwiftTestingTestSkipped() {
-        let input = #"􀙟 Test "myTest" skipped."#
+        let input = #"􀙟 Test myTest() skipped."#
         let formatted = logFormatted(input)
-        let expectedOutput = "::notice ::Skipped myTest"
+        let expectedOutput = "::notice ::Skipped myTest()"
         XCTAssertEqual(formatted, expectedOutput)
     }
 
     func testSwiftTestingTestSkippedReason() {
-        let input = #"􀙟 Test "myTest" skipped: "Reason for skipping""#
+        let input = #"􀙟 Test myTest() skipped: "Reason for skipping""#
         let formatted = logFormatted(input)
-        let expectedOutput = "::notice ::Skipped myTest.(Reason for skipping)"
+        let expectedOutput = "::notice ::Skipped myTest().(Reason for skipping)"
         XCTAssertEqual(formatted, expectedOutput)
     }
 

--- a/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
@@ -646,25 +646,25 @@ final class TeamCityRendererTests: XCTestCase {
         let input = #"􀢄 Suite "MyTestSuite" failed after 8.456 seconds with 2 issues."#
         let formatted = noColoredFormatted(input)
 
-        XCTAssertEqual(formatted, "##teamcity[message text=\'Suite failed\' errorDetails=\'MyTestSuite failed after 8.456 seconds with 2 issue(s)\' status=\'ERROR\']\nSuite failed")
+        XCTAssertEqual(formatted, "##teamcity[message text=\'Suite failed\' errorDetails=\'\"MyTestSuite\" failed after 8.456 seconds with 2 issue(s)\' status=\'ERROR\']\nSuite failed")
     }
 
     func testSwiftTestingTestFailed() {
         let input = #"􀢄 Test "myTest" failed after 1.234 seconds with 1 issue."#
         let formatted = noColoredFormatted(input)
-        XCTAssertEqual(formatted, "##teamcity[message text=\'Test failed\' errorDetails=\'myTest (1.234 seconds) 1 issue(s)\' status=\'ERROR\']\nTest failed")
+        XCTAssertEqual(formatted, "##teamcity[message text=\'Test failed\' errorDetails=\'\"myTest\" (1.234 seconds) 1 issue(s)\' status=\'ERROR\']\nTest failed")
     }
 
     func testSwiftTestingTestSkipped() {
         let input = #"􀙟 Test "myTest" skipped."#
         let formatted = noColoredFormatted(input)
-        XCTAssertEqual(formatted, "##teamcity[message text=\'Test skipped|nmyTest\' status=\'WARNING\']\nTest skipped")
+        XCTAssertEqual(formatted, "##teamcity[message text=\'Test skipped|n\"myTest\"\' status=\'WARNING\']\nTest skipped")
     }
 
     func testSwiftTestingTestSkippedReason() {
         let input = #"􀙟 Test "myTest" skipped: "Reason for skipping""#
         let formatted = noColoredFormatted(input)
-        XCTAssertEqual(formatted, "##teamcity[message text=\'Test skipped|nmyTest (Reason for skipping)\' status=\'WARNING\']\nTest skipped")
+        XCTAssertEqual(formatted, "##teamcity[message text=\'Test skipped|n\"myTest\" (Reason for skipping)\' status=\'WARNING\']\nTest skipped")
     }
 
     func testSwiftTestingIssue() {

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -666,8 +666,8 @@ final class TerminalRendererTests: XCTestCase {
     }
 
     func testSwiftTestingSuiteFailed() {
-        let input = #"􀢄 Suite "MyTestSuite" failed after 8.456 seconds with 2 issues."#
-        let output = "Suite MyTestSuite failed after 8.456 seconds with 2 issue(s)"
+        let input = #"􀢄 Suite "My Test Suite" failed after 8.456 seconds with 2 issues."#
+        let output = "Suite \"My Test Suite\" failed after 8.456 seconds with 2 issue(s)"
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 
@@ -679,31 +679,31 @@ final class TerminalRendererTests: XCTestCase {
 
     func testSwiftTestingTestFailed() {
         let input = #"􀢄 Test "myTest" failed after 1.234 seconds with 1 issue."#
-        let output = "    ✖ myTest (1.234 seconds) 1 issue(s)"
+        let output = "    ✖ \"myTest\" (1.234 seconds) 1 issue(s)"
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 
     func testSwiftTestingTestSkipped() {
         let input = #"􀙟 Test "myTest" skipped."#
-        let output = "    ⊘ myTest skipped"
+        let output = "    ⊘ \"myTest\" skipped"
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 
     func testSwiftTestingTestSkippedReason() {
         let input = #"􀙟 Test "myTest" skipped: "Reason for skipping""#
-        let output = "    ⊘ myTest skipped (Reason for skipping)"
+        let output = "    ⊘ \"myTest\" skipped (Reason for skipping)"
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 
     func testSwiftTestingIssue() {
         let input = #"􀢄 Test "myTest" recorded an issue with 2 arguments."#
-        let output = "    [!]  Test [myTest] recorded an issue with 2 argument(s)"
+        let output = "    [!]  Test \"myTest\" recorded an issue with 2 argument(s)"
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 
     func testSwiftTestingIssueDetails() {
         let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
-        let output = #"    [!]  Test [myTest] recorded an issue at PlanTests.swift:43:5: Expectation failed"#
+        let output = #"    [!]  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 }


### PR DESCRIPTION

This pull request modifies the regex patterns used to capture output in Swift test runs. Specifically:

1. **Removed symbol capture**: 
   - Xcode and Swift Package Manager testing use different symbols to denote test statuses (e.g., ✔, ✖, etc.). Since these symbols can vary across environments, they were removed from the regex capture groups. The focus is now on capturing the essential parts of the test output (such as test names, results, and timings), ensuring better cross-environment compatibility.
   
2. **Relaxed test/suite name captures**:
   - Tests and suites can be annotated with various names, including special characters and spaces. The regex patterns were updated to be more flexible, allowing for a broader range of valid names without failing to capture. This enables better parsing of outputs, regardless of how the test or suite names are formatted.


**Changes:**

- **Capture groups no longer include symbols**. The symbol component was removed from all regex patterns to ensure consistent parsing across different environments like Xcode and Swift Package Manager, where test run symbols can differ.
  
- **Improved flexibility in capturing test and suite names**. The regex patterns were updated to allow for names with special characters, spaces, or other variations.


For instance, this change was made to handle test runs more reliably:

**Before:**
```swift
static let regex = Regex(pattern: #"^(􀟈)\s*(Test run started\.)$"#)
```

**After:**
```swift
static let regex = Regex(pattern: #"^.\s+(Test run started\.)$"#)
```

Additionally, suite and test captures were relaxed. Tests/Suites can be annotated (`@Test("This is a test name")`) or not so we need to be flexible in capturing.


This update simplifies the handling of different environments and improves the accuracy of capturing test run details without depending on symbols that vary between environments.