### PR TITLE
Delete Match Method

### DIFF
--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -134,25 +134,20 @@ package final class Parser {
             return nil
         }
 
-        // Find first parser that can parse specified string
-        guard let idx = captureGroupTypes.firstIndex(where: { $0.regex.match(string: line) }) else {
-            return nil
+        for (index, captureGroupType) in captureGroupTypes.enumerated() {
+            guard let groups = captureGroupType.regex.captureGroups(for: line) else { continue }
+
+            guard let captureGroup = captureGroupType.init(groups: groups) else {
+                assertionFailure()
+                return nil
+            }
+
+            // Move found parser to the top, so next time it will be checked first
+            captureGroupTypes.insert(captureGroupTypes.remove(at: index), at: 0)
+
+            return captureGroup
         }
 
-        guard let captureGroupType = captureGroupTypes[safe: idx] else {
-            assertionFailure()
-            return nil
-        }
-
-        let groups: [String] = captureGroupType.regex.captureGroups(for: line)
-        guard let captureGroup = captureGroupType.init(groups: groups) else {
-            assertionFailure()
-            return nil
-        }
-
-        // Move found parser to the top, so next time it will be checked first
-        captureGroupTypes.insert(captureGroupTypes.remove(at: idx), at: 0)
-
-        return captureGroup
+        return nil
     }
 }

--- a/Sources/XcbeautifyLib/XCRegex.swift
+++ b/Sources/XcbeautifyLib/XCRegex.swift
@@ -15,14 +15,15 @@ package final class XCRegex: @unchecked Sendable {
         self.pattern = pattern
     }
 
-    func match(string: String) -> Bool {
-        let fullRange = NSRange(string.startIndex..., in: string)
-        return regex?.rangeOfFirstMatch(in: string, range: fullRange).location != NSNotFound
-    }
+    func captureGroups(for line: String) -> [String]? {
+        assert(regex != nil)
 
-    func captureGroups(for line: String) -> [String] {
-        let matches = regex?.matches(in: line, range: NSRange(location: 0, length: line.utf16.count))
-        guard let match = matches?.first else { return [] }
+        guard
+            let matches = regex?.matches(in: line, range: NSRange(location: 0, length: line.utf16.count)),
+            let match = matches.first
+        else {
+            return nil
+        }
 
         let lastRangeIndex = match.numberOfRanges - 1
         guard lastRangeIndex >= 1 else { return [] }

--- a/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
+++ b/Tests/XcbeautifyLibTests/CaptureGroupTests.swift
@@ -18,22 +18,22 @@ final class CaptureGroupTests: XCTestCase {
         ]
 
         for input in inputs {
-            XCTAssertTrue(SwiftCompilingCaptureGroup.regex.match(string: input))
+            XCTAssertNotNil(SwiftCompilingCaptureGroup.regex.captureGroups(for: input))
         }
     }
 
     func testMatchCompilationResults() {
         let input = #"/* com.apple.actool.compilation-results */"#
-        XCTAssertTrue(CompilationResultCaptureGroup.regex.match(string: input))
+        XCTAssertNotNil(CompilationResultCaptureGroup.regex.captureGroups(for: input))
     }
 
     func testMatchSwiftDriverJobDiscoveryEmittingModule() {
         let input = #"SwiftDriverJobDiscovery normal arm64 Emitting module for Widgets (in target 'Widgets' from project 'Backyard Birds')"#
-        XCTAssertTrue(SwiftDriverJobDiscoveryEmittingModuleCaptureGroup.regex.match(string: input))
+        XCTAssertNotNil(SwiftDriverJobDiscoveryEmittingModuleCaptureGroup.regex.captureGroups(for: input))
     }
 
     func testMkDirCaptureGroup() throws {
         let input = "MkDir /Backyard-Birds/Build/Products/Debug/Widgets.appex/Contents (in target \'Widgets\' from project \'Backyard Birds\')"
-        XCTAssertTrue(MkDirCaptureGroup.regex.match(string: input))
+        XCTAssertNotNil(MkDirCaptureGroup.regex.captureGroups(for: input))
     }
 }


### PR DESCRIPTION
Delete the `match` method which first checks whether a given `String` input matches against a specified regular expression. Instead, attempt to extract the capture groups from a given regular expression. If the `captureGroups` method returns `nil`, it implies a failed match. Otherwise, a successful match is implied by a non-`nil` return value.