### PR TITLE
Rename to XCRegex

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -2,7 +2,7 @@ import Foundation
 
 package protocol CaptureGroup {
     static var outputType: OutputType { get }
-    static var regex: XcbeautifyLib.Regex { get }
+    static var regex: XCRegex { get }
     init?(groups: [String])
 }
 
@@ -49,7 +49,7 @@ struct AnalyzeCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = file path
     /// $2 = filename
-    static let regex = Regex(pattern: #"^Analyze(?:Shallow)?\s(.*\/(.*\.(?:m|mm|cc|cpp|c|cxx)))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^Analyze(?:Shallow)?\s(.*\/(.*\.(?:m|mm|cc|cpp|c|cxx)))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let filePath: String
     let filename: String
@@ -71,7 +71,7 @@ struct BuildTargetCaptureGroup: TargetCaptureGroup {
     /// $1 = target
     /// $2 = project
     /// $3 = configuration
-    static let regex = Regex(pattern: #"^=== BUILD TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#)
+    static let regex = XCRegex(pattern: #"^=== BUILD TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#)
 
     let target: String
     let project: String
@@ -93,7 +93,7 @@ struct AggregateTargetCaptureGroup: TargetCaptureGroup {
     /// $1 = target
     /// $2 = project
     /// $3 = configuration
-    static let regex = Regex(pattern: #"^=== BUILD AGGREGATE TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#)
+    static let regex = XCRegex(pattern: #"^=== BUILD AGGREGATE TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#)
 
     let target: String
     let project: String
@@ -115,7 +115,7 @@ struct AnalyzeTargetCaptureGroup: TargetCaptureGroup {
     /// $1 = target
     /// $2 = project
     /// $3 = configuration
-    static let regex = Regex(pattern: #"^=== ANALYZE TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#)
+    static let regex = XCRegex(pattern: #"^=== ANALYZE TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH.*CONFIGURATION\s(.*)\s==="#)
 
     let target: String
     let project: String
@@ -133,7 +133,7 @@ struct AnalyzeTargetCaptureGroup: TargetCaptureGroup {
 /// Nothing returned here for now
 struct CheckDependenciesCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
-    static let regex = Regex(pattern: #"^Check dependencies"#)
+    static let regex = XCRegex(pattern: #"^Check dependencies"#)
 
     private init() { }
 
@@ -149,7 +149,7 @@ struct ShellCommandCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = command path
     /// $2 = arguments
-    static let regex = Regex(pattern: #"^\s{4}(cd|setenv|(?:[\w\/:\s\-.]+?\/)?[\w\-]+)\s(.*)$"#)
+    static let regex = XCRegex(pattern: #"^\s{4}(cd|setenv|(?:[\w\/:\s\-.]+?\/)?[\w\-]+)\s(.*)$"#)
 
     let commandPath: String
     let arguments: String
@@ -166,7 +166,7 @@ struct CleanRemoveCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
     /// Nothing returned here for now
-    static let regex = Regex(pattern: #"^Clean.Remove(.*)"#)
+    static let regex = XCRegex(pattern: #"^Clean.Remove(.*)"#)
 
     let directory: String
 
@@ -184,7 +184,7 @@ struct CleanTargetCaptureGroup: TargetCaptureGroup {
     /// $1 = target
     /// $2 = project
     /// $3 = configuration
-    static let regex = Regex(pattern: #"^=== CLEAN TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH CONFIGURATION\s(.*)\s==="#)
+    static let regex = XCRegex(pattern: #"^=== CLEAN TARGET\s(.*)\sOF PROJECT\s(.*)\sWITH CONFIGURATION\s(.*)\s==="#)
 
     let target: String
     let project: String
@@ -204,7 +204,7 @@ struct CodesignCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = file
-    static let regex = Regex(pattern: #"^CodeSign\s(((?!.framework/Versions/A)(?:\ |[^ ]))*?)( \(in target '.*' from project '.*' at path '.*'\))?$"#)
+    static let regex = XCRegex(pattern: #"^CodeSign\s(((?!.framework/Versions/A)(?:\ |[^ ]))*?)( \(in target '.*' from project '.*' at path '.*'\))?$"#)
 
     let file: String
 
@@ -220,7 +220,7 @@ struct CodesignFrameworkCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = file
-    static let regex = Regex(pattern: #"^CodeSign\s((?:\ |[^ ])*.framework)\/Versions/A"#)
+    static let regex = XCRegex(pattern: #"^CodeSign\s((?:\ |[^ ])*.framework)\/Versions/A"#)
 
     let frameworkPath: String
 
@@ -238,13 +238,13 @@ struct CompileCaptureGroup: CompileFileCaptureGroup {
     /// Regular expression captured groups:
     /// $1 = filename (e.g. KWNull.m)
     /// $2 = target
-    static let regex = Regex(pattern: #"^\[\d+\/\d+\]\sCompiling\s([^ ]+)\s([^ \.]+\.(?:m|mm|c|cc|cpp|cxx|swift))"#)
+    static let regex = XCRegex(pattern: #"^\[\d+\/\d+\]\sCompiling\s([^ ]+)\s([^ \.]+\.(?:m|mm|c|cc|cpp|cxx|swift))"#)
     #else
     /// Regular expression captured groups:
     /// $1 = file path
     /// $2 = filename (e.g. KWNull.m)
     /// $3 = target
-    static let regex = Regex(pattern: #"^Compile[\w]+\s.+?\s((?:\.|[^ ])+\/((?:\.|[^ ])+\.(?:m|mm|c|cc|cpp|cxx|swift)))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^Compile[\w]+\s.+?\s((?:\.|[^ ])+\/((?:\.|[^ ])+\.(?:m|mm|c|cc|cpp|cxx|swift)))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
     #endif
 
     #if !os(Linux)
@@ -276,7 +276,7 @@ struct SwiftCompileCaptureGroup: CompileFileCaptureGroup {
     /// $1 = file path
     /// $2 = target
     /// $3 = project
-    static let regex = Regex(pattern: #"^SwiftCompile \w+ \w+ ((?:\S|(?<=\\) )+) \(in target '(.*)' from project '(.*)'\)$"#)
+    static let regex = XCRegex(pattern: #"^SwiftCompile \w+ \w+ ((?:\S|(?<=\\) )+) \(in target '(.*)' from project '(.*)'\)$"#)
 
     let filePath: String
     let filename: String
@@ -296,7 +296,7 @@ struct SwiftCompileCaptureGroup: CompileFileCaptureGroup {
 struct SwiftCompilingCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: #"^SwiftCompile \w+ \w+ Compiling\\"#)
+    static let regex = XCRegex(pattern: #"^SwiftCompile \w+ \w+ Compiling\\"#)
 
     init?(groups: [String]) { }
 }
@@ -307,7 +307,7 @@ struct CompileCommandCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = compiler command
     /// $2 = file path
-    static let regex = Regex(pattern: #"^\s*(.*clang\s.*\s\-c\s(.*\.(?:m|mm|c|cc|cpp|cxx))\s.*\.o)$"#)
+    static let regex = XCRegex(pattern: #"^\s*(.*clang\s.*\s\-c\s(.*\.(?:m|mm|c|cc|cpp|cxx))\s.*\.o)$"#)
 
     let compilerCommand: String
     let filePath: String
@@ -327,7 +327,7 @@ struct CompileXibCaptureGroup: CompileFileCaptureGroup {
     /// $1 = file path
     /// $2 = filename (e.g. MainMenu.xib)
     /// $3 = target
-    static let regex = Regex(pattern: #"^CompileXIB\s(.*\/(.*\.xib))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^CompileXIB\s(.*\/(.*\.xib))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let filePath: String
     let filename: String
@@ -349,7 +349,7 @@ struct CompileStoryboardCaptureGroup: CompileFileCaptureGroup {
     /// $1 = file path
     /// $2 = filename (e.g. Main.storyboard)
     /// $3 = target
-    static let regex = Regex(pattern: #"^CompileStoryboard\s(.*\/([^\/].*\.storyboard))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^CompileStoryboard\s(.*\/([^\/].*\.storyboard))\s.*\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let filePath: String
     let filename: String
@@ -368,7 +368,7 @@ struct CopyFilesCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
     // ((?:\S|(?<=\\) )+) --> Match any non-whitespace character OR any escaped space (space in filename)
-    static let regex = Regex(pattern: #"^Copy ((?:\S|(?<=\\) )+) ((?:\S|(?<=\\) )+) \(in target '(.*)' from project '.*'\)$"#)
+    static let regex = XCRegex(pattern: #"^Copy ((?:\S|(?<=\\) )+) ((?:\S|(?<=\\) )+) \(in target '(.*)' from project '.*'\)$"#)
 
     let firstFilePath: String
     let firstFilename: String
@@ -394,7 +394,7 @@ struct CopyHeaderCaptureGroup: CopyCaptureGroup {
     /// $1 = source file
     /// $2 = target file
     /// $3 = target
-    static let regex = Regex(pattern: #"^CpHeader\s(.*\.h)\s(.*\.h) \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^CpHeader\s(.*\.h)\s(.*\.h) \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let file: String
     let targetFile: String
@@ -415,7 +415,7 @@ struct CopyPlistCaptureGroup: CopyCaptureGroup {
     /// Regular expression captured groups:
     /// $1 = source file
     /// $2 = target file
-    static let regex = Regex(pattern: #"^CopyPlistFile\s(.*\.plist)\s(.*\.plist) \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^CopyPlistFile\s(.*\.plist)\s(.*\.plist) \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let file: String
     let target: String
@@ -433,7 +433,7 @@ struct CopyStringsCaptureGroup: CopyCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = file
-    static let regex = Regex(pattern: #"^CopyStringsFile\s(.*\.strings)\s(.*\.strings) \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^CopyStringsFile\s(.*\.strings)\s(.*\.strings) \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let file: String
     let target: String
@@ -451,7 +451,7 @@ struct CpresourceCaptureGroup: CopyCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = resource
-    static let regex = Regex(pattern: #"^CpResource\s(.*)\s\/(.*) \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^CpResource\s(.*)\s\/(.*) \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let file: String
     let target: String
@@ -472,7 +472,7 @@ struct ExecutedWithoutSkippedCaptureGroup: ExecutedCaptureGroup {
     /// $2 = number of failures
     /// $3 = number of unexpected failures
     /// $4 = wall clock time in seconds (e.g. 0.295)
-    static let regex = Regex(pattern: #"^\s*(Executed\s(\d+)\stest[s]?,\swith\s(\d+)\sfailure[s]?\s\((\d+)\sunexpected\)\sin\s\d+\.\d{3}\s\((\d+\.\d{3})\)\sseconds.*)$"#)
+    static let regex = XCRegex(pattern: #"^\s*(Executed\s(\d+)\stest[s]?,\swith\s(\d+)\sfailure[s]?\s\((\d+)\sunexpected\)\sin\s\d+\.\d{3}\s\((\d+\.\d{3})\)\sseconds.*)$"#)
 
     let wholeResult: String
     let numberOfTests: Int
@@ -502,7 +502,7 @@ struct ExecutedWithSkippedCaptureGroup: ExecutedCaptureGroup {
     /// $3 = number of failures
     /// $4 = number of unexpected failures
     /// $5 = wall clock time in seconds (e.g. 0.295)
-    static let regex = Regex(pattern: #"^\s*(Executed\s(\d+)\stest[s]?,\swith\s(\d+)\stest[s]?\sskipped\sand\s(\d+)\sfailure[s]?\s\((\d+)\sunexpected\)\sin\s\d+\.\d{3}\s\((\d+\.\d{3})\)\sseconds.*)$"#)
+    static let regex = XCRegex(pattern: #"^\s*(Executed\s(\d+)\stest[s]?,\swith\s(\d+)\stest[s]?\sskipped\sand\s(\d+)\sfailure[s]?\s\((\d+)\sunexpected\)\sin\s\d+\.\d{3}\s\((\d+\.\d{3})\)\sseconds.*)$"#)
 
     let wholeResult: String
     let numberOfTests: Int
@@ -527,7 +527,7 @@ struct ExecutedWithSkippedCaptureGroup: ExecutedCaptureGroup {
 struct ExplicitDependencyCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: #"^[ \t]*➜ Explicit dependency on target '([^']+)' in project '([^']+)'$"#)
+    static let regex = XCRegex(pattern: #"^[ \t]*➜ Explicit dependency on target '([^']+)' in project '([^']+)'$"#)
 
     let target: String
     let project: String
@@ -549,9 +549,9 @@ struct FailingTestCaptureGroup: CaptureGroup {
     /// $3 = test case
     /// $4 = reason
     #if os(Linux)
-    static let regex = Regex(pattern: #"^\s*(.+:\d+):\serror:\s(.*)\.(.*)\s:(?:\s'.*'\s\[failed\],)?\s(.*)"#)
+    static let regex = XCRegex(pattern: #"^\s*(.+:\d+):\serror:\s(.*)\.(.*)\s:(?:\s'.*'\s\[failed\],)?\s(.*)"#)
     #else
-    static let regex = Regex(pattern: #"^\s*(.+:\d+):\serror:\s[\+\-]\[(.*?)\s(.*)\]\s:(?:\s'.*'\s\[FAILED\],)?\s(.*)"#)
+    static let regex = XCRegex(pattern: #"^\s*(.+:\d+):\serror:\s[\+\-]\[(.*?)\s(.*)\]\s:(?:\s'.*'\s\[FAILED\],)?\s(.*)"#)
     #endif
 
     let file: String
@@ -575,7 +575,7 @@ struct UIFailingTestCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = file
     /// $2 = reason
-    static let regex = Regex(pattern: #"^\s{4}t = \s+\d+\.\d+s\s+Assertion Failure: (.*:\d+): (.*)$"#)
+    static let regex = XCRegex(pattern: #"^\s{4}t = \s+\d+\.\d+s\s+Assertion Failure: (.*:\d+): (.*)$"#)
 
     let file: String
     let reason: String
@@ -596,7 +596,7 @@ struct RestartingTestCaptureGroup: CaptureGroup {
     /// $2 = test suite + test case
     /// $3 = test suite
     /// $4 = test case
-    static let regex = Regex(pattern: #"^(Restarting after unexpected exit, crash, or test timeout in (-\[(\w+)\s(\w+)\]|(\w+)\.(\w+)\(\));.*)"#)
+    static let regex = XCRegex(pattern: #"^(Restarting after unexpected exit, crash, or test timeout in (-\[(\w+)\s(\w+)\]|(\w+)\.(\w+)\(\));.*)"#)
 
     let wholeMessage: String
     let testSuiteAndTestCase: String
@@ -618,7 +618,7 @@ struct GenerateCoverageDataCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = coverage report file path
-    static let regex = Regex(pattern: #"^generating\s+coverage\s+data\.*"#)
+    static let regex = XCRegex(pattern: #"^generating\s+coverage\s+data\.*"#)
 
     private init() { }
 
@@ -630,7 +630,7 @@ struct GenerateCoverageDataCaptureGroup: CaptureGroup {
 
 struct GeneratedCoverageReportCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
-    static let regex = Regex(pattern: #"^generated\s+coverage\s+report:\s+(.+)"#)
+    static let regex = XCRegex(pattern: #"^generated\s+coverage\s+report:\s+(.+)"#)
 
     let coverageReportFilePath: String
 
@@ -647,7 +647,7 @@ struct GenerateDSYMCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = dsym
     /// $2 = target
-    static let regex = Regex(pattern: #"^GenerateDSYMFile \/.*\/(.*\.dSYM) \/.* \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^GenerateDSYMFile \/.*\/(.*\.dSYM) \/.* \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let dsym: String
     let target: String
@@ -666,7 +666,7 @@ struct LibtoolCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = library
     /// $2 = target
-    static let regex = Regex(pattern: #"^Libtool.*\/(.*) .* .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^Libtool.*\/(.*) .* .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let filename: String
     let target: String
@@ -685,12 +685,12 @@ struct LinkingCaptureGroup: CaptureGroup {
     #if os(Linux)
     /// Regular expression captured groups:
     /// $1 = target
-    static let regex = Regex(pattern: #"^\[\d+\/\d+\]\sLinking\s([^ ]+)"#)
+    static let regex = XCRegex(pattern: #"^\[\d+\/\d+\]\sLinking\s([^ ]+)"#)
     #else
     /// Regular expression captured groups:
     /// $1 = binary filename
     /// $2 = target
-    static let regex = Regex(pattern: #"^Ld \/?.*\/(.*?) normal .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^Ld \/?.*\/(.*?) normal .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
     #endif
 
     #if !os(Linux)
@@ -720,9 +720,9 @@ struct TestCaseSkippedCaptureGroup: CaptureGroup {
     /// $2 = test case
     /// $3 = time
     #if os(Linux)
-    static let regex = Regex(pattern: #"^\s*Test Case\s'(.*)\.(.*)'\sskipped\s\((\d*\.\d{1,3})\sseconds\)"#)
+    static let regex = XCRegex(pattern: #"^\s*Test Case\s'(.*)\.(.*)'\sskipped\s\((\d*\.\d{1,3})\sseconds\)"#)
     #else
-    static let regex = Regex(pattern: #"^\s*Test Case\s'-\[(.*?)\s(.*)\]'\sskipped\s\((\d*\.\d{3})\sseconds\)."#)
+    static let regex = XCRegex(pattern: #"^\s*Test Case\s'-\[(.*?)\s(.*)\]'\sskipped\s\((\d*\.\d{3})\sseconds\)."#)
     #endif
 
     let suite: String
@@ -746,9 +746,9 @@ struct TestCasePassedCaptureGroup: CaptureGroup {
     /// $2 = test case
     /// $3 = time
     #if os(Linux)
-    static let regex = Regex(pattern: #"^\s*Test Case\s'(.*)\.(.*)'\spassed\s\((\d*\.\d{1,3})\sseconds\)"#)
+    static let regex = XCRegex(pattern: #"^\s*Test Case\s'(.*)\.(.*)'\spassed\s\((\d*\.\d{1,3})\sseconds\)"#)
     #else
-    static let regex = Regex(pattern: #"^\s*Test Case\s'-\[(.*?)\s(.*)\]'\spassed\s\((\d*\.\d{3})\sseconds\)."#)
+    static let regex = XCRegex(pattern: #"^\s*Test Case\s'-\[(.*?)\s(.*)\]'\spassed\s\((\d*\.\d{3})\sseconds\)."#)
     #endif
 
     let suite: String
@@ -771,9 +771,9 @@ struct TestCaseStartedCaptureGroup: CaptureGroup {
     /// $1 = suite
     /// $2 = test case
     #if os(Linux)
-    static let regex = Regex(pattern: #"^Test Case '(.*)\.(.*)' started at"#)
+    static let regex = XCRegex(pattern: #"^Test Case '(.*)\.(.*)' started at"#)
     #else
-    static let regex = Regex(pattern: #"^Test Case '-\[(.*?) (.*)\]' started.$"#)
+    static let regex = XCRegex(pattern: #"^Test Case '-\[(.*?) (.*)\]' started.$"#)
     #endif
 
     let suite: String
@@ -793,7 +793,7 @@ struct TestCasePendingCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = test case
-    static let regex = Regex(pattern: #"^Test Case\s'-\[(.*?)\s(.*)PENDING\]'\spassed"#)
+    static let regex = XCRegex(pattern: #"^Test Case\s'-\[(.*?)\s(.*)PENDING\]'\spassed"#)
 
     let suite: String
     let testCase: String
@@ -813,9 +813,9 @@ struct TestCaseMeasuredCaptureGroup: CaptureGroup {
     /// $2 = test case
     /// $3 = time
     #if os(Linux)
-    static let regex = Regex(pattern: #"^[^:]*:[^:]*:\sTest Case\s'(.*?)\.(.*)'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#)
+    static let regex = XCRegex(pattern: #"^[^:]*:[^:]*:\sTest Case\s'(.*?)\.(.*)'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#)
     #else
-    static let regex = Regex(pattern: #"^[^:]*:[^:]*:\sTest Case\s'-\[(.*?)\s(.*)\]'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#)
+    static let regex = XCRegex(pattern: #"^[^:]*:[^:]*:\sTest Case\s'-\[(.*?)\s(.*)\]'\smeasured\s\[([^,]*),\s([^\]]*)\]\saverage:\s(\d*\.\d{3}), relative standard deviation: (\d*\.\d{3})"#)
     #endif
 
     let suite: String
@@ -845,7 +845,7 @@ struct ParallelTestCaseSkippedCaptureGroup: CaptureGroup {
     /// $2 = test case
     /// $3 = installed app file and ID (e.g. "MyApp.app (12345)"), process (e.g. "xctest (12345)"), or device (e.g. "iPhone X")
     /// $4 = time
-    static let regex = Regex(pattern: #"^Test\s+case\s+'(.*)\.(.*)\(\)'\s+skipped\s+on\s+'(.*)'\s+\((\d*\.(.*){3})\s+seconds\)"#)
+    static let regex = XCRegex(pattern: #"^Test\s+case\s+'(.*)\.(.*)\(\)'\s+skipped\s+on\s+'(.*)'\s+\((\d*\.(.*){3})\s+seconds\)"#)
 
     let suite: String
     let testCase: String
@@ -870,7 +870,7 @@ struct ParallelTestCasePassedCaptureGroup: CaptureGroup {
     /// $2 = test case
     /// $3 = installed app file and ID (e.g. "MyApp.app (12345)"), process (e.g. "xctest (12345)"), or device (e.g. "iPhone X")
     /// $4 = time
-    static let regex = Regex(pattern: #"^Test\s+case\s+'(.*)[\.\/](.*)\(\)'\s+passed\s+on\s+'(.*)'\s+\((\d*\.(.*){3})\s+seconds\)"#)
+    static let regex = XCRegex(pattern: #"^Test\s+case\s+'(.*)[\.\/](.*)\(\)'\s+passed\s+on\s+'(.*)'\s+\((\d*\.(.*){3})\s+seconds\)"#)
 
     let suite: String
     let testCase: String
@@ -894,7 +894,7 @@ struct ParallelTestCaseAppKitPassedCaptureGroup: CaptureGroup {
     /// $1 = suite
     /// $2 = test case
     /// $3 = time
-    static let regex = Regex(pattern: #"^\s*Test case\s'-\[(.*?)\s(.*)\]'\spassed\son\s'.*'\s\((\d*\.\d{3})\sseconds\)"#)
+    static let regex = XCRegex(pattern: #"^\s*Test case\s'-\[(.*?)\s(.*)\]'\spassed\son\s'.*'\s\((\d*\.\d{3})\sseconds\)"#)
 
     let suite: String
     let testCase: String
@@ -917,7 +917,7 @@ struct ParallelTestCaseFailedCaptureGroup: CaptureGroup {
     /// $2 = test case
     /// $3 = installed app file and ID (e.g. "MyApp.app (12345)"), process (e.g. "xctest (12345)"), or device (e.g. "iPhone X")
     /// $4 = time
-    static let regex = Regex(pattern: #"^Test\s+case\s+'(.*)[\./](.*)\(\)'\s+failed\s+on\s+'(.*)'\s+\((\d*\.(.*){3})\s+seconds\)"#)
+    static let regex = XCRegex(pattern: #"^Test\s+case\s+'(.*)[\./](.*)\(\)'\s+failed\s+on\s+'(.*)'\s+\((\d*\.(.*){3})\s+seconds\)"#)
 
     let suite: String
     let testCase: String
@@ -940,7 +940,7 @@ struct ParallelTestingStartedCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = whole message
     /// $2 = device
-    static let regex = Regex(pattern: #"^(Testing\s+started\s+on\s+'(.*)'.*)$"#)
+    static let regex = XCRegex(pattern: #"^(Testing\s+started\s+on\s+'(.*)'.*)$"#)
 
     let wholeMessage: String
     let device: String
@@ -959,7 +959,7 @@ struct ParallelTestingPassedCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = whole message
     /// $2 = device
-    static let regex = Regex(pattern: #"^(Testing\s+passed\s+on\s+'(.*)'.*)$"#)
+    static let regex = XCRegex(pattern: #"^(Testing\s+passed\s+on\s+'(.*)'.*)$"#)
 
     let wholeMessage: String
     let device: String
@@ -978,7 +978,7 @@ struct ParallelTestingFailedCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = whole error
     /// $2 = device
-    static let regex = Regex(pattern: #"^(Testing\s+failed\s+on\s+'(.*)'.*)$"#)
+    static let regex = XCRegex(pattern: #"^(Testing\s+failed\s+on\s+'(.*)'.*)$"#)
 
     let wholeError: String
     let device: String
@@ -997,7 +997,7 @@ struct ParallelTestSuiteStartedCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = suite
     /// $2 = device
-    static let regex = Regex(pattern: #"^\s*Test\s+Suite\s+'(.*)'\s+started\s+on\s+'(.*)'"#)
+    static let regex = XCRegex(pattern: #"^\s*Test\s+Suite\s+'(.*)'\s+started\s+on\s+'(.*)'"#)
 
     let suite: String
     let device: String
@@ -1012,7 +1012,7 @@ struct ParallelTestSuiteStartedCaptureGroup: CaptureGroup {
 
 struct PhaseSuccessCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .result
-    static let regex = Regex(pattern: #"^\*\*\s(.*)\sSUCCEEDED\s\*\*"#)
+    static let regex = XCRegex(pattern: #"^\*\*\s(.*)\sSUCCEEDED\s\*\*"#)
 
     let phase: String
 
@@ -1029,7 +1029,7 @@ struct PhaseScriptExecutionCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = phase name
     /// $2 = target
-    static let regex = Regex(pattern: #"^PhaseScriptExecution\s(.*)\s\/.*\.sh\s\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^PhaseScriptExecution\s(.*)\s\/.*\.sh\s\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let phaseName: String
     let target: String
@@ -1048,7 +1048,7 @@ struct ProcessPchCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = file
     /// $2 = build target
-    static let regex = Regex(pattern: #"^ProcessPCH(?:\+\+)?\s.*\s\/.*\/(.*) normal .* .* .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^ProcessPCH(?:\+\+)?\s.*\s\/.*\/(.*) normal .* .* .* \((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let file: String
     let buildTarget: String
@@ -1066,7 +1066,7 @@ struct ProcessPchCommandCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 file path
-    static let regex = Regex(pattern: #"^\s*.*\/usr\/bin\/clang\s.*\s\-c\s(.*?)(?<!\\)\s.*\-o\s.*\.gch"#)
+    static let regex = XCRegex(pattern: #"^\s*.*\/usr\/bin\/clang\s.*\s\-c\s(.*?)(?<!\\)\s.*\-o\s.*\.gch"#)
 
     let filePath: String
 
@@ -1085,7 +1085,7 @@ struct PreprocessCaptureGroup: CaptureGroup {
     /// $2 = file
     /// $3 = target
     /// $4 = project
-    static let regex = Regex(pattern: #"^Preprocess\s(.*\/(.*\.(?:m|mm|cc|cpp|c|cxx)))\s.*\(in target '(.*)' from project '(.*)'\)"#)
+    static let regex = XCRegex(pattern: #"^Preprocess\s(.*\/(.*\.(?:m|mm|cc|cpp|c|cxx)))\s.*\(in target '(.*)' from project '(.*)'\)"#)
 
     let filePath: String
     let file: String
@@ -1109,7 +1109,7 @@ struct PbxcpCaptureGroup: CopyCaptureGroup {
     /// $1 = source file
     /// $2 = target file
     /// $3 = build target
-    static let regex = Regex(pattern: #"^PBXCp\s(.*)\s\/(.*)\s\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
+    static let regex = XCRegex(pattern: #"^PBXCp\s(.*)\s\/(.*)\s\((in target: (.*)|in target '(.*)' from project '.*')\)"#)
 
     let file: String
     let targetFile: String
@@ -1131,7 +1131,7 @@ struct ProcessInfoPlistCaptureGroup: CaptureGroup {
     /// $1 = file path
     /// $2 = filename
     /// $4 = target
-    static let regex = Regex(pattern: #"^ProcessInfoPlistFile\s.*\.plist\s(.*\/+(.*\.plist))( \((in target: (.*)|in target '(.*)' from project '.*')\))?"#)
+    static let regex = XCRegex(pattern: #"^ProcessInfoPlistFile\s.*\.plist\s(.*\/+(.*\.plist))( \((in target: (.*)|in target '(.*)' from project '.*')\))?"#)
 
     let filePath: String
     let filename: String
@@ -1164,9 +1164,9 @@ struct TestsRunCompletionCaptureGroup: CaptureGroup {
     /// $2 = result
     /// $3 = time
     #if os(Linux)
-    static let regex = Regex(pattern: #"^\s*(Test Suite '(.*)' (finished|passed|failed) at (.*).*)"#)
+    static let regex = XCRegex(pattern: #"^\s*(Test Suite '(.*)' (finished|passed|failed) at (.*).*)"#)
     #else
-    static let regex = Regex(pattern: #"^\s*(Test Suite '(?:.*\/)?(.*[ox]ctest.*)' (finished|passed|failed) at (.*).*)"#)
+    static let regex = XCRegex(pattern: #"^\s*(Test Suite '(?:.*\/)?(.*[ox]ctest.*)' (finished|passed|failed) at (.*).*)"#)
     #endif
 
     let wholeResult: String
@@ -1191,9 +1191,9 @@ struct TestSuiteStartedCaptureGroup: CaptureGroup {
     /// $1 = suite
     /// $2 = time
     #if os(Linux)
-    static let regex = Regex(pattern: #"^\s*Test Suite '(.*)' started at(.*)"#)
+    static let regex = XCRegex(pattern: #"^\s*Test Suite '(.*)' started at(.*)"#)
     #else
-    static let regex = Regex(pattern: #"^\s*Test Suite '(?:.*\/)?(.*[ox]ctest.*)' started at(.*)"#)
+    static let regex = XCRegex(pattern: #"^\s*Test Suite '(?:.*\/)?(.*[ox]ctest.*)' started at(.*)"#)
     #endif
 
     let suite: String
@@ -1212,7 +1212,7 @@ struct TestSuiteStartCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = test suite name
-    static let regex = Regex(pattern: #"^\s*Test Suite '(.*)' started at"#)
+    static let regex = XCRegex(pattern: #"^\s*Test Suite '(.*)' started at"#)
 
     let testSuiteName: String
 
@@ -1225,7 +1225,7 @@ struct TestSuiteStartCaptureGroup: CaptureGroup {
 
 struct TestSuiteAllTestsPassedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .result
-    static let regex = Regex(pattern: #"^\s*(Test Suite 'All tests' passed at.*)"#)
+    static let regex = XCRegex(pattern: #"^\s*(Test Suite 'All tests' passed at.*)"#)
 
     let wholeResult: String
 
@@ -1238,7 +1238,7 @@ struct TestSuiteAllTestsPassedCaptureGroup: CaptureGroup {
 
 struct TestSuiteAllTestsFailedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .result
-    static let regex = Regex(pattern: #"^\s*(Test Suite 'All tests' failed at.*)"#)
+    static let regex = XCRegex(pattern: #"^\s*(Test Suite 'All tests' failed at.*)"#)
 
     let wholeResult: String
 
@@ -1254,7 +1254,7 @@ struct TIFFutilCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = filename
-    static let regex = Regex(pattern: #"^TiffUtil\s(.*)"#)
+    static let regex = XCRegex(pattern: #"^TiffUtil\s(.*)"#)
 
     let filename: String
 
@@ -1271,7 +1271,7 @@ struct TouchCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = filename
     /// $3 = target
-    static let regex = Regex(pattern: #"^Touch\s(.*\/(.+))( \((in target: (.*)|in target '(.*)' from project '.*')\))"#)
+    static let regex = XCRegex(pattern: #"^Touch\s(.*\/(.+))( \((in target: (.*)|in target '(.*)' from project '.*')\))"#)
 
     let filename: String
     let target: String
@@ -1289,7 +1289,7 @@ struct WriteFileCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = file path
-    static let regex = Regex(pattern: #"^write-file\s(.*)"#)
+    static let regex = XCRegex(pattern: #"^write-file\s(.*)"#)
 
     let filePath: String
 
@@ -1303,7 +1303,7 @@ struct WriteFileCaptureGroup: CaptureGroup {
 struct WriteAuxiliaryFileCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: #"^WriteAuxiliaryFile (.*\/(.*\..*)) \(in target '(.*)' from project '.*'\)$"#)
+    static let regex = XCRegex(pattern: #"^WriteAuxiliaryFile (.*\/(.*\..*)) \(in target '(.*)' from project '.*'\)$"#)
 
     let filePath: String
     let filename: String
@@ -1325,7 +1325,7 @@ struct CompileWarningCaptureGroup: CaptureGroup {
     /// $1 = file path
     /// $2 = filename
     /// $3 = reason
-    static let regex = Regex(pattern: #"^(([^:]*):*\d*:*\d*):\swarning:\s(.*)$"#)
+    static let regex = XCRegex(pattern: #"^(([^:]*):*\d*:*\d*):\swarning:\s(.*)$"#)
 
     let filePath: String
     let filename: String
@@ -1346,7 +1346,7 @@ struct LDWarningCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = ld prefix
     /// $2 = warning message
-    static let regex = Regex(pattern: #"^(ld: )warning: (.*)"#)
+    static let regex = XCRegex(pattern: #"^(ld: )warning: (.*)"#)
 
     let ldPrefix: String
     let warningMessage: String
@@ -1364,7 +1364,7 @@ struct GenericWarningCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = whole warning
-    static let regex = Regex(pattern: #"^warning:\s(.*)$"#)
+    static let regex = XCRegex(pattern: #"^warning:\s(.*)$"#)
 
     let wholeWarning: String
 
@@ -1380,7 +1380,7 @@ struct WillNotBeCodeSignedCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = whole warning
-    static let regex = Regex(pattern: #"^(.* will not be code signed because .*)$"#)
+    static let regex = XCRegex(pattern: #"^(.* will not be code signed because .*)$"#)
 
     let wholeWarning: String
 
@@ -1396,7 +1396,7 @@ struct DuplicateLocalizedStringKeyCaptureGroup: CaptureGroup {
 
     /// Regular expresion captured groups:
     /// $1 = warning message.
-    static let regex = Regex(pattern: #"^[\d\s-:]+ --- WARNING: (Key ".*" used with multiple values. Value ".*" kept. Value ".*" ignored.)$"#)
+    static let regex = XCRegex(pattern: #"^[\d\s-:]+ --- WARNING: (Key ".*" used with multiple values. Value ".*" kept. Value ".*" ignored.)$"#)
 
     let warningMessage: String
 
@@ -1412,7 +1412,7 @@ struct ClangErrorCaptureGroup: ErrorCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    static let regex = Regex(pattern: #"^(clang: error:.*)$"#)
+    static let regex = XCRegex(pattern: #"^(clang: error:.*)$"#)
 
     let wholeError: String
 
@@ -1428,7 +1428,7 @@ struct CheckDependenciesErrorsCaptureGroup: ErrorCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    static let regex = Regex(pattern: #"^(Code\s?Sign error:.*|Code signing is required for product type .* in SDK .*|No profile matching .* found:.*|Provisioning profile .* doesn't .*|Swift is unavailable on .*|.?Use Legacy Swift Language Version.*)$"#)
+    static let regex = XCRegex(pattern: #"^(Code\s?Sign error:.*|Code signing is required for product type .* in SDK .*|No profile matching .* found:.*|Provisioning profile .* doesn't .*|Swift is unavailable on .*|.?Use Legacy Swift Language Version.*)$"#)
 
     let wholeError: String
 
@@ -1444,7 +1444,7 @@ struct ProvisioningProfileRequiredCaptureGroup: ErrorCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    static let regex = Regex(pattern: #"^(.*requires a provisioning profile.*)$"#)
+    static let regex = XCRegex(pattern: #"^(.*requires a provisioning profile.*)$"#)
 
     let wholeError: String
 
@@ -1460,7 +1460,7 @@ struct NoCertificateCaptureGroup: ErrorCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    static let regex = Regex(pattern: #"^(No certificate matching.*)$"#)
+    static let regex = XCRegex(pattern: #"^(No certificate matching.*)$"#)
 
     let wholeError: String
 
@@ -1478,7 +1478,7 @@ struct CompileErrorCaptureGroup: CaptureGroup {
     /// $1 = file path
     /// $2 = is fatal error
     /// $3 = reason
-    static let regex = Regex(pattern: #"^(([^:]*):*\d*:*\d*):\s(?:fatal\s)?error:\s(.*)$"#)
+    static let regex = XCRegex(pattern: #"^(([^:]*):*\d*:*\d*):\s(?:fatal\s)?error:\s(.*)$"#)
 
     let filePath: String
     let isFatalError: String
@@ -1498,7 +1498,7 @@ struct CursorCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = cursor (with whitespaces and tildes)
-    static let regex = Regex(pattern: #"^([\s~]*\^[\s~]*)$"#)
+    static let regex = XCRegex(pattern: #"^([\s~]*\^[\s~]*)$"#)
 
     let cursor: String
 
@@ -1515,7 +1515,7 @@ struct FatalErrorCaptureGroup: ErrorCaptureGroup {
     /// Regular expression captured groups:
     /// $1 = whole error.
     /// it varies a lot, not sure if it makes sense to catch everything separately
-    static let regex = Regex(pattern: #"^(fatal error:.*)$"#)
+    static let regex = XCRegex(pattern: #"^(fatal error:.*)$"#)
 
     let wholeError: String
 
@@ -1532,7 +1532,7 @@ struct FileMissingErrorCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = whole error.
     /// $2 = file path
-    static let regex = Regex(pattern: #"^<unknown>:0:\s(error:\s.*)\s'(\/.+\/.*\..*)'$"#)
+    static let regex = XCRegex(pattern: #"^<unknown>:0:\s(error:\s.*)\s'(\/.+\/.*\..*)'$"#)
 
     let reason: String
     let filePath: String
@@ -1550,7 +1550,7 @@ struct LDErrorCaptureGroup: ErrorCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    static let regex = Regex(pattern: #"^(ld:.*)"#)
+    static let regex = XCRegex(pattern: #"^(ld:.*)"#)
 
     let wholeError: String
 
@@ -1566,7 +1566,7 @@ struct LinkerDuplicateSymbolsLocationCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = file path
-    static let regex = Regex(pattern: #"^\s+(\/.*\.o[\)]?)$"#)
+    static let regex = XCRegex(pattern: #"^\s+(\/.*\.o[\)]?)$"#)
 
     let wholeError: String
 
@@ -1582,7 +1582,7 @@ struct LinkerDuplicateSymbolsCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = reason
-    static let regex = Regex(pattern: #"^(duplicate symbol .*):$"#)
+    static let regex = XCRegex(pattern: #"^(duplicate symbol .*):$"#)
 
     let reason: String
 
@@ -1598,7 +1598,7 @@ struct LinkerUndefinedSymbolLocationCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = symbol location
-    static let regex = Regex(pattern: #"^(.* in .*\.o)$"#)
+    static let regex = XCRegex(pattern: #"^(.* in .*\.o)$"#)
 
     let symbolLocation: String
 
@@ -1614,7 +1614,7 @@ struct LinkerUndefinedSymbolsCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = reason
-    static let regex = Regex(pattern: #"^(Undefined symbols for architecture .*):$"#)
+    static let regex = XCRegex(pattern: #"^(Undefined symbols for architecture .*):$"#)
 
     let reason: String
 
@@ -1630,7 +1630,7 @@ struct PodsErrorCaptureGroup: ErrorCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = reason
-    static let regex = Regex(pattern: #"^(error:\s.*)"#)
+    static let regex = XCRegex(pattern: #"^(error:\s.*)"#)
 
     let wholeError: String
 
@@ -1647,7 +1647,7 @@ struct SymbolReferencedFromCaptureGroup: CaptureGroup {
     /// Regular expression captured groups:
     /// $1 = wholeError
     /// $2 = reference
-    static let regex = Regex(pattern: #"(\s+\"(.*)\", referenced from:)$"#)
+    static let regex = XCRegex(pattern: #"(\s+\"(.*)\", referenced from:)$"#)
 
     let wholeError: String
     let reference: String
@@ -1665,7 +1665,7 @@ struct ModuleIncludesErrorCaptureGroup: ErrorCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = error reason
-    static let regex = Regex(pattern: #"^\<module-includes\>:.*?:.*?:\s(?:fatal\s)?(error:\s.*)$/"#)
+    static let regex = XCRegex(pattern: #"^\<module-includes\>:.*?:.*?:\s(?:fatal\s)?(error:\s.*)$/"#)
 
     let wholeError: String
 
@@ -1682,7 +1682,7 @@ struct UndefinedSymbolLocationCaptureGroup: CaptureGroup {
     /// $1 = whole warning
     /// $2 = target
     /// $3 = filename
-    static let regex = Regex(pattern: #"(.+ in (.+)\((.+)\.o\))$"#)
+    static let regex = XCRegex(pattern: #"(.+ in (.+)\((.+)\.o\))$"#)
 
     let wholeWarning: String
     let target: String
@@ -1699,7 +1699,7 @@ struct UndefinedSymbolLocationCaptureGroup: CaptureGroup {
 
 struct PackageFetchingCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
-    static let regex = Regex(pattern: #"^Fetching from (.*?)$"#)
+    static let regex = XCRegex(pattern: #"^Fetching from (.*?)$"#)
 
     let source: String
 
@@ -1712,7 +1712,7 @@ struct PackageFetchingCaptureGroup: CaptureGroup {
 
 struct PackageUpdatingCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
-    static let regex = Regex(pattern: #"^Updating from (.*?)$"#)
+    static let regex = XCRegex(pattern: #"^Updating from (.*?)$"#)
 
     let source: String
 
@@ -1725,7 +1725,7 @@ struct PackageUpdatingCaptureGroup: CaptureGroup {
 
 struct PackageCheckingOutCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
-    static let regex = Regex(pattern: #"^Checking out (.*?) of package (.*?)$"#)
+    static let regex = XCRegex(pattern: #"^Checking out (.*?) of package (.*?)$"#)
 
     let version: String
     let package: String
@@ -1740,7 +1740,7 @@ struct PackageCheckingOutCaptureGroup: CaptureGroup {
 
 struct PackageGraphResolvingStartCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
-    static let regex = Regex(pattern: #"^\s*Resolve Package Graph\s*$"#)
+    static let regex = XCRegex(pattern: #"^\s*Resolve Package Graph\s*$"#)
 
     private init() { }
 
@@ -1752,7 +1752,7 @@ struct PackageGraphResolvingStartCaptureGroup: CaptureGroup {
 
 struct PackageGraphResolvingEndedCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
-    static let regex = Regex(pattern: #"^Resolved source packages:$"#)
+    static let regex = XCRegex(pattern: #"^Resolved source packages:$"#)
 
     private init() { }
 
@@ -1769,7 +1769,7 @@ struct PackageGraphResolvedItemCaptureGroup: CaptureGroup {
     /// $1 = package name
     /// $2 = package url
     /// $3 = package version
-    static let regex = Regex(pattern: #"^\s*([^\s:]+):\s([^ ]+)\s@\s(\d+\.\d+\.\d+)"#)
+    static let regex = XCRegex(pattern: #"^\s*([^\s:]+):\s([^ ]+)\s@\s(\d+\.\d+\.\d+)"#)
 
     let packageName: String
     let packageURL: String
@@ -1789,7 +1789,7 @@ struct XcodebuildErrorCaptureGroup: ErrorCaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = whole error
-    static let regex = Regex(pattern: #"^(xcodebuild: error:.*)$"#)
+    static let regex = XCRegex(pattern: #"^(xcodebuild: error:.*)$"#)
 
     let wholeError: String
 
@@ -1803,7 +1803,7 @@ struct XcodebuildErrorCaptureGroup: ErrorCaptureGroup {
 struct CompilationResultCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: #"^\/\* com.apple.actool.compilation-results \*\/$"#)
+    static let regex = XCRegex(pattern: #"^\/\* com.apple.actool.compilation-results \*\/$"#)
 
     init?(groups: [String]) { }
 }
@@ -1811,7 +1811,7 @@ struct CompilationResultCaptureGroup: CaptureGroup {
 struct SwiftDriverJobDiscoveryEmittingModuleCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: #"SwiftDriverJobDiscovery \w+ \w+ Emitting module for .* \(in target '.*' from project '.*'\)"#)
+    static let regex = XCRegex(pattern: #"SwiftDriverJobDiscovery \w+ \w+ Emitting module for .* \(in target '.*' from project '.*'\)"#)
 
     init?(groups: [String]) { }
 }
@@ -1823,7 +1823,7 @@ struct TestingStartedCaptureGroup: CaptureGroup {
 
     /// Regular expression captured groups:
     /// $1 = whole message
-    static let regex = Regex(pattern: "^(Testing started.*)$")
+    static let regex = XCRegex(pattern: "^(Testing started.*)$")
 
     let wholeMessage: String
 
@@ -1848,7 +1848,7 @@ struct SwiftDriverJobDiscoveryCompilingCaptureGroup: CaptureGroup {
     // $3 = filenames
     // $4 = target
     // $5 = project
-    static let regex = Regex(pattern: #"^SwiftDriverJobDiscovery (\S+) (\S+) Compiling ((?:\S|(?>, )|(?<=\\) )+) \(in target '(.*)' from project '(.*)'\)"#)
+    static let regex = XCRegex(pattern: #"^SwiftDriverJobDiscovery (\S+) (\S+) Compiling ((?:\S|(?>, )|(?<=\\) )+) \(in target '(.*)' from project '(.*)'\)"#)
 
     let state: String // Currently, the only expected/known value is `normal`
     let architecture: String
@@ -1872,7 +1872,7 @@ struct SwiftTestingRunStartedCaptureGroup: CaptureGroup {
 
     /// Regular expression to capture the start of a test run.
     /// $1 = message
-    static let regex = Regex(pattern: #"^.\s+(Test run started\.)$"#)
+    static let regex = XCRegex(pattern: #"^.\s+(Test run started\.)$"#)
 
     let message: String
 
@@ -1889,7 +1889,7 @@ struct SwiftTestingRunCompletionCaptureGroup: CaptureGroup {
     /// Regular expression to capture the number of tests and total time.
     /// $1 = number of tests
     /// $2 = total time in seconds
-    static let regex = Regex(pattern: #"^.\s+Test run with (\d+) test(?:s)? passed after ([\d.]+) seconds\.$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Test run with (\d+) test(?:s)? passed after ([\d.]+) seconds\.$"#)
 
     let numberOfTests: Int
     let totalTime: String
@@ -1910,7 +1910,7 @@ struct SwiftTestingRunFailedCaptureGroup: CaptureGroup {
     /// $1 = number of tests
     /// $2 = total time in seconds
     /// $3 = number of issues
-    static let regex = Regex(pattern: #"^.\s+Test run with (\d+) test(?:s)? failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Test run with (\d+) test(?:s)? failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
 
     let numberOfTests: Int
     let totalTime: String
@@ -1932,7 +1932,7 @@ struct SwiftTestingSuiteStartedCaptureGroup: CaptureGroup {
 
     /// Regular expression to capture the start of a test suite.
     /// $1 = suite name
-    static let regex = Regex(pattern: #"^.\s+Suite (.*) started\.$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Suite (.*) started\.$"#)
 
     let suiteName: String
 
@@ -1948,7 +1948,7 @@ struct SwiftTestingTestStartedCaptureGroup: CaptureGroup {
 
     /// Regular expression to capture the start of a test case.
     /// $1 = test name
-    static let regex = Regex(pattern: #"^.\s+Test\s+(.*) started\.$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Test\s+(.*) started\.$"#)
 
     let testName: String
     let wholeMessage: String
@@ -1967,7 +1967,7 @@ struct SwiftTestingSuitePassedCaptureGroup: CaptureGroup {
     /// Regular expression to capture the successful completion of a test suite.
     /// $1 = suite name
     /// $2 = total time taken in seconds
-    static let regex = Regex(pattern: #"^.\s+Suite (.*) passed after ([\d.]+) seconds\.$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Suite (.*) passed after ([\d.]+) seconds\.$"#)
 
     let suiteName: String
     let timeTaken: String
@@ -1988,7 +1988,7 @@ struct SwiftTestingSuiteFailedCaptureGroup: CaptureGroup {
     /// $1 = suite name
     /// $2 = total time taken in seconds
     /// $3 = number of issues
-    static let regex = Regex(pattern: #"^.\s+Suite (.*) failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Suite (.*) failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
 
     let suiteName: String
     let timeTaken: String
@@ -2012,7 +2012,7 @@ struct SwiftTestingTestFailedCaptureGroup: CaptureGroup {
     /// $1 = test name
     /// $2 = time taken in seconds
     /// $3 = number of issues
-    static let regex = Regex(pattern: #"^.\s+Test (?!run\s)(.*) failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Test (?!run\s)(.*) failed after ([\d.]+) seconds with (\d+) issue[s]?\.$"#)
 
     let testName: String
     let timeTaken: String
@@ -2035,7 +2035,7 @@ struct SwiftTestingTestPassedCaptureGroup: CaptureGroup {
     /// Regular expression to capture the successful completion of a test case.
     /// $1 = test name
     /// $2 = time taken in seconds
-    static let regex = Regex(pattern: #"^.*Test (?!run\s)(.*) passed after ([\d.]+) seconds\.$"#)
+    static let regex = XCRegex(pattern: #"^.*Test (?!run\s)(.*) passed after ([\d.]+) seconds\.$"#)
 
     let testName: String
     let timeTaken: String
@@ -2054,7 +2054,7 @@ struct SwiftTestingTestSkippedCaptureGroup: CaptureGroup {
 
     /// Regular expression to capture a skipped test case.
     /// $1 = test name
-    static let regex = Regex(pattern: #"^.\s+Test (.*) skipped\.$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Test (.*) skipped\.$"#)
 
     let testName: String
 
@@ -2071,7 +2071,7 @@ struct SwiftTestingTestSkippedReasonCaptureGroup: CaptureGroup {
     /// Regular expression to capture a skipped test case with a reason.
     /// $1 = test name
     /// $2 = optional reason
-    static let regex = Regex(pattern: #"^.\s+Test (.*) skipped(?:\s*:\s*"(.*)")?$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Test (.*) skipped(?:\s*:\s*"(.*)")?$"#)
 
     let testName: String
     let reason: String?
@@ -2090,7 +2090,7 @@ struct SwiftTestingIssueCaptureGroup: CaptureGroup {
     /// Regular expression to capture the symbol, test description, and issue details.
     /// $1 = test description
     /// $2 = issue details
-    static let regex = Regex(pattern: #"^.\s+Test (.*?) recorded an issue(?: at (.*))?$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Test (.*?) recorded an issue(?: at (.*))?$"#)
 
     let testDescription: String
     let issueDetails: String?
@@ -2110,7 +2110,7 @@ struct SwiftTestingIssueArgumentCaptureGroup: CaptureGroup {
     /// Regular expression to capture the symbol, test description, and optional number of arguments.
     /// $1 = test description
     /// $2 = number of arguments (optional)
-    static let regex = Regex(pattern: #"^.\s+Test (.*?) recorded an issue(?: with (\d+) arguments?)?"#)
+    static let regex = XCRegex(pattern: #"^.\s+Test (.*?) recorded an issue(?: with (\d+) arguments?)?"#)
 
     let testDescription: String
     let numberOfArguments: Int?
@@ -2129,7 +2129,7 @@ struct SwiftTestingPassingArgumentCaptureGroup: CaptureGroup {
 
     /// Regular expression to capture the symbol and number of arguments.
     /// $1 = number of arguments
-    static let regex = Regex(pattern: #"^.\s+Passing (\d+) argument[s]?.*$"#)
+    static let regex = XCRegex(pattern: #"^.\s+Passing (\d+) argument[s]?.*$"#)
 
     let numberOfArguments: Int
 
@@ -2144,7 +2144,7 @@ struct SwiftTestingPassingArgumentCaptureGroup: CaptureGroup {
 struct SwiftDriverTargetCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: #"^SwiftDriver (.*) normal (?:arm64|x86_64) com\.apple\.xcode\.tools\.swift\.compiler"#)
+    static let regex = XCRegex(pattern: #"^SwiftDriver (.*) normal (?:arm64|x86_64) com\.apple\.xcode\.tools\.swift\.compiler"#)
 
     let target: String
 
@@ -2158,7 +2158,7 @@ struct SwiftDriverTargetCaptureGroup: CaptureGroup {
 struct SwiftDriverCompilationTarget: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: #"^SwiftDriver\\ Compilation (.*) normal (?:arm64|x86_64) com\.apple\.xcode\.tools\.swift\.compiler"#)
+    static let regex = XCRegex(pattern: #"^SwiftDriver\\ Compilation (.*) normal (?:arm64|x86_64) com\.apple\.xcode\.tools\.swift\.compiler"#)
 
     let target: String
 
@@ -2172,7 +2172,7 @@ struct SwiftDriverCompilationTarget: CaptureGroup {
 struct SwiftDriverCompilationRequirementsCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: #"^SwiftDriver\\ Compilation\\ Requirements (.*) normal (?:arm64|x86_64) com\.apple\.xcode\.tools\.swift\.compiler"#)
+    static let regex = XCRegex(pattern: #"^SwiftDriver\\ Compilation\\ Requirements (.*) normal (?:arm64|x86_64) com\.apple\.xcode\.tools\.swift\.compiler"#)
 
     let target: String
 
@@ -2186,7 +2186,7 @@ struct SwiftDriverCompilationRequirementsCaptureGroup: CaptureGroup {
 struct MkDirCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .task
 
-    static let regex = Regex(pattern: "^MkDir.*")
+    static let regex = XCRegex(pattern: "^MkDir.*")
 
     init?(groups: [String]) { }
 }

--- a/Sources/XcbeautifyLib/Regex.swift
+++ b/Sources/XcbeautifyLib/Regex.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // `NSRegularExpression` is marked as `@unchecked Sendable`.
 // Match the definition here.
-package final class Regex: @unchecked Sendable {
+package final class XCRegex: @unchecked Sendable {
     let pattern: String
 
     private lazy var regex: NSRegularExpression? = {


### PR DESCRIPTION
Avoid a naming collision with the built-in `Regex` type.