### PR TITLE
[Azure] Add A Renderer For Azure DevOps Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ set -o pipefail && xcodebuild [flags] | xcbeautify --renderer github-actions
 set -o pipefail && xcodebuild [flags] | xcbeautify --renderer teamcity
 ```
 
+### Azure DevOps Pipeline
+
+`xcbeautify` features an integrated Azure DevOps Pipeline renderer that harnesses [logging commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands) to highlight warnings, errors and results directly within the Azure DevOps Pipeline user interface. To utilize this function, simply run `xcbeautify` and add the `--renderer azure-devops-pipelines` flag during execution:
+
+```
+set -o pipefail && xcodebuild [flags] | xcbeautify --renderer azure-devops-pipelines
+```
+
 ## Development
 
 Generate Xcode project:

--- a/Sources/XcbeautifyLib/Constants.swift
+++ b/Sources/XcbeautifyLib/Constants.swift
@@ -43,4 +43,7 @@ public enum Renderer: String {
 
     /// Formats output suitable for TeamCity service messages. Maps to `TeamCityRenderer`.
     case teamcity
+
+    /// Formats output suitable for Azure DevOps Pipeline annotations. Maps to `AzureDevOpsPipelineRenderer`
+    case azureDevOpsPipelines = "azure-devops-pipelines"
 }

--- a/Sources/XcbeautifyLib/Formatter.swift
+++ b/Sources/XcbeautifyLib/Formatter.swift
@@ -19,6 +19,8 @@ package struct Formatter {
             self.renderer = GitHubActionsRenderer(colored: colored, additionalLines: additionalLines)
         case .teamcity:
             self.renderer = TeamCityRenderer(colored: colored, additionalLines: additionalLines)
+        case .azureDevOpsPipelines:
+            self.renderer = AzureDevOpsPipelinesRenderer(colored: colored, additionalLines: additionalLines)
         }
     }
 

--- a/Sources/XcbeautifyLib/Renderers/FileComponents.swift
+++ b/Sources/XcbeautifyLib/Renderers/FileComponents.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct FileComponents {
+    let path: String
+    let line: Int?
+    let column: Int?
+
+    init(path: String, line: Int?, column: Int?) {
+        self.path = path
+        self.line = line
+        self.column = column
+    }
+}
+
+extension String {
+    func asFileComponents() -> FileComponents {
+        let _components = split(separator: ":").map(String.init)
+        assert((1...3).contains(_components.count))
+
+        guard let path = _components[safe: 0] else {
+            return FileComponents(path: self, line: nil, column: nil)
+        }
+
+        let components = _components.dropFirst().compactMap(Int.init)
+        assert((0...2).contains(components.count))
+
+        return FileComponents(path: path, line: components[safe: 0], column: components[safe: 1])
+    }
+}

--- a/Sources/XcbeautifyLib/Renderers/Microsoft/AzureDevOpsPipelinesRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/Microsoft/AzureDevOpsPipelinesRenderer.swift
@@ -16,7 +16,7 @@ struct AzureDevOpsPipelinesRenderer: MicrosoftOutputRendering {
     ) -> String {
         assert(annotation.platforms.contains(.azureDevOps))
         let formattedFileComponents = fileComponents?.formatted ?? ""
-        return "##vso[task.logissue type=\(annotation.rawValue)\(formattedFileComponents)]\(message)"
+        return "##vso[task.logissue type=\(annotation.value)\(formattedFileComponents)]\(message)"
     }
 }
 

--- a/Sources/XcbeautifyLib/Renderers/Microsoft/AzureDevOpsPipelinesRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/Microsoft/AzureDevOpsPipelinesRenderer.swift
@@ -16,7 +16,7 @@ struct AzureDevOpsPipelinesRenderer: MicrosoftOutputRendering {
     ) -> String {
         assert(annotation.platforms.contains(.azureDevOps))
         let formattedFileComponents = fileComponents?.formatted ?? ""
-        return "###vso[task.logissue type=\(annotation.rawValue)\(formattedFileComponents)]\(message)"
+        return "##vso[task.logissue type=\(annotation.rawValue)\(formattedFileComponents)]\(message)"
     }
 }
 

--- a/Sources/XcbeautifyLib/Renderers/Microsoft/AzureDevOpsPipelinesRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/Microsoft/AzureDevOpsPipelinesRenderer.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+struct AzureDevOpsPipelinesRenderer: MicrosoftOutputRendering {
+    let colored: Bool
+    let additionalLines: () -> String?
+
+    init(colored: Bool, additionalLines: @escaping () -> String?) {
+        self.colored = colored
+        self.additionalLines = additionalLines
+    }
+
+    func makeOutputLog(
+        annotation: Annotation,
+        fileComponents: FileComponents?,
+        message: String
+    ) -> String {
+        assert(annotation.platforms.contains(.azureDevOps))
+        let formattedFileComponents = fileComponents?.formatted ?? ""
+        return "###vso[task.logissue type=\(annotation.rawValue)\(formattedFileComponents)]\(message)"
+    }
+}
+
+private extension FileComponents {
+    var formatted: String {
+        guard let line else {
+            return ";sourcepath=\(path)"
+        }
+
+        guard let column else {
+            return ";sourcepath=\(path);linenumber=\(line)"
+        }
+
+        return ";sourcepath=\(path);linenumber=\(line);columnnumber=\(column)"
+    }
+}

--- a/Sources/XcbeautifyLib/Renderers/Microsoft/GitHubActionsRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/Microsoft/GitHubActionsRenderer.swift
@@ -16,7 +16,7 @@ struct GitHubActionsRenderer: MicrosoftOutputRendering {
     ) -> String {
         assert(annotation.platforms.contains(.githubAction))
         let formattedFileComponents = fileComponents?.formatted ?? ""
-        return "::\(annotation.rawValue) \(formattedFileComponents)::\(message)"
+        return "::\(annotation.value) \(formattedFileComponents)::\(message)"
     }
 
     func formatParallelTestCaseSkipped(group: ParallelTestCaseSkippedCaptureGroup) -> String {

--- a/Sources/XcbeautifyLib/Renderers/Microsoft/GitHubActionsRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/Microsoft/GitHubActionsRenderer.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+struct GitHubActionsRenderer: MicrosoftOutputRendering {
+    let colored: Bool
+    let additionalLines: () -> String?
+
+    init(colored: Bool, additionalLines: @escaping () -> String?) {
+        self.colored = colored
+        self.additionalLines = additionalLines
+    }
+
+    func makeOutputLog(
+        annotation: Annotation,
+        fileComponents: FileComponents? = nil,
+        message: String
+    ) -> String {
+        assert(annotation.platforms.contains(.githubAction))
+        let formattedFileComponents = fileComponents?.formatted ?? ""
+        return "::\(annotation.rawValue) \(formattedFileComponents)::\(message)"
+    }
+
+    func formatParallelTestCaseSkipped(group: ParallelTestCaseSkippedCaptureGroup) -> String {
+        let testCase = group.testCase
+        let device = group.device
+        let time = group.time
+        let message = Format.indent + testCase + " on '\(device)' (\(time) seconds)"
+        return makeOutputLog(
+            annotation: .notice,
+            message: message
+        )
+    }
+
+    func formatTestCaseSkipped(group: TestCaseSkippedCaptureGroup) -> String {
+        let testSuite = group.suite
+        let testCase = group.testCase
+        let message = "Skipped \(testSuite).\(testCase)"
+        return makeOutputLog(
+            annotation: .notice,
+            message: message
+        )
+    }
+
+    func formatSwiftTestingRunCompletion(group: SwiftTestingRunCompletionCaptureGroup) -> String {
+        let outputString = "Test run with \(group.numberOfTests) tests passed after \(group.totalTime) seconds"
+        return makeOutputLog(annotation: .notice, message: outputString)
+    }
+
+    func formatSwiftTestingTestSkipped(group: SwiftTestingTestSkippedCaptureGroup) -> String {
+        let message = "Skipped \(group.testName)"
+        return makeOutputLog(
+            annotation: .notice,
+            message: message
+        )
+    }
+
+    func formatSwiftTestingTestSkippedReason(group: SwiftTestingTestSkippedReasonCaptureGroup) -> String {
+        let message = "Skipped \(group.testName)" + (group.reason.map { ".(\($0))" } ?? "")
+        return makeOutputLog(
+            annotation: .notice,
+            message: message
+        )
+    }
+}
+
+private extension FileComponents {
+    var formatted: String {
+        guard let line else {
+            return "file=\(path)"
+        }
+
+        guard let column else {
+            return "file=\(path),line=\(line)"
+        }
+
+        return "file=\(path),line=\(line),col=\(column)"
+    }
+}

--- a/Sources/XcbeautifyLib/Renderers/Microsoft/MicrosoftOutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/Microsoft/MicrosoftOutputRendering.swift
@@ -1,27 +1,47 @@
 import Foundation
 
-struct GitHubActionsRenderer: OutputRendering {
-    private enum AnnotationType: String {
-        case notice
-        case warning
-        case error
+struct Annotation {
+    struct Platforms: OptionSet {
+        let rawValue: Int
+
+        static let githubAction = Platforms(rawValue: 1 << 0)
+        static let azureDevOps = Platforms(rawValue: 1 << 1)
+
+        static let all: Platforms = [.githubAction, .azureDevOps]
     }
 
-    let colored: Bool
-    let additionalLines: () -> String?
+    let rawValue: String
+    let platforms: Platforms
 
-    init(colored: Bool, additionalLines: @escaping () -> String?) {
-        self.colored = colored
-        self.additionalLines = additionalLines
+    static let warning = Annotation(rawValue: "warning", platforms: [.githubAction, .azureDevOps])
+
+    static let error = Annotation(rawValue: "error", platforms: [.githubAction, .azureDevOps])
+
+    static let notice = Annotation(rawValue: "notice", platforms: .githubAction)
+}
+
+extension Annotation: RawRepresentable {
+    init?(rawValue: String) {
+        switch rawValue {
+        case "warning":
+            self = .warning
+        case "error":
+            self = .error
+        case "notice":
+            self = .notice
+        default:
+            return nil
+        }
     }
+}
 
-    private func outputGitHubActionsLog(
-        annotationType: AnnotationType,
-        fileComponents: FileComponents? = nil,
-        message: String
-    ) -> String {
-        let formattedFileComponents = fileComponents?.formatted ?? ""
-        return "::\(annotationType) \(formattedFileComponents)::\(message)"
+protocol MicrosoftOutputRendering: OutputRendering {
+    func makeOutputLog(annotation: Annotation, fileComponents: FileComponents?, message: String) -> String
+}
+
+extension MicrosoftOutputRendering {
+    func makeOutputLog(annotation: Annotation, message: String) -> String {
+        makeOutputLog(annotation: annotation, fileComponents: nil, message: message)
     }
 
     func formatCompileError(group: CompileErrorCaptureGroup) -> String {
@@ -39,8 +59,8 @@ struct GitHubActionsRenderer: OutputRendering {
         \(cursor)
         """
 
-        return outputGitHubActionsLog(
-            annotationType: .error,
+        return makeOutputLog(
+            annotation: .error,
             fileComponents: fileComponents,
             message: message
         )
@@ -61,39 +81,33 @@ struct GitHubActionsRenderer: OutputRendering {
         \(cursor)
         """
 
-        return outputGitHubActionsLog(
-            annotationType: .warning,
+        return makeOutputLog(
+            annotation: .warning,
             fileComponents: fileComponents,
             message: message
         )
     }
 
     func formatSymbolReferencedFrom(group: SymbolReferencedFromCaptureGroup) -> String {
-        outputGitHubActionsLog(
-            annotationType: .error,
-            message: group.wholeError
-        )
+        makeOutputLog(annotation: .error, message: group.wholeError)
     }
 
     func formatUndefinedSymbolLocation(group: UndefinedSymbolLocationCaptureGroup) -> String {
-        outputGitHubActionsLog(
-            annotationType: .warning,
-            message: group.wholeWarning
-        )
+        makeOutputLog(annotation: .warning, message: group.wholeWarning)
     }
 
     func formatDuplicateLocalizedStringKey(group: DuplicateLocalizedStringKeyCaptureGroup) -> String {
         let message = group.warningMessage
-        return outputGitHubActionsLog(
-            annotationType: .warning,
+        return makeOutputLog(
+            annotation: .warning,
             message: message
         )
     }
 
     func formatError(group: any ErrorCaptureGroup) -> String {
         let errorMessage = group.wholeError
-        return outputGitHubActionsLog(
-            annotationType: .error,
+        return makeOutputLog(
+            annotation: .error,
             message: errorMessage
         )
     }
@@ -104,8 +118,8 @@ struct GitHubActionsRenderer: OutputRendering {
         let testCase = group.testCase
         let failingReason = group.reason
         let message = Format.indent + testCase + ", " + failingReason
-        return outputGitHubActionsLog(
-            annotationType: .error,
+        return makeOutputLog(
+            annotation: .error,
             fileComponents: fileComponents,
             message: message
         )
@@ -115,8 +129,8 @@ struct GitHubActionsRenderer: OutputRendering {
         let reason = group.reason
         let filePath = group.filePath
         let fileComponents = filePath.asFileComponents()
-        return outputGitHubActionsLog(
-            annotationType: .error,
+        return makeOutputLog(
+            annotation: .error,
             fileComponents: fileComponents,
             message: reason
         )
@@ -125,20 +139,21 @@ struct GitHubActionsRenderer: OutputRendering {
     func formatLdWarning(group: LDWarningCaptureGroup) -> String {
         let prefix = group.ldPrefix
         let warningMessage = group.warningMessage
-        return outputGitHubActionsLog(
-            annotationType: .warning,
+        return makeOutputLog(
+            annotation: .warning,
+            fileComponents: nil,
             message: "\(prefix)\(warningMessage)"
         )
     }
 
     func formatLinkerDuplicateSymbolsError(group: LinkerDuplicateSymbolsCaptureGroup) -> String {
         let reason = group.reason
-        return outputGitHubActionsLog(annotationType: .error, message: reason)
+        return makeOutputLog(annotation: .error, message: reason)
     }
 
     func formatLinkerUndefinedSymbolsError(group: LinkerUndefinedSymbolsCaptureGroup) -> String {
         let reason = group.reason
-        return outputGitHubActionsLog(annotationType: .error, message: reason)
+        return makeOutputLog(annotation: .error, message: reason)
     }
 
     func formatParallelTestCaseFailed(group: ParallelTestCaseFailedCaptureGroup) -> String {
@@ -146,44 +161,23 @@ struct GitHubActionsRenderer: OutputRendering {
         let device = group.device
         let time = group.time
         let message = "    \(testCase) on '\(device)' (\(time) seconds)"
-        return outputGitHubActionsLog(
-            annotationType: .error,
-            message: message
-        )
-    }
-
-    func formatParallelTestCaseSkipped(group: ParallelTestCaseSkippedCaptureGroup) -> String {
-        let testCase = group.testCase
-        let device = group.device
-        let time = group.time
-        let message = Format.indent + testCase + " on '\(device)' (\(time) seconds)"
-        return outputGitHubActionsLog(
-            annotationType: .notice,
+        return makeOutputLog(
+            annotation: .error,
             message: message
         )
     }
 
     func formatParallelTestingFailed(group: ParallelTestingFailedCaptureGroup) -> String {
-        outputGitHubActionsLog(
-            annotationType: .error,
+        makeOutputLog(
+            annotation: .error,
             message: group.wholeError
         )
     }
 
     func formatRestartingTest(group: RestartingTestCaptureGroup) -> String {
         let message = Format.indent + group.wholeMessage
-        return outputGitHubActionsLog(
-            annotationType: .error,
-            message: message
-        )
-    }
-
-    func formatTestCaseSkipped(group: TestCaseSkippedCaptureGroup) -> String {
-        let testSuite = group.suite
-        let testCase = group.testCase
-        let message = "Skipped \(testSuite).\(testCase)"
-        return outputGitHubActionsLog(
-            annotationType: .notice,
+        return makeOutputLog(
+            annotation: .error,
             message: message
         )
     }
@@ -193,8 +187,8 @@ struct GitHubActionsRenderer: OutputRendering {
         let fileComponents = file.asFileComponents()
         let failingReason = group.reason
         let message = Format.indent + failingReason
-        return outputGitHubActionsLog(
-            annotationType: .error,
+        return makeOutputLog(
+            annotation: .error,
             fileComponents: fileComponents,
             message: message
         )
@@ -202,118 +196,57 @@ struct GitHubActionsRenderer: OutputRendering {
 
     func formatWarning(group: GenericWarningCaptureGroup) -> String {
         let warningMessage = group.wholeWarning
-        return outputGitHubActionsLog(
-            annotationType: .warning,
+        return makeOutputLog(
+            annotation: .warning,
             message: warningMessage
         )
     }
 
     func formatWillNotBeCodesignWarning(group: WillNotBeCodeSignedCaptureGroup) -> String {
         let warningMessage = group.wholeWarning
-        return outputGitHubActionsLog(
-            annotationType: .warning,
+        return makeOutputLog(
+            annotation: .warning,
             message: warningMessage
         )
     }
 
-    func formatSwiftTestingRunCompletion(group: SwiftTestingRunCompletionCaptureGroup) -> String {
-        let outputString = "Test run with \(group.numberOfTests) tests passed after \(group.totalTime) seconds"
-        return outputGitHubActionsLog(annotationType: .notice, message: outputString)
-    }
-
     func formatSwiftTestingRunFailed(group: SwiftTestingRunFailedCaptureGroup) -> String {
         let errorMessage = "Test run with \(group.numberOfTests) tests failed after \(group.totalTime) seconds with \(group.numberOfIssues) issue(s)"
-        return outputGitHubActionsLog(
-            annotationType: .error,
+        return makeOutputLog(
+            annotation: .error,
             message: errorMessage
         )
     }
 
     func formatSwiftTestingSuiteFailed(group: SwiftTestingSuiteFailedCaptureGroup) -> String {
         let errorMessage = "Suite \(group.suiteName) failed after \(group.timeTaken) seconds with \(group.numberOfIssues) issue(s)"
-        return outputGitHubActionsLog(
-            annotationType: .error,
+        return makeOutputLog(
+            annotation: .error,
             message: errorMessage
         )
     }
 
     func formatSwiftTestingTestFailed(group: SwiftTestingTestFailedCaptureGroup) -> String {
         let errorMessage = "\(group.testName) (\(group.timeTaken) seconds) \(group.numberOfIssues) issue(s)"
-        return outputGitHubActionsLog(
-            annotationType: .error,
+        return makeOutputLog(
+            annotation: .error,
             message: errorMessage
-        )
-    }
-
-    func formatSwiftTestingTestSkipped(group: SwiftTestingTestSkippedCaptureGroup) -> String {
-        let message = "Skipped \(group.testName)"
-        return outputGitHubActionsLog(
-            annotationType: .notice,
-            message: message
-        )
-    }
-
-    func formatSwiftTestingTestSkippedReason(group: SwiftTestingTestSkippedReasonCaptureGroup) -> String {
-        let message = "Skipped \(group.testName)" + (group.reason.map { ".(\($0))" } ?? "")
-        return outputGitHubActionsLog(
-            annotationType: .notice,
-            message: message
         )
     }
 
     func formatSwiftTestingIssue(group: SwiftTestingIssueCaptureGroup) -> String {
         let message = "Recorded an issue" + (group.issueDetails.map { " (\($0))" } ?? "")
-        return outputGitHubActionsLog(
-            annotationType: .error,
+        return makeOutputLog(
+            annotation: .error,
             message: message
         )
     }
 
     func formatSwiftTestingIssueArguments(group: SwiftTestingIssueArgumentCaptureGroup) -> String {
         let message = "Recorded an issue" + (group.numberOfArguments.map { " (\($0)) argument(s)" } ?? "")
-        return outputGitHubActionsLog(
-            annotationType: .error,
+        return makeOutputLog(
+            annotation: .error,
             message: message
         )
-    }
-}
-
-private struct FileComponents {
-    private let path: String
-    private let line: Int?
-    private let column: Int?
-
-    init(path: String, line: Int?, column: Int?) {
-        self.path = path
-        self.line = line
-        self.column = column
-    }
-
-    var formatted: String {
-        guard let line else {
-            return "file=\(path)"
-        }
-
-        guard let column else {
-            return "file=\(path),line=\(line)"
-        }
-
-        return "file=\(path),line=\(line),col=\(column)"
-    }
-}
-
-private extension String {
-    func asFileComponents() -> FileComponents {
-        let _components = split(separator: ":").map(String.init)
-        assert((1...3).contains(_components.count))
-
-        guard let path = _components[safe: 0] else {
-            return FileComponents(path: self, line: nil, column: nil)
-        }
-
-        let components = _components.dropFirst().compactMap(Int.init)
-        assert((0...2).contains(components.count))
-
-        return FileComponents(path: path, line: components[safe: 0], column: components[safe: 1])
     }
 }

--- a/Sources/XcbeautifyLib/Renderers/Microsoft/MicrosoftOutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/Microsoft/MicrosoftOutputRendering.swift
@@ -10,29 +10,14 @@ struct Annotation {
         static let all: Platforms = [.githubAction, .azureDevOps]
     }
 
-    let rawValue: String
+    let value: String
     let platforms: Platforms
 
-    static let warning = Annotation(rawValue: "warning", platforms: [.githubAction, .azureDevOps])
+    static let warning = Annotation(value: "warning", platforms: [.githubAction, .azureDevOps])
 
-    static let error = Annotation(rawValue: "error", platforms: [.githubAction, .azureDevOps])
+    static let error = Annotation(value: "error", platforms: [.githubAction, .azureDevOps])
 
-    static let notice = Annotation(rawValue: "notice", platforms: .githubAction)
-}
-
-extension Annotation: RawRepresentable {
-    init?(rawValue: String) {
-        switch rawValue {
-        case "warning":
-            self = .warning
-        case "error":
-            self = .error
-        case "notice":
-            self = .notice
-        default:
-            return nil
-        }
-    }
+    static let notice = Annotation(value: "notice", platforms: .githubAction)
 }
 
 protocol MicrosoftOutputRendering: OutputRendering {

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -34,12 +34,14 @@ struct Xcbeautify: ParsableCommand {
 
     // swiftformat:disable redundantReturn
 
-    @Option(help: "Specify a renderer to format raw xcodebuild output ( options: terminal | github-actions | teamcity ).")
+    @Option(help: "Specify a renderer to format raw xcodebuild output ( options: terminal | github-actions | teamcity | azure-devops-pipelines).")
     var renderer: Renderer = {
         if ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true" {
             return .gitHubActions
         } else if ProcessInfo.processInfo.environment["TEAMCITY_VERSION"] != nil {
             return .teamcity
+        } else if ProcessInfo.processInfo.environment["AZURE_DEVOPS_PIPELINES"] != nil {
+            return .azureDevOpsPipelines
         } else {
             return .terminal
         }

--- a/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
@@ -218,7 +218,17 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
     }
     #endif
 
-    func testFailingTest() { }
+    func testFailingTest() {
+        #if os(Linux)
+        let input = "/path/to/Tests.swift:123: error: Suite.testCase : XCTAssertEqual failed: (\"1\") is not equal to (\"2\") -"
+        let output = "##vso[task.logissue type=error;sourcepath=/path/to/Tests.swift;linenumber=123]    testCase, XCTAssertEqual failed: (\"1\") is not equal to (\"2\") -"
+        #else
+        let input = "/path/to/Tests.swift:123: error: -[Tests.Suite testCase] : XCTAssertEqual failed: (\"1\") is not equal to (\"2\")"
+        let output = "##vso[task.logissue type=error;sourcepath=/path/to/Tests.swift;linenumber=123]    testCase, XCTAssertEqual failed: (\"1\") is not equal to (\"2\")"
+        #endif
+
+        XCTAssertEqual(logFormatted(input), output)
+    }
 
     func testFatalError() {
         let input = "fatal error: malformed or corrupted AST file: 'could not find file '/path/file.h' referenced by AST file' note: after modifying system headers, please delete the module cache at '/path/DerivedData/ModuleCache/M5WJ0FYE7N06'"

--- a/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
@@ -1,0 +1,776 @@
+import Testing
+@testable import XcbeautifyLib
+
+@MainActor
+@Suite
+struct AzureDevOpsPipelinesRendererTests {
+    private var parser: Parser!
+    private var formatter: XcbeautifyLib.Formatter!
+
+    init() {
+        parser = Parser()
+        formatter = Formatter(colored: false, renderer: .azureDevOpsPipelines, additionalLines: { nil })
+    }
+
+    private func logFormatted(_ string: String) -> String? {
+        guard let captureGroup = parser.parse(line: string) else { return nil }
+        return formatter.format(captureGroup: captureGroup)
+    }
+
+    @Test
+    func aggregateTarget() {
+        let formatted = logFormatted("=== BUILD AGGREGATE TARGET Be Aggro OF PROJECT AggregateExample WITH CONFIGURATION Debug ===")
+        #expect(formatted == "Aggregate target Be Aggro of project AggregateExample with configuration Debug")
+    }
+
+    @Test
+    func analyze() {
+        let formatted = logFormatted("AnalyzeShallow /Users/admin/CocoaLumberjack/Classes/DDTTYLogger.m normal x86_64 (in target: CocoaLumberjack-Static)")
+        #expect(formatted == "[CocoaLumberjack-Static] Analyzing DDTTYLogger.m")
+    }
+
+    @Test
+    func analyzeTarget() {
+        let formatted = logFormatted("=== ANALYZE TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ===")
+        #expect(formatted == "Analyze target The Spacer of project Pods with configuration Debug")
+    }
+
+    @Test
+    func buildTarget() {
+        let formatted = logFormatted("=== BUILD TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ===")
+        #expect(formatted == "Build target The Spacer of project Pods with configuration Debug")
+    }
+
+    @Test
+    func checkDependenciesErrors() { }
+
+    @Test
+    func checkDependencies() {
+        let command = "Check Dependencies"
+        let formatted = logFormatted(command)
+        #expect(formatted == command)
+    }
+
+    @Test
+    func clangError() {
+        let formatted = logFormatted("clang: error: linker command failed with exit code 1 (use -v to see invocation)")
+        #expect(formatted == "###vso[task.logissue type=error]clang: error: linker command failed with exit code 1 (use -v to see invocation)")
+    }
+
+    @Test
+    func cleanRemove() {
+        let formatted = logFormatted("Clean.Remove clean /Users/admin/Library/Developer/Xcode/DerivedData/MyLibrary-abcd/Build/Intermediates/MyLibrary.build/Debug-iphonesimulator/MyLibraryTests.build")
+        #expect(formatted == "Cleaning MyLibraryTests.build")
+    }
+
+    @Test
+    func cleanTarget() {
+        let formatted = logFormatted("=== ANALYZE TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ===")
+        #expect(formatted == "Analyze target The Spacer of project Pods with configuration Debug")
+    }
+
+    @Test
+    func codesignFramework() {
+        let formatted = logFormatted("CodeSign build/Release/MyFramework.framework/Versions/A")
+        #expect(formatted == "Signing build/Release/MyFramework.framework")
+    }
+
+    @Test
+    func codesign() {
+        let formatted = logFormatted("CodeSign build/Release/MyApp.app")
+        #expect(formatted == "Signing MyApp.app")
+    }
+
+    @Test
+    func multipleCodesigns() {
+        let formattedApp = logFormatted("CodeSign build/Release/MyApp.app")
+        let formattedFramework = logFormatted("CodeSign build/Release/MyFramework.framework/Versions/A (in target 'X' from project 'Y')")
+        #expect(formattedApp == "Signing MyApp.app")
+        #expect(formattedFramework == "Signing build/Release/MyFramework.framework")
+    }
+
+    @Test
+    func compileCommand() { }
+
+    @Test
+    func compileError() {
+        let inputError = "/path/file.swift:64:69: error: cannot find 'input' in scope"
+        let outputError = "###vso[task.logissue type=error;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]cannot find 'input' in scope\n\n"
+        #expect(logFormatted(inputError) == outputError)
+
+        let inputFatal = "/path/file.swift:64:69: fatal error: cannot find 'input' in scope"
+        let outputFatal = "###vso[task.logissue type=error;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]cannot find 'input' in scope\n\n"
+        #expect(logFormatted(inputFatal) == outputFatal)
+    }
+
+    @Test
+    func compile() {
+        #if os(macOS)
+        // Xcode 10 and before
+        let input1 = "CompileSwift normal x86_64 /Users/admin/dev/Swifttrain/xcbeautify/Sources/xcbeautify/setup.swift (in target: xcbeautify)"
+        // Xcode 11+'s output
+        let input2 = "CompileSwift normal x86_64 /Users/admin/dev/Swifttrain/xcbeautify/Sources/xcbeautify/setup.swift (in target 'xcbeautify' from project 'xcbeautify')"
+        let output = "[xcbeautify] Compiling setup.swift"
+        #expect(logFormatted(input1) == output)
+        #expect(logFormatted(input2) == output)
+        #endif
+    }
+
+    @Test
+    func swiftCompile_arm64() {
+        let input = "SwiftCompile normal arm64 /path/to/File.swift (in target 'Target' from project 'Project')"
+        let output = "[Target] Compiling File.swift"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func swiftCompile_x86_64() {
+        let input = "SwiftCompile normal x86_64 /Backyard-Birds/Build/Intermediates.noindex/BackyardBirdsData.build/Debug/BackyardBirdsData.build/DerivedSources/resource_bundle_accessor.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"
+        let output = "[BackyardBirdsData] Compiling resource_bundle_accessor.swift"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func swiftCompiling() {
+        let input = #"SwiftCompile normal x86_64 Compiling\ BackyardBirdsDataContainer.swift,\ ColorData.swift,\ DataGeneration.swift,\ DataGenerationOptions.swift /Backyard-Birds/BackyardBirdsData/General/BackyardBirdsDataContainer.swift /Backyard-Birds/BackyardBirdsData/General/ColorData.swift /Backyard-Birds/BackyardBirdsData/General/DataGeneration.swift /Backyard-Birds/BackyardBirdsData/General/DataGenerationOptions.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#
+        #expect(logFormatted(input) == nil)
+    }
+
+    @Test
+    func compileStoryboard() {
+        let formatted = logFormatted("CompileStoryboard /Users/admin/MyApp/MyApp/Main.storyboard (in target: MyApp)")
+        #expect(formatted == "[MyApp] Compiling Main.storyboard")
+    }
+
+    @Test
+    func compileWarning() {
+        let input = "/path/file.swift:64:69: warning: 'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value"
+        let output = "###vso[task.logissue type=warning;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value\n\n"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func compileXib() {
+        let input = "CompileXIB /path/file.xib (in target 'MyApp' from project 'MyProject')"
+        let output = "[MyApp] Compiling file.xib"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func copyHeader() {
+        let input = "CpHeader /path/to/destination/file.h /path/file.h (in target 'MyApp' from project 'MyProject')"
+        let output = "[MyApp] Copying file.h"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func copyPlist() {
+        let input = "CopyPlistFile /path/to/destination/file.plist /path/file.plist (in target 'MyApp' from project 'MyProject')"
+        let output = "[MyApp] Copying file.plist"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func copyStrings() {
+        let input = "CopyStringsFile /path/to/destination/file.strings /path/file.strings (in target 'MyApp' from project 'MyProject')"
+        let output = "[MyApp] Copying file.strings"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func cpResource() {
+        let input = "CpResource /path/to/destination/file.ttf /path/file.ttf (in target 'MyApp' from project 'MyProject')"
+        let output = "[MyApp] Copying file.ttf"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func copyMatchingSourceAndDestinationFiles() {
+        let input = "Copy /path/to/some/file.swift /path/to/some/other/file.swift (in target 'Target' from project 'Project')"
+        let output = "[Target] Copy file.swift -> file.swift"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func copyDifferentSourceAndDestinationFiles() {
+        let input = #"Copy /Backyard-Birds/Build/Products/Debug/Backyard_Birds.swiftmodule/x86_64-apple-macos.abi.json /Backyard-Birds/Build/Intermediates.noindex/Backyard\ Birds.build/Debug/Backyard\ Birds.build/Objects-normal/x86_64/Backyard_Birds.abi.json (in target 'Backyard Birds' from project 'Backyard Birds')"#
+        let output = "[Backyard Birds] Copy x86_64-apple-macos.abi.json -> Backyard_Birds.abi.json"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func cursor() { }
+
+    @Test
+    func executed() throws {
+        let input1 = "Test Suite 'All tests' failed at 2022-01-15 21:31:49.073."
+        let formatted1 = logFormatted(input1)
+        #expect(input1 == formatted1)
+
+        let input2 = "Executed 3 tests, with 2 failures (1 unexpected) in 0.112 (0.112) seconds"
+        let formatted2 = logFormatted(input2)
+        #expect(input2 == formatted2)
+
+        let input3 = "Test Suite 'All tests' passed at 2022-01-15 21:33:49.073."
+        let formatted3 = logFormatted(input3)
+        #expect(input3 == formatted3)
+
+        let input4 = "Executed 1 test, with 1 failure (1 unexpected) in 0.200 (0.200) seconds"
+        let formatted4 = logFormatted(input4)
+        #expect(input4 == formatted4)
+    }
+
+    #if os(macOS)
+    @Test
+    func executedWithSkipped() {
+        let input1 = "Test Suite 'All tests' failed at 2022-01-15 21:31:49.073."
+        let formatted1 = logFormatted(input1)
+        #expect(input1 == formatted1)
+
+        let input2 = "Executed 56 tests, with 3 test skipped and 2 failures (1 unexpected) in 1.029 (1.029) seconds"
+        let formatted2 = logFormatted(input2)
+        #expect(input2 == formatted2)
+
+        let input3 = "Test Suite 'All tests' passed at 2022-01-15 21:33:49.073."
+        let formatted3 = logFormatted(input3)
+        #expect(input3 == formatted3)
+
+        let input4 = "Executed 1 test, with 1 test skipped and 1 failure (1 unexpected) in 3.000 (3.000) seconds"
+        let formatted4 = logFormatted(input4)
+        #expect(input4 == formatted4)
+    }
+    #endif
+
+    @Test
+    func failingTest() { }
+
+    @Test
+    func fatalError() {
+        let input = "fatal error: malformed or corrupted AST file: 'could not find file '/path/file.h' referenced by AST file' note: after modifying system headers, please delete the module cache at '/path/DerivedData/ModuleCache/M5WJ0FYE7N06'"
+        let output = "###vso[task.logissue type=error]fatal error: malformed or corrupted AST file: 'could not find file '/path/file.h' referenced by AST file' note: after modifying system headers, please delete the module cache at '/path/DerivedData/ModuleCache/M5WJ0FYE7N06'"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func fileMissingError() {
+        let input = "<unknown>:0: error: no such file or directory: '/path/file.swift'"
+        let output = "###vso[task.logissue type=error;sourcepath=/path/file.swift]error: no such file or directory:"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func generateCoverageData() {
+        let formatted = logFormatted("Generating coverage data...")
+        #expect(formatted == "Generating code coverage data...")
+    }
+
+    @Test
+    func generatedCoverageReport() {
+        let formatted = logFormatted("Generated coverage report: /path/to/code coverage.xccovreport")
+        #expect(formatted == "Generated code coverage report: /path/to/code coverage.xccovreport")
+    }
+
+    @Test
+    func generateDsym() {
+        let input = "GenerateDSYMFile /path/file.dSYM /path/to/file (in target 'MyApp' from project 'MyProject')"
+        let output = "[MyApp] Generating file.dSYM"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func genericWarning() {
+        let input = "warning: some warning here 123"
+        let output = "###vso[task.logissue type=warning]some warning here 123"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func ldError() {
+        let inputLdLibraryError = "ld: library not found for -lPods-Yammer"
+        #expect(logFormatted(inputLdLibraryError) == "###vso[task.logissue type=error]ld: library not found for -lPods-Yammer")
+
+        let inputLdSymbolsError = "ld: symbol(s) not found for architecture x86_64"
+        #expect(logFormatted(inputLdSymbolsError) == "###vso[task.logissue type=error]ld: symbol(s) not found for architecture x86_64")
+    }
+
+    @Test
+    func ldWarning() {
+        let input = "ld: warning: embedded dylibs/frameworks only run on iOS 8 or later"
+        let output = "###vso[task.logissue type=warning]ld: embedded dylibs/frameworks only run on iOS 8 or later"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func libtool() { }
+
+    @Test
+    func linkerDuplicateSymbolsLocation() { }
+
+    @Test
+    func linkerDuplicateSymbols() { }
+
+    @Test
+    func linkerUndefinedSymbolLocation() { }
+
+    @Test
+    func linkerUndefinedSymbols() { }
+
+    @Test
+    func linking() {
+        #if os(macOS)
+        let formatted = logFormatted("Ld /Users/admin/Library/Developer/Xcode/DerivedData/xcbeautify-abcd/Build/Products/Debug/xcbeautify normal x86_64 (in target: xcbeautify)")
+        #expect(formatted == "[xcbeautify] Linking xcbeautify")
+
+        let formatted2 = logFormatted("Ld /Users/admin/Library/Developer/Xcode/DerivedData/MyApp-abcd/Build/Intermediates.noindex/ArchiveIntermediates/MyApp/IntermediateBuildFilesPath/MyApp.build/Release-iphoneos/MyApp.build/Objects-normal/armv7/My\\ App normal armv7 (in target: MyApp)")
+        #expect(formatted2 == "[MyApp] Linking My\\ App")
+        #endif
+    }
+
+    @Test
+    func moduleIncludesError() { }
+
+    @Test
+    func noCertificate() { }
+
+    @Test
+    func parallelTestCaseFailed() {
+        let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'xctest (49438)' (0.131 seconds)")
+        #expect(formatted == "###vso[task.logissue type=error]    testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+    }
+
+    @Test
+    func parallelTestCasePassed() {
+        let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'xctest (49438)' (0.131 seconds)")
+        #expect(formatted == "    ✔ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+    }
+
+    @Test
+    func parallelTestCaseSkipped() {
+        let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' skipped on 'xctest (49438)' (0.131 seconds)")
+        #expect(formatted == "    ⊘ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+    }
+
+    @Test
+    func concurrentDestinationTestSuiteStarted() {
+        let formatted = logFormatted("Test suite 'XcbeautifyLibTests (iOS).xctest' started on 'iPhone X'")
+        #expect(formatted == "Test Suite XcbeautifyLibTests (iOS).xctest started on 'iPhone X'")
+    }
+
+    @Test
+    func concurrentDestinationTestCaseFailed() {
+        let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'iPhone X' (77.158 seconds)")
+        #expect(formatted == "###vso[task.logissue type=error]    testBuildTarget on 'iPhone X' (77.158 seconds)")
+    }
+
+    @Test
+    func concurrentDestinationTestCasePassed() {
+        let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'iPhone X' (77.158 seconds)")
+        #expect(formatted == "    ✔ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
+    }
+
+    @Test
+    func parallelTestCaseAppKitPassed() {
+        let formatted = logFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed on 'xctest (49438)' (0.131 seconds).")
+        #expect(formatted == "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
+    }
+
+    @Test
+    func parallelTestingStarted() {
+        let formatted = logFormatted("Testing started on 'iPhone X'")
+        #expect(formatted == "Testing started on 'iPhone X'")
+    }
+
+    @Test
+    func parallelTestingPassed() {
+        let formatted = logFormatted("Testing passed on 'iPhone X'")
+        #expect(formatted == "Testing passed on 'iPhone X'")
+    }
+
+    @Test
+    func parallelTestingFailed() {
+        let formatted = logFormatted("Testing failed on 'iPhone X'")
+        #expect(formatted == "###vso[task.logissue type=error]Testing failed on 'iPhone X'")
+    }
+
+    @Test
+    func pbxCp() {
+        let formatted = logFormatted("PBXCp /Users/admin/CocoaLumberjack/Classes/Extensions/DDDispatchQueueLogFormatter.h /Users/admin/Library/Developer/Xcode/DerivedData/Lumberjack-abcd/Build/Products/Release/include/CocoaLumberjack/DDDispatchQueueLogFormatter.h (in target: CocoaLumberjack-Static)")
+        #expect(formatted == "[CocoaLumberjack-Static] Copying DDDispatchQueueLogFormatter.h")
+    }
+
+    @Test
+    func phaseScriptExecution() {
+        let input1 = "PhaseScriptExecution [CP]\\ Check\\ Pods\\ Manifest.lock /Users/admin/Library/Developer/Xcode/DerivedData/App-abcd/Build/Intermediates.noindex/ArchiveIntermediates/App/IntermediateBuildFilesPath/App.build/Release-iphoneos/App.build/Script-53BECF2B2F2E203E928C31AE.sh (in target: App)"
+        let input2 = "PhaseScriptExecution [CP]\\ Check\\ Pods\\ Manifest.lock /Users/admin/Library/Developer/Xcode/DerivedData/App-abcd/Build/Intermediates.noindex/ArchiveIntermediates/App/IntermediateBuildFilesPath/App.build/Release-iphoneos/App.build/Script-53BECF2B2F2E203E928C31AE.sh (in target 'App' from project 'App')"
+        #expect(logFormatted(input1) == "[App] Running script [CP] Check Pods Manifest.lock")
+        #expect(logFormatted(input2) == "[App] Running script [CP] Check Pods Manifest.lock")
+    }
+
+    @Test
+    func phaseSuccess() {
+        let formatted = logFormatted("** CLEAN SUCCEEDED ** [0.085 sec]")
+        #expect(formatted == "Clean Succeeded")
+    }
+
+    @Test
+    func podsError() {
+        let input = "error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation."
+        let output = "###vso[task.logissue type=error]error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation."
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func preprocess() {
+        let input = "Preprocess /Example/Example/Something.m normal arm64 (in target 'SomeTarget' from project 'SomeProject')"
+        let output = "[SomeTarget] Preprocess Something.m"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func processInfoPlist() {
+        let formatted = logFormatted("ProcessInfoPlistFile /Users/admin/Library/Developer/Xcode/DerivedData/xcbeautify-abcd/Build/Products/Debug/Guaka.framework/Versions/A/Resources/Info.plist /Users/admin/xcbeautify/xcbeautify.xcodeproj/Guaka_Info.plist")
+        #expect(formatted == "Processing Guaka_Info.plist")
+    }
+
+    @Test
+    func processPchCommand() {
+        let formatted = logFormatted("/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++-header -target x86_64-apple-macos10.13 -c /path/to/my.pch -o /path/to/output/AcVDiff_Prefix.pch.gch")
+        #expect(formatted == "Preprocessing /path/to/my.pch")
+    }
+
+    @Test
+    func processPchCommandArbitraryExtension() {
+        let formatted = logFormatted(#"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++-header -target x86_64-apple-macos12.3 -c /path/with\ space/cmake_pch.hxx -o /path/with\ space/build/SharedPrecompiledHeaders/SharedPrecompiledHeaders/2304651503107189736/cmake_pch.hxx.gch --serialize-diagnostics /path/with\ space/build/SharedPrecompiledHeaders/SharedPrecompiledHeaders/2304651503107189736/cmake_pch.hxx.dia"#)
+        #expect(formatted == #"Preprocessing /path/with\ space/cmake_pch.hxx"#)
+    }
+
+    @Test
+    func processPch() {
+        let formatted = logFormatted("ProcessPCH /Users/admin/Library/Developer/Xcode/DerivedData/Lumberjack-abcd/Build/Intermediates.noindex/PrecompiledHeaders/SharedPrecompiledHeaders/5872309797734264511/CocoaLumberjack-Prefix.pch.gch /Users/admin/CocoaLumberjack/Framework/Lumberjack/CocoaLumberjack-Prefix.pch normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.analyzer (in target: CocoaLumberjack)")
+        #expect(formatted == "[CocoaLumberjack] Processing CocoaLumberjack-Prefix.pch")
+    }
+
+    @Test
+    func processPchArbitraryExtension() {
+        let formatted = logFormatted(#"ProcessPCH++ /Users/admin/src/Test\ Folder/_builds/SharedPrecompiledHeaders/SharedPrecompiledHeaders/2304651503107189736/cmake_pch.hxx.gch /Users/admin/src/Test\ Folder/_builds/CMakeFiles/foo.dir/Debug/cmake_pch.hxx normal x86_64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'foo' from project 'foo')"#)
+        #expect(formatted == "[foo] Processing cmake_pch.hxx")
+    }
+
+    @Test
+    func processPchPlusPlus() {
+        let formatted = logFormatted("ProcessPCH++ /Users/admin/Library/Developer/Xcode/DerivedData/Lumberjack-abcd/Build/Intermediates.noindex/PrecompiledHeaders/SharedPrecompiledHeaders/5872309797734264511/CocoaLumberjack-Prefix.pch.gch /Users/admin/CocoaLumberjack/Framework/Lumberjack/CocoaLumberjack-Prefix.pch normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.analyzer (in target: CocoaLumberjack)")
+        #expect(formatted == "[CocoaLumberjack] Processing CocoaLumberjack-Prefix.pch")
+    }
+
+    @Test
+    func provisioningProfileRequired() {
+        let input = #"MyProject requires a provisioning profile. Select a provisioning profile for the "Debug" build configuration in the project editor."#
+        let output = #"###vso[task.logissue type=error]MyProject requires a provisioning profile. Select a provisioning profile for the "Debug" build configuration in the project editor."#
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func restartingTests() {
+        let formatted = logFormatted("Restarting after unexpected exit, crash, or test timeout in HomePresenterTest.testIsCellPresented(); summary will include totals from previous launches.")
+        #expect(formatted == "###vso[task.logissue type=error]    Restarting after unexpected exit, crash, or test timeout in HomePresenterTest.testIsCellPresented(); summary will include totals from previous launches.")
+    }
+
+    @Test
+    func shellCommand() {
+        let formatted = logFormatted("    cd /foo/bar/baz")
+        #expect(formatted == nil)
+    }
+
+    @Test
+    func symbolReferencedFrom() {
+        let formatted = logFormatted("  \"NetworkBusiness.ImageDownloadManager.saveImage(image: __C.UIImage, needWatermark: Swift.Bool, params: [Swift.String : Any], downloadHandler: (Swift.Bool) -> ()?) -> ()\", referenced from:")
+        #expect(formatted == "###vso[task.logissue type=error]  \"NetworkBusiness.ImageDownloadManager.saveImage(image: __C.UIImage, needWatermark: Swift.Bool, params: [Swift.String : Any], downloadHandler: (Swift.Bool) -> ()?) -> ()\", referenced from:")
+    }
+
+    @Test
+    func undefinedSymbolLocation() {
+        let formatted = logFormatted("      MediaBrowser.ChatGalleryViewController.downloadImage() -> () in MediaBrowser(ChatGalleryViewController.o)")
+        #expect(formatted == "###vso[task.logissue type=warning]      MediaBrowser.ChatGalleryViewController.downloadImage() -> () in MediaBrowser(ChatGalleryViewController.o)")
+    }
+
+    @Test
+    func testCaseMeasured() {
+        #if os(macOS)
+        let formatted = logFormatted(#"/Users/cyberbeni/Desktop/framework/TypedNotificationCenter/<compiler-generated>:54: Test Case '-[TypedNotificationCenterPerformanceTests.BridgedNotificationTests test_subscribing_2senders_notificationName]' measured [High Water Mark For Heap Allocations, KB] average: 5407.634, relative standard deviation: 45.772%, values: [9341.718750, 3779.468750, 3779.468750, 9630.344727, 3779.468750, 3779.468750, 3895.093750, 3779.468750, 8532.372070, 3779.468750], performanceMetricID:com.apple.XCTPerformanceMetric_HighWaterMarkForHeapAllocations, baselineName: "", baselineAverage: , polarity: prefers smaller, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 1.000, maxStandardDeviation: 1.000"#)
+        #expect(formatted == #"    ◷ test_subscribing_2senders_notificationName measured (5407.634 KB ±45.772% -- High Water Mark For Heap Allocations)"#)
+        #endif
+    }
+
+    @Test
+    func testCasePassed() {
+        #if os(macOS)
+        let formatted = logFormatted("Test Case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed (0.131 seconds).")
+        #expect(formatted == "    ✔ testBuildTarget (0.131 seconds)")
+        #endif
+    }
+
+    @Test
+    func testCaseSkipped() {
+        #if os(macOS)
+        let formatted = logFormatted("Test Case '-[SomeTests testName]' skipped (0.004 seconds).")
+        #expect(formatted == "    ⊘ testName (0.004 seconds)")
+        #endif
+    }
+
+    @Test
+    func testCasePending() { }
+
+    @Test
+    func testCaseStarted() { }
+
+    @Test
+    func testSuiteStart() { }
+
+    @Test
+    func testSuiteStarted() { }
+
+    #if os(macOS)
+    @Test
+    func testSuiteAllTestsPassed() {
+        let input = "Test Suite 'All tests' passed at 2022-01-15 21:31:49.073."
+        let formatted = logFormatted(input)
+        #expect(input == formatted)
+    }
+    #endif
+
+    #if os(macOS)
+    @Test
+    func testSuiteAllTestsFailed() {
+        let input = "Test Suite 'All tests' failed at 2022-01-15 21:31:49.073."
+        let formatted = logFormatted(input)
+        #expect(input == formatted)
+    }
+    #endif
+
+    @Test
+    func testsRunCompletion() { }
+
+    @Test
+    func tiffutil() {
+        let input = "TiffUtil file.tiff"
+        #expect(logFormatted(input) == nil)
+    }
+
+    @Test
+    func touch() {
+        let formatted = logFormatted("Touch /Users/admin/Library/Developer/Xcode/DerivedData/xcbeautify-dgnqmpfertotpceazwfhtfwtuuwt/Build/Products/Debug/XcbeautifyLib.framework (in target: XcbeautifyLib)")
+        #expect(formatted == "[XcbeautifyLib] Touching XcbeautifyLib.framework")
+    }
+
+    @Test
+    func uiFailingTest() {
+        let formatted = logFormatted("    t =    10.13s Assertion Failure: <unknown>:0: App crashed in <external symbol>")
+        #expect(formatted == "###vso[task.logissue type=error;sourcepath=<unknown>;linenumber=0]    App crashed in <external symbol>")
+    }
+
+    @Test
+    func willNotBeCodeSigned() {
+        let input = "FrameworkName will not be code signed because its settings don't specify a development team."
+        let output = "###vso[task.logissue type=warning]FrameworkName will not be code signed because its settings don't specify a development team."
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func writeAuxiliaryFileGeneric() {
+        let input = #"WriteAuxiliaryFile /path/to/some/auxiliary/file.extension (in target 'Target' from project 'Project')"#
+        let output = "[Target] Write Auxiliary File file.extension"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func writeAuxiliaryFileBackyardBirds() {
+        let input = #"WriteAuxiliaryFile /Backyard-Birds/Build/Intermediates.noindex/LayeredArtworkLibrary.build/Debug/LayeredArtworkLibrary_LayeredArtworkLibrary.build/empty-LayeredArtworkLibrary_LayeredArtworkLibrary.plist (in target 'LayeredArtworkLibrary_LayeredArtworkLibrary' from project 'LayeredArtworkLibrary')"#
+        let output = "[LayeredArtworkLibrary_LayeredArtworkLibrary] Write Auxiliary File empty-LayeredArtworkLibrary_LayeredArtworkLibrary.plist"
+        #expect(logFormatted(input) == output)
+    }
+
+    @Test
+    func writeFile() {
+        let input = "write-file /path/file.SwiftFileList"
+        #expect(logFormatted(input) == nil)
+    }
+
+    @Test
+    func packageFetching() {
+        let input1 = "Fetching from https://github.com/cpisciotta/xcbeautify"
+        let output1 = "Fetching https://github.com/cpisciotta/xcbeautify"
+        let formatted1 = logFormatted(input1)
+        #expect(formatted1 == output1)
+
+        let input2 = "Fetching from https://github.com/cpisciotta/xcbeautify (cached)"
+        let output2 = "Fetching https://github.com/cpisciotta/xcbeautify (cached)"
+        let formatted2 = logFormatted(input2)
+        #expect(formatted2 == output2)
+
+        let input3 = "Fetching from https://github.com/cpisciotta/xcbeautify.git"
+        let output3 = "Fetching https://github.com/cpisciotta/xcbeautify.git"
+        let formatted3 = logFormatted(input3)
+        #expect(formatted3 == output3)
+    }
+
+    @Test
+    func packageUpdating() {
+        let input1 = "Updating from https://github.com/cpisciotta/xcbeautify"
+        let output1 = "Updating https://github.com/cpisciotta/xcbeautify"
+        let formatted1 = logFormatted(input1)
+        #expect(formatted1 == output1)
+
+        let input2 = "Updating from https://github.com/cpisciotta/xcbeautify (cached)"
+        let output2 = "Updating https://github.com/cpisciotta/xcbeautify (cached)"
+        let formatted2 = logFormatted(input2)
+        #expect(formatted2 == output2)
+
+        let input3 = "Updating from https://github.com/cpisciotta/xcbeautify.git"
+        let output3 = "Updating https://github.com/cpisciotta/xcbeautify.git"
+        let formatted3 = logFormatted(input3)
+        #expect(formatted3 == output3)
+    }
+
+    @Test
+    func packageCheckingOut() {
+        let input1 = "Cloning local copy of package 'xcbeautify'"
+        let formatted1 = logFormatted(input1)
+        #expect(formatted1 == nil)
+
+        let input2 = "Checking out x.y.z of package 'xcbeautify'"
+        let output2 = "Checking out 'xcbeautify' @ x.y.z"
+        let formatted2 = logFormatted(input2)
+        #expect(formatted2 == output2)
+    }
+
+    @Test
+    func packageGraphResolved() {
+        // Start
+        let start = logFormatted("Resolve Package Graph")
+        #expect(start == "Resolving Package Graph")
+
+        // Ended
+        let ended = logFormatted("Resolved source packages:")
+        #expect(ended == "Resolved source packages")
+
+        // Package
+        let package = logFormatted("  StrasbourgParkAPI: https://github.com/yageek/StrasbourgParkAPI.git @ 3.0.2")
+        #expect(package == "StrasbourgParkAPI - https://github.com/yageek/StrasbourgParkAPI.git @ 3.0.2")
+    }
+
+    @Test
+    func xcodebuildError() {
+        let formatted = logFormatted("xcodebuild: error: Existing file at -resultBundlePath \"/output/file.xcresult\"")
+        #expect(formatted == "###vso[task.logissue type=error]xcodebuild: error: Existing file at -resultBundlePath \"/output/file.xcresult\"")
+    }
+
+    @Test
+    func xcodeprojError() {
+        // Given
+        let errorText = #"/path/to/project.xcodeproj: error: No signing certificate "iOS Distribution" found: No "iOS Distribution" signing certificate matching team ID "xxxxx" with a private key was found. (in target 'target' from project 'project')"#
+        let expectedFormatted = "###vso[task.logissue type=error;sourcepath=/path/to/project.xcodeproj]No signing certificate \"iOS Distribution\" found: No \"iOS Distribution\" signing certificate matching team ID \"xxxxx\" with a private key was found. (in target 'target' from project 'project')\n\n"
+
+        // When
+        let actualFormatted = logFormatted(errorText)
+
+        // Then
+        #expect(actualFormatted == expectedFormatted)
+    }
+
+    @Test
+    func xcodeprojWarning() {
+        // Given
+        let errorText = "/Users/xxxxx/Example/Pods/Pods.xcodeproj: warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.0.99. (in target 'XXPay' from project 'Pods')"
+        let expectedFormatted = "###vso[task.logissue type=warning;sourcepath=/Users/xxxxx/Example/Pods/Pods.xcodeproj]The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.0.99. (in target 'XXPay' from project 'Pods')\n\n"
+
+        // When
+        let actualFormatted = logFormatted(errorText)
+
+        // Then
+        #expect(actualFormatted == expectedFormatted)
+    }
+
+    @Test
+    func duplicateLocalizedStringKey() {
+        let formatted = logFormatted(#"2022-12-07 16:26:40 --- WARNING: Key "duplicate" used with multiple values. Value "First" kept. Value "Second" ignored."#)
+        #expect(formatted == #"###vso[task.logissue type=warning]Key "duplicate" used with multiple values. Value "First" kept. Value "Second" ignored."#)
+    }
+
+    @Test
+    func testingStarted() {
+        let formatted = logFormatted(#"Testing started"#)
+        #expect(formatted == #"Testing started"#)
+    }
+
+    @Test
+    func swiftTestingRunCompletion() {
+        let input = #"􁁛 Test run with 5 tests passed after 12.345 seconds."#
+        let formatted = logFormatted(input)
+        let expectedOutput = "Test run with 5 tests passed after 12.345 seconds"
+        #expect(formatted == expectedOutput)
+    }
+
+    @Test
+    func swiftTestingRunFailed() {
+        let input = #"􀢄 Test run with 10 tests failed after 15.678 seconds with 3 issues."#
+        let formatted = logFormatted(input)
+        let expectedOutput = "###vso[task.logissue type=error]Test run with 10 tests failed after 15.678 seconds with 3 issue(s)"
+        #expect(formatted == expectedOutput)
+    }
+
+    @Test
+    func swiftTestingSuiteFailed() {
+        let input = #"􀢄 Suite "MyTestSuite" failed after 8.456 seconds with 2 issues."#
+        let formatted = logFormatted(input)
+        let expectedOutput = "###vso[task.logissue type=error]Suite \"MyTestSuite\" failed after 8.456 seconds with 2 issue(s)"
+        #expect(formatted == expectedOutput)
+    }
+
+    @Test
+    func swiftTestingTestFailed() {
+        let input = #"􀢄 Test "myTest" failed after 1.234 seconds with 1 issue."#
+        let formatted = logFormatted(input)
+        let expectedOutput = "###vso[task.logissue type=error]\"myTest\" (1.234 seconds) 1 issue(s)"
+        #expect(formatted == expectedOutput)
+    }
+
+    @Test
+    func swiftTestingTestSkipped() {
+        let input = #"􀙟 Test myTest() skipped."#
+        let formatted = logFormatted(input)
+        let expectedOutput = "    ⊘ myTest() skipped"
+        #expect(formatted == expectedOutput)
+    }
+
+    @Test
+    func swiftTestingTestSkippedReason() {
+        let input = #"􀙟 Test myTest() skipped: "Reason for skipping""#
+        let formatted = logFormatted(input)
+        let expectedOutput = "    ⊘ myTest() skipped (Reason for skipping)"
+        #expect(formatted == expectedOutput)
+    }
+
+    @Test
+    func swiftTestingIssue() {
+        let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
+        let formatted = logFormatted(input)
+        let expectedOutput = "###vso[task.logissue type=error]Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
+        #expect(formatted == expectedOutput)
+    }
+
+    @Test
+    func swiftTestingIssueArguments() {
+        let input = #"􀢄 Test "myTest" recorded an issue with 2 arguments."#
+        let formatted = logFormatted(input)
+        let expectedOutput = "###vso[task.logissue type=error]Recorded an issue (2) argument(s)"
+        #expect(formatted == expectedOutput)
+    }
+
+    @Test
+    func swiftTestingIssueDetails() {
+        let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
+        let formatted = logFormatted(input)
+        let expectedOutput = "###vso[task.logissue type=error]Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
+        #expect(formatted == expectedOutput)
+    }
+}

--- a/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
@@ -52,41 +52,41 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
         XCTAssertEqual(formatted, command)
     }
 
-    func testclangError() {
+    func testClangError() {
         let formatted = logFormatted("clang: error: linker command failed with exit code 1 (use -v to see invocation)")
         XCTAssertEqual(formatted, "##vso[task.logissue type=error]clang: error: linker command failed with exit code 1 (use -v to see invocation)")
     }
 
-    func testcleanRemove() {
+    func testCleanRemove() {
         let formatted = logFormatted("Clean.Remove clean /Users/admin/Library/Developer/Xcode/DerivedData/MyLibrary-abcd/Build/Intermediates/MyLibrary.build/Debug-iphonesimulator/MyLibraryTests.build")
         XCTAssertEqual(formatted, "Cleaning MyLibraryTests.build")
     }
 
-    func testcleanTarget() {
+    func testCleanTarget() {
         let formatted = logFormatted("=== ANALYZE TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ===")
         XCTAssertEqual(formatted, "Analyze target The Spacer of project Pods with configuration Debug")
     }
 
-    func testcodesignFramework() {
+    func testCodesignFramework() {
         let formatted = logFormatted("CodeSign build/Release/MyFramework.framework/Versions/A")
         XCTAssertEqual(formatted, "Signing build/Release/MyFramework.framework")
     }
 
-    func testcodesign() {
+    func testCodesign() {
         let formatted = logFormatted("CodeSign build/Release/MyApp.app")
         XCTAssertEqual(formatted, "Signing MyApp.app")
     }
 
-    func testmultipleCodesigns() {
+    func testMultipleCodesigns() {
         let formattedApp = logFormatted("CodeSign build/Release/MyApp.app")
         let formattedFramework = logFormatted("CodeSign build/Release/MyFramework.framework/Versions/A (in target 'X' from project 'Y')")
         XCTAssertEqual(formattedApp, "Signing MyApp.app")
         XCTAssertEqual(formattedFramework, "Signing build/Release/MyFramework.framework")
     }
 
-    func testcompileCommand() { }
+    func testCompileCommand() { }
 
-    func testcompileError() {
+    func testCompileError() {
         let inputError = "/path/file.swift:64:69: error: cannot find 'input' in scope"
         let outputError = "##vso[task.logissue type=error;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]cannot find 'input' in scope\n\n"
         XCTAssertEqual(logFormatted(inputError), outputError)
@@ -96,7 +96,7 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
         XCTAssertEqual(logFormatted(inputFatal), outputFatal)
     }
 
-    func testcompile() {
+    func testCompile() {
         #if os(macOS)
         // Xcode 10 and before
         let input1 = "CompileSwift normal x86_64 /Users/admin/dev/Swifttrain/xcbeautify/Sources/xcbeautify/setup.swift (in target: xcbeautify)"
@@ -108,79 +108,79 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
         #endif
     }
 
-    func testswiftCompile_arm64() {
+    func testSwiftCompile_arm64() {
         let input = "SwiftCompile normal arm64 /path/to/File.swift (in target 'Target' from project 'Project')"
         let output = "[Target] Compiling File.swift"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testswiftCompile_x86_64() {
+    func testSwiftCompile_x86_64() {
         let input = "SwiftCompile normal x86_64 /Backyard-Birds/Build/Intermediates.noindex/BackyardBirdsData.build/Debug/BackyardBirdsData.build/DerivedSources/resource_bundle_accessor.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"
         let output = "[BackyardBirdsData] Compiling resource_bundle_accessor.swift"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testswiftCompiling() {
+    func testSwiftCompiling() {
         let input = #"SwiftCompile normal x86_64 Compiling\ BackyardBirdsDataContainer.swift,\ ColorData.swift,\ DataGeneration.swift,\ DataGenerationOptions.swift /Backyard-Birds/BackyardBirdsData/General/BackyardBirdsDataContainer.swift /Backyard-Birds/BackyardBirdsData/General/ColorData.swift /Backyard-Birds/BackyardBirdsData/General/DataGeneration.swift /Backyard-Birds/BackyardBirdsData/General/DataGenerationOptions.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#
         XCTAssertNil(logFormatted(input))
     }
 
-    func testcompileStoryboard() {
+    func testCompileStoryboard() {
         let formatted = logFormatted("CompileStoryboard /Users/admin/MyApp/MyApp/Main.storyboard (in target: MyApp)")
         XCTAssertEqual(formatted, "[MyApp] Compiling Main.storyboard")
     }
 
-    func testcompileWarning() {
+    func testCompileWarning() {
         let input = "/path/file.swift:64:69: warning: 'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value"
         let output = "##vso[task.logissue type=warning;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value\n\n"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testcompileXib() {
+    func testCompileXib() {
         let input = "CompileXIB /path/file.xib (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Compiling file.xib"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testcopyHeader() {
+    func testCopyHeader() {
         let input = "CpHeader /path/to/destination/file.h /path/file.h (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Copying file.h"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testcopyPlist() {
+    func testCopyPlist() {
         let input = "CopyPlistFile /path/to/destination/file.plist /path/file.plist (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Copying file.plist"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testcopyStrings() {
+    func testCopyStrings() {
         let input = "CopyStringsFile /path/to/destination/file.strings /path/file.strings (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Copying file.strings"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testcpResource() {
+    func testCPResource() {
         let input = "CpResource /path/to/destination/file.ttf /path/file.ttf (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Copying file.ttf"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testcopyMatchingSourceAndDestinationFiles() {
+    func testCopyMatchingSourceAndDestinationFiles() {
         let input = "Copy /path/to/some/file.swift /path/to/some/other/file.swift (in target 'Target' from project 'Project')"
         let output = "[Target] Copy file.swift -> file.swift"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testcopyDifferentSourceAndDestinationFiles() {
+    func testCopyDifferentSourceAndDestinationFiles() {
         let input = #"Copy /Backyard-Birds/Build/Products/Debug/Backyard_Birds.swiftmodule/x86_64-apple-macos.abi.json /Backyard-Birds/Build/Intermediates.noindex/Backyard\ Birds.build/Debug/Backyard\ Birds.build/Objects-normal/x86_64/Backyard_Birds.abi.json (in target 'Backyard Birds' from project 'Backyard Birds')"#
         let output = "[Backyard Birds] Copy x86_64-apple-macos.abi.json -> Backyard_Birds.abi.json"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testcursor() { }
+    func testCursor() { }
 
-    func testexecuted() throws {
+    func testExecuted() throws {
         let input1 = "Test Suite 'All tests' failed at 2022-01-15 21:31:49.073."
         let formatted1 = logFormatted(input1)
         XCTAssertEqual(input1, formatted1)
@@ -199,7 +199,7 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
     }
 
     #if os(macOS)
-    func testexecutedWithSkipped() {
+    func testExecutedWithSkipped() {
         let input1 = "Test Suite 'All tests' failed at 2022-01-15 21:31:49.073."
         let formatted1 = logFormatted(input1)
         XCTAssertEqual(input1, formatted1)
@@ -218,43 +218,43 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
     }
     #endif
 
-    func testfailingTest() { }
+    func testFailingTest() { }
 
-    func testfatalError() {
+    func testFatalError() {
         let input = "fatal error: malformed or corrupted AST file: 'could not find file '/path/file.h' referenced by AST file' note: after modifying system headers, please delete the module cache at '/path/DerivedData/ModuleCache/M5WJ0FYE7N06'"
         let output = "##vso[task.logissue type=error]fatal error: malformed or corrupted AST file: 'could not find file '/path/file.h' referenced by AST file' note: after modifying system headers, please delete the module cache at '/path/DerivedData/ModuleCache/M5WJ0FYE7N06'"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testfileMissingError() {
+    func testFileMissingError() {
         let input = "<unknown>:0: error: no such file or directory: '/path/file.swift'"
         let output = "##vso[task.logissue type=error;sourcepath=/path/file.swift]error: no such file or directory:"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testgenerateCoverageData() {
+    func testGenerateCoverageData() {
         let formatted = logFormatted("Generating coverage data...")
         XCTAssertEqual(formatted, "Generating code coverage data...")
     }
 
-    func testgeneratedCoverageReport() {
+    func testGeneratedCoverageReport() {
         let formatted = logFormatted("Generated coverage report: /path/to/code coverage.xccovreport")
         XCTAssertEqual(formatted, "Generated code coverage report: /path/to/code coverage.xccovreport")
     }
 
-    func testgenerateDsym() {
+    func testGenerateDsym() {
         let input = "GenerateDSYMFile /path/file.dSYM /path/to/file (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Generating file.dSYM"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testgenericWarning() {
+    func testGenericWarning() {
         let input = "warning: some warning here 123"
         let output = "##vso[task.logissue type=warning]some warning here 123"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testldError() {
+    func testLDError() {
         let inputLdLibraryError = "ld: library not found for -lPods-Yammer"
         XCTAssertEqual(logFormatted(inputLdLibraryError), "##vso[task.logissue type=error]ld: library not found for -lPods-Yammer")
 
@@ -262,23 +262,23 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
         XCTAssertEqual(logFormatted(inputLdSymbolsError), "##vso[task.logissue type=error]ld: symbol(s) not found for architecture x86_64")
     }
 
-    func testldWarning() {
+    func testLDWarning() {
         let input = "ld: warning: embedded dylibs/frameworks only run on iOS 8 or later"
         let output = "##vso[task.logissue type=warning]ld: embedded dylibs/frameworks only run on iOS 8 or later"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testlibtool() { }
+    func testLibtool() { }
 
-    func testlinkerDuplicateSymbolsLocation() { }
+    func testLinkerDuplicateSymbolsLocation() { }
 
-    func testlinkerDuplicateSymbols() { }
+    func testLinkerDuplicateSymbols() { }
 
-    func testlinkerUndefinedSymbolLocation() { }
+    func testLinkerUndefinedSymbolLocation() { }
 
-    func testlinkerUndefinedSymbols() { }
+    func testLinkerUndefinedSymbols() { }
 
-    func testlinking() {
+    func testLinking() {
         #if os(macOS)
         let formatted = logFormatted("Ld /Users/admin/Library/Developer/Xcode/DerivedData/xcbeautify-abcd/Build/Products/Debug/xcbeautify normal x86_64 (in target: xcbeautify)")
         XCTAssertEqual(formatted, "[xcbeautify] Linking xcbeautify")
@@ -288,176 +288,176 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
         #endif
     }
 
-    func testmoduleIncludesError() { }
+    func testModuleIncludesError() { }
 
-    func testnoCertificate() { }
+    func testNoCertificate() { }
 
-    func testparallelTestCaseFailed() {
+    func testParallelTestCaseFailed() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'xctest (49438)' (0.131 seconds)")
         XCTAssertEqual(formatted, "##vso[task.logissue type=error]    testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
-    func testparallelTestCasePassed() {
+    func testParallelTestCasePassed() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'xctest (49438)' (0.131 seconds)")
         XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
-    func testparallelTestCaseSkipped() {
+    func testParallelTestCaseSkipped() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' skipped on 'xctest (49438)' (0.131 seconds)")
         XCTAssertEqual(formatted, "    ⊘ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
-    func testconcurrentDestinationTestSuiteStarted() {
+    func testConcurrentDestinationTestSuiteStarted() {
         let formatted = logFormatted("Test suite 'XcbeautifyLibTests (iOS).xctest' started on 'iPhone X'")
         XCTAssertEqual(formatted, "Test Suite XcbeautifyLibTests (iOS).xctest started on 'iPhone X'")
     }
 
-    func testconcurrentDestinationTestCaseFailed() {
+    func testConcurrentDestinationTestCaseFailed() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'iPhone X' (77.158 seconds)")
         XCTAssertEqual(formatted, "##vso[task.logissue type=error]    testBuildTarget on 'iPhone X' (77.158 seconds)")
     }
 
-    func testconcurrentDestinationTestCasePassed() {
+    func testConcurrentDestinationTestCasePassed() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'iPhone X' (77.158 seconds)")
         XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
     }
 
-    func testparallelTestCaseAppKitPassed() {
+    func testParallelTestCaseAppKitPassed() {
         let formatted = logFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed on 'xctest (49438)' (0.131 seconds).")
         XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
     }
 
-    func testparallelTestingStarted() {
+    func testParallelTestingStarted() {
         let formatted = logFormatted("Testing started on 'iPhone X'")
         XCTAssertEqual(formatted, "Testing started on 'iPhone X'")
     }
 
-    func testparallelTestingPassed() {
+    func testParallelTestingPassed() {
         let formatted = logFormatted("Testing passed on 'iPhone X'")
         XCTAssertEqual(formatted, "Testing passed on 'iPhone X'")
     }
 
-    func testparallelTestingFailed() {
+    func testParallelTestingFailed() {
         let formatted = logFormatted("Testing failed on 'iPhone X'")
         XCTAssertEqual(formatted, "##vso[task.logissue type=error]Testing failed on 'iPhone X'")
     }
 
-    func testpbxCp() {
+    func testPBXCp() {
         let formatted = logFormatted("PBXCp /Users/admin/CocoaLumberjack/Classes/Extensions/DDDispatchQueueLogFormatter.h /Users/admin/Library/Developer/Xcode/DerivedData/Lumberjack-abcd/Build/Products/Release/include/CocoaLumberjack/DDDispatchQueueLogFormatter.h (in target: CocoaLumberjack-Static)")
         XCTAssertEqual(formatted, "[CocoaLumberjack-Static] Copying DDDispatchQueueLogFormatter.h")
     }
 
-    func testphaseScriptExecution() {
+    func testPhaseScriptExecution() {
         let input1 = "PhaseScriptExecution [CP]\\ Check\\ Pods\\ Manifest.lock /Users/admin/Library/Developer/Xcode/DerivedData/App-abcd/Build/Intermediates.noindex/ArchiveIntermediates/App/IntermediateBuildFilesPath/App.build/Release-iphoneos/App.build/Script-53BECF2B2F2E203E928C31AE.sh (in target: App)"
         let input2 = "PhaseScriptExecution [CP]\\ Check\\ Pods\\ Manifest.lock /Users/admin/Library/Developer/Xcode/DerivedData/App-abcd/Build/Intermediates.noindex/ArchiveIntermediates/App/IntermediateBuildFilesPath/App.build/Release-iphoneos/App.build/Script-53BECF2B2F2E203E928C31AE.sh (in target 'App' from project 'App')"
         XCTAssertEqual(logFormatted(input1), "[App] Running script [CP] Check Pods Manifest.lock")
         XCTAssertEqual(logFormatted(input2), "[App] Running script [CP] Check Pods Manifest.lock")
     }
 
-    func testphaseSuccess() {
+    func testPhaseSuccess() {
         let formatted = logFormatted("** CLEAN SUCCEEDED ** [0.085 sec]")
         XCTAssertEqual(formatted, "Clean Succeeded")
     }
 
-    func testpodsError() {
+    func testPodsError() {
         let input = "error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation."
         let output = "##vso[task.logissue type=error]error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation."
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testpreprocess() {
+    func testPreprocess() {
         let input = "Preprocess /Example/Example/Something.m normal arm64 (in target 'SomeTarget' from project 'SomeProject')"
         let output = "[SomeTarget] Preprocess Something.m"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testprocessInfoPlist() {
+    func testProcessInfoPlist() {
         let formatted = logFormatted("ProcessInfoPlistFile /Users/admin/Library/Developer/Xcode/DerivedData/xcbeautify-abcd/Build/Products/Debug/Guaka.framework/Versions/A/Resources/Info.plist /Users/admin/xcbeautify/xcbeautify.xcodeproj/Guaka_Info.plist")
         XCTAssertEqual(formatted, "Processing Guaka_Info.plist")
     }
 
-    func testprocessPchCommand() {
+    func testProcessPchCommand() {
         let formatted = logFormatted("/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++-header -target x86_64-apple-macos10.13 -c /path/to/my.pch -o /path/to/output/AcVDiff_Prefix.pch.gch")
         XCTAssertEqual(formatted, "Preprocessing /path/to/my.pch")
     }
 
-    func testprocessPchCommandArbitraryExtension() {
+    func testProcessPchCommandArbitraryExtension() {
         let formatted = logFormatted(#"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++-header -target x86_64-apple-macos12.3 -c /path/with\ space/cmake_pch.hxx -o /path/with\ space/build/SharedPrecompiledHeaders/SharedPrecompiledHeaders/2304651503107189736/cmake_pch.hxx.gch --serialize-diagnostics /path/with\ space/build/SharedPrecompiledHeaders/SharedPrecompiledHeaders/2304651503107189736/cmake_pch.hxx.dia"#)
         XCTAssertEqual(formatted, #"Preprocessing /path/with\ space/cmake_pch.hxx"#)
     }
 
-    func testprocessPch() {
+    func testProcessPch() {
         let formatted = logFormatted("ProcessPCH /Users/admin/Library/Developer/Xcode/DerivedData/Lumberjack-abcd/Build/Intermediates.noindex/PrecompiledHeaders/SharedPrecompiledHeaders/5872309797734264511/CocoaLumberjack-Prefix.pch.gch /Users/admin/CocoaLumberjack/Framework/Lumberjack/CocoaLumberjack-Prefix.pch normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.analyzer (in target: CocoaLumberjack)")
         XCTAssertEqual(formatted, "[CocoaLumberjack] Processing CocoaLumberjack-Prefix.pch")
     }
 
-    func testprocessPchArbitraryExtension() {
+    func testProcessPchArbitraryExtension() {
         let formatted = logFormatted(#"ProcessPCH++ /Users/admin/src/Test\ Folder/_builds/SharedPrecompiledHeaders/SharedPrecompiledHeaders/2304651503107189736/cmake_pch.hxx.gch /Users/admin/src/Test\ Folder/_builds/CMakeFiles/foo.dir/Debug/cmake_pch.hxx normal x86_64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'foo' from project 'foo')"#)
         XCTAssertEqual(formatted, "[foo] Processing cmake_pch.hxx")
     }
 
-    func testprocessPchPlusPlus() {
+    func testProcessPchPlusPlus() {
         let formatted = logFormatted("ProcessPCH++ /Users/admin/Library/Developer/Xcode/DerivedData/Lumberjack-abcd/Build/Intermediates.noindex/PrecompiledHeaders/SharedPrecompiledHeaders/5872309797734264511/CocoaLumberjack-Prefix.pch.gch /Users/admin/CocoaLumberjack/Framework/Lumberjack/CocoaLumberjack-Prefix.pch normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.analyzer (in target: CocoaLumberjack)")
         XCTAssertEqual(formatted, "[CocoaLumberjack] Processing CocoaLumberjack-Prefix.pch")
     }
 
-    func testprovisioningProfileRequired() {
+    func testProvisioningProfileRequired() {
         let input = #"MyProject requires a provisioning profile. Select a provisioning profile for the "Debug" build configuration in the project editor."#
         let output = #"##vso[task.logissue type=error]MyProject requires a provisioning profile. Select a provisioning profile for the "Debug" build configuration in the project editor."#
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testrestartingTests() {
+    func testRestartingTests() {
         let formatted = logFormatted("Restarting after unexpected exit, crash, or test timeout in HomePresenterTest.testIsCellPresented(); summary will include totals from previous launches.")
         XCTAssertEqual(formatted, "##vso[task.logissue type=error]    Restarting after unexpected exit, crash, or test timeout in HomePresenterTest.testIsCellPresented(); summary will include totals from previous launches.")
     }
 
-    func testshellCommand() {
+    func testShellCommand() {
         let formatted = logFormatted("    cd /foo/bar/baz")
         XCTAssertNil(formatted)
     }
 
-    func testsymbolReferencedFrom() {
+    func testSymbolReferencedFrom() {
         let formatted = logFormatted("  \"NetworkBusiness.ImageDownloadManager.saveImage(image: __C.UIImage, needWatermark: Swift.Bool, params: [Swift.String : Any], downloadHandler: (Swift.Bool) -> ()?) -> ()\", referenced from:")
         XCTAssertEqual(formatted, "##vso[task.logissue type=error]  \"NetworkBusiness.ImageDownloadManager.saveImage(image: __C.UIImage, needWatermark: Swift.Bool, params: [Swift.String : Any], downloadHandler: (Swift.Bool) -> ()?) -> ()\", referenced from:")
     }
 
-    func testundefinedSymbolLocation() {
+    func testUndefinedSymbolLocation() {
         let formatted = logFormatted("      MediaBrowser.ChatGalleryViewController.downloadImage() -> () in MediaBrowser(ChatGalleryViewController.o)")
         XCTAssertEqual(formatted, "##vso[task.logissue type=warning]      MediaBrowser.ChatGalleryViewController.downloadImage() -> () in MediaBrowser(ChatGalleryViewController.o)")
     }
 
-    func testtestCaseMeasured() {
+    func testTestCaseMeasured() {
         #if os(macOS)
         let formatted = logFormatted(#"/Users/cyberbeni/Desktop/framework/TypedNotificationCenter/<compiler-generated>:54: Test Case '-[TypedNotificationCenterPerformanceTests.BridgedNotificationTests test_subscribing_2senders_notificationName]' measured [High Water Mark For Heap Allocations, KB] average: 5407.634, relative standard deviation: 45.772%, values: [9341.718750, 3779.468750, 3779.468750, 9630.344727, 3779.468750, 3779.468750, 3895.093750, 3779.468750, 8532.372070, 3779.468750], performanceMetricID:com.apple.XCTPerformanceMetric_HighWaterMarkForHeapAllocations, baselineName: "", baselineAverage: , polarity: prefers smaller, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 1.000, maxStandardDeviation: 1.000"#)
         XCTAssertEqual(formatted, #"    ◷ test_subscribing_2senders_notificationName measured (5407.634 KB ±45.772% -- High Water Mark For Heap Allocations)"#)
         #endif
     }
 
-    func testtestCasePassed() {
+    func testTestCasePassed() {
         #if os(macOS)
         let formatted = logFormatted("Test Case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed (0.131 seconds).")
         XCTAssertEqual(formatted, "    ✔ testBuildTarget (0.131 seconds)")
         #endif
     }
 
-    func testtestCaseSkipped() {
+    func testTestCaseSkipped() {
         #if os(macOS)
         let formatted = logFormatted("Test Case '-[SomeTests testName]' skipped (0.004 seconds).")
         XCTAssertEqual(formatted, "    ⊘ testName (0.004 seconds)")
         #endif
     }
 
-    func testtestCasePending() { }
+    func testTestCasePending() { }
 
-    func testtestCaseStarted() { }
+    func testTestCaseStarted() { }
 
-    func testtestSuiteStart() { }
+    func testTestSuiteStart() { }
 
-    func testtestSuiteStarted() { }
+    func testTestSuiteStarted() { }
 
     #if os(macOS)
-    func testtestSuiteAllTestsPassed() {
+    func testTestSuiteAllTestsPassed() {
         let input = "Test Suite 'All tests' passed at 2022-01-15 21:31:49.073."
         let formatted = logFormatted(input)
         XCTAssertEqual(input, formatted)
@@ -465,54 +465,54 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
     #endif
 
     #if os(macOS)
-    func testtestSuiteAllTestsFailed() {
+    func testTestSuiteAllTestsFailed() {
         let input = "Test Suite 'All tests' failed at 2022-01-15 21:31:49.073."
         let formatted = logFormatted(input)
         XCTAssertEqual(input, formatted)
     }
     #endif
 
-    func testtestsRunCompletion() { }
+    func testTestsRunCompletion() { }
 
-    func testtiffutil() {
+    func testTiffutil() {
         let input = "TiffUtil file.tiff"
         XCTAssertEqual(logFormatted(input), nil)
     }
 
-    func testtouch() {
+    func testTouch() {
         let formatted = logFormatted("Touch /Users/admin/Library/Developer/Xcode/DerivedData/xcbeautify-dgnqmpfertotpceazwfhtfwtuuwt/Build/Products/Debug/XcbeautifyLib.framework (in target: XcbeautifyLib)")
         XCTAssertEqual(formatted, "[XcbeautifyLib] Touching XcbeautifyLib.framework")
     }
 
-    func testuiFailingTest() {
+    func testUIFailingTest() {
         let formatted = logFormatted("    t =    10.13s Assertion Failure: <unknown>:0: App crashed in <external symbol>")
         XCTAssertEqual(formatted, "##vso[task.logissue type=error;sourcepath=<unknown>;linenumber=0]    App crashed in <external symbol>")
     }
 
-    func testwillNotBeCodeSigned() {
+    func testWillNotBeCodeSigned() {
         let input = "FrameworkName will not be code signed because its settings don't specify a development team."
         let output = "##vso[task.logissue type=warning]FrameworkName will not be code signed because its settings don't specify a development team."
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testwriteAuxiliaryFileGeneric() {
+    func testWriteAuxiliaryFileGeneric() {
         let input = #"WriteAuxiliaryFile /path/to/some/auxiliary/file.extension (in target 'Target' from project 'Project')"#
         let output = "[Target] Write Auxiliary File file.extension"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testwriteAuxiliaryFileBackyardBirds() {
+    func testWriteAuxiliaryFileBackyardBirds() {
         let input = #"WriteAuxiliaryFile /Backyard-Birds/Build/Intermediates.noindex/LayeredArtworkLibrary.build/Debug/LayeredArtworkLibrary_LayeredArtworkLibrary.build/empty-LayeredArtworkLibrary_LayeredArtworkLibrary.plist (in target 'LayeredArtworkLibrary_LayeredArtworkLibrary' from project 'LayeredArtworkLibrary')"#
         let output = "[LayeredArtworkLibrary_LayeredArtworkLibrary] Write Auxiliary File empty-LayeredArtworkLibrary_LayeredArtworkLibrary.plist"
         XCTAssertEqual(logFormatted(input), output)
     }
 
-    func testwriteFile() {
+    func testWriteFile() {
         let input = "write-file /path/file.SwiftFileList"
         XCTAssertNil(logFormatted(input))
     }
 
-    func testpackageFetching() {
+    func testPackageFetching() {
         let input1 = "Fetching from https://github.com/cpisciotta/xcbeautify"
         let output1 = "Fetching https://github.com/cpisciotta/xcbeautify"
         let formatted1 = logFormatted(input1)

--- a/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
@@ -1,15 +1,22 @@
-import Testing
+import XCTest
 @testable import XcbeautifyLib
 
-@MainActor
-@Suite
-struct AzureDevOpsPipelinesRendererTests {
+final class AzureDevOpsPipelinesRendererTests: XCTestCase {
     private var parser: Parser!
     private var formatter: XcbeautifyLib.Formatter!
 
-    init() {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
         parser = Parser()
         formatter = Formatter(colored: false, renderer: .azureDevOpsPipelines, additionalLines: { nil })
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+
+        parser = nil
+        formatter = nil
     }
 
     private func logFormatted(_ string: String) -> String? {
@@ -17,760 +24,652 @@ struct AzureDevOpsPipelinesRendererTests {
         return formatter.format(captureGroup: captureGroup)
     }
 
-    @Test
-    func aggregateTarget() {
+    func testAggregateTarget() {
         let formatted = logFormatted("=== BUILD AGGREGATE TARGET Be Aggro OF PROJECT AggregateExample WITH CONFIGURATION Debug ===")
-        #expect(formatted == "Aggregate target Be Aggro of project AggregateExample with configuration Debug")
+        XCTAssertEqual(formatted, "Aggregate target Be Aggro of project AggregateExample with configuration Debug")
     }
 
-    @Test
-    func analyze() {
+    func testAnalyze() {
         let formatted = logFormatted("AnalyzeShallow /Users/admin/CocoaLumberjack/Classes/DDTTYLogger.m normal x86_64 (in target: CocoaLumberjack-Static)")
-        #expect(formatted == "[CocoaLumberjack-Static] Analyzing DDTTYLogger.m")
+        XCTAssertEqual(formatted, "[CocoaLumberjack-Static] Analyzing DDTTYLogger.m")
     }
 
-    @Test
-    func analyzeTarget() {
+    func testAnalyzeTarget() {
         let formatted = logFormatted("=== ANALYZE TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ===")
-        #expect(formatted == "Analyze target The Spacer of project Pods with configuration Debug")
+        XCTAssertEqual(formatted, "Analyze target The Spacer of project Pods with configuration Debug")
     }
 
-    @Test
-    func buildTarget() {
+    func testBuildTarget() {
         let formatted = logFormatted("=== BUILD TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ===")
-        #expect(formatted == "Build target The Spacer of project Pods with configuration Debug")
+        XCTAssertEqual(formatted, "Build target The Spacer of project Pods with configuration Debug")
     }
 
-    @Test
-    func checkDependenciesErrors() { }
+    func testCheckDependenciesErrors() { }
 
-    @Test
-    func checkDependencies() {
+    func testCheckDependencies() {
         let command = "Check Dependencies"
         let formatted = logFormatted(command)
-        #expect(formatted == command)
+        XCTAssertEqual(formatted, command)
     }
 
-    @Test
-    func clangError() {
+    func testclangError() {
         let formatted = logFormatted("clang: error: linker command failed with exit code 1 (use -v to see invocation)")
-        #expect(formatted == "###vso[task.logissue type=error]clang: error: linker command failed with exit code 1 (use -v to see invocation)")
+        XCTAssertEqual(formatted, "##vso[task.logissue type=error]clang: error: linker command failed with exit code 1 (use -v to see invocation)")
     }
 
-    @Test
-    func cleanRemove() {
+    func testcleanRemove() {
         let formatted = logFormatted("Clean.Remove clean /Users/admin/Library/Developer/Xcode/DerivedData/MyLibrary-abcd/Build/Intermediates/MyLibrary.build/Debug-iphonesimulator/MyLibraryTests.build")
-        #expect(formatted == "Cleaning MyLibraryTests.build")
+        XCTAssertEqual(formatted, "Cleaning MyLibraryTests.build")
     }
 
-    @Test
-    func cleanTarget() {
+    func testcleanTarget() {
         let formatted = logFormatted("=== ANALYZE TARGET The Spacer OF PROJECT Pods WITH THE DEFAULT CONFIGURATION Debug ===")
-        #expect(formatted == "Analyze target The Spacer of project Pods with configuration Debug")
+        XCTAssertEqual(formatted, "Analyze target The Spacer of project Pods with configuration Debug")
     }
 
-    @Test
-    func codesignFramework() {
+    func testcodesignFramework() {
         let formatted = logFormatted("CodeSign build/Release/MyFramework.framework/Versions/A")
-        #expect(formatted == "Signing build/Release/MyFramework.framework")
+        XCTAssertEqual(formatted, "Signing build/Release/MyFramework.framework")
     }
 
-    @Test
-    func codesign() {
+    func testcodesign() {
         let formatted = logFormatted("CodeSign build/Release/MyApp.app")
-        #expect(formatted == "Signing MyApp.app")
+        XCTAssertEqual(formatted, "Signing MyApp.app")
     }
 
-    @Test
-    func multipleCodesigns() {
+    func testmultipleCodesigns() {
         let formattedApp = logFormatted("CodeSign build/Release/MyApp.app")
         let formattedFramework = logFormatted("CodeSign build/Release/MyFramework.framework/Versions/A (in target 'X' from project 'Y')")
-        #expect(formattedApp == "Signing MyApp.app")
-        #expect(formattedFramework == "Signing build/Release/MyFramework.framework")
+        XCTAssertEqual(formattedApp, "Signing MyApp.app")
+        XCTAssertEqual(formattedFramework, "Signing build/Release/MyFramework.framework")
     }
 
-    @Test
-    func compileCommand() { }
+    func testcompileCommand() { }
 
-    @Test
-    func compileError() {
+    func testcompileError() {
         let inputError = "/path/file.swift:64:69: error: cannot find 'input' in scope"
-        let outputError = "###vso[task.logissue type=error;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]cannot find 'input' in scope\n\n"
-        #expect(logFormatted(inputError) == outputError)
+        let outputError = "##vso[task.logissue type=error;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]cannot find 'input' in scope\n\n"
+        XCTAssertEqual(logFormatted(inputError), outputError)
 
         let inputFatal = "/path/file.swift:64:69: fatal error: cannot find 'input' in scope"
-        let outputFatal = "###vso[task.logissue type=error;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]cannot find 'input' in scope\n\n"
-        #expect(logFormatted(inputFatal) == outputFatal)
+        let outputFatal = "##vso[task.logissue type=error;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]cannot find 'input' in scope\n\n"
+        XCTAssertEqual(logFormatted(inputFatal), outputFatal)
     }
 
-    @Test
-    func compile() {
+    func testcompile() {
         #if os(macOS)
         // Xcode 10 and before
         let input1 = "CompileSwift normal x86_64 /Users/admin/dev/Swifttrain/xcbeautify/Sources/xcbeautify/setup.swift (in target: xcbeautify)"
         // Xcode 11+'s output
         let input2 = "CompileSwift normal x86_64 /Users/admin/dev/Swifttrain/xcbeautify/Sources/xcbeautify/setup.swift (in target 'xcbeautify' from project 'xcbeautify')"
         let output = "[xcbeautify] Compiling setup.swift"
-        #expect(logFormatted(input1) == output)
-        #expect(logFormatted(input2) == output)
+        XCTAssertEqual(logFormatted(input1), output)
+        XCTAssertEqual(logFormatted(input2), output)
         #endif
     }
 
-    @Test
-    func swiftCompile_arm64() {
+    func testswiftCompile_arm64() {
         let input = "SwiftCompile normal arm64 /path/to/File.swift (in target 'Target' from project 'Project')"
         let output = "[Target] Compiling File.swift"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func swiftCompile_x86_64() {
+    func testswiftCompile_x86_64() {
         let input = "SwiftCompile normal x86_64 /Backyard-Birds/Build/Intermediates.noindex/BackyardBirdsData.build/Debug/BackyardBirdsData.build/DerivedSources/resource_bundle_accessor.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"
         let output = "[BackyardBirdsData] Compiling resource_bundle_accessor.swift"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func swiftCompiling() {
+    func testswiftCompiling() {
         let input = #"SwiftCompile normal x86_64 Compiling\ BackyardBirdsDataContainer.swift,\ ColorData.swift,\ DataGeneration.swift,\ DataGenerationOptions.swift /Backyard-Birds/BackyardBirdsData/General/BackyardBirdsDataContainer.swift /Backyard-Birds/BackyardBirdsData/General/ColorData.swift /Backyard-Birds/BackyardBirdsData/General/DataGeneration.swift /Backyard-Birds/BackyardBirdsData/General/DataGenerationOptions.swift (in target 'BackyardBirdsData' from project 'BackyardBirdsData')"#
-        #expect(logFormatted(input) == nil)
+        XCTAssertNil(logFormatted(input))
     }
 
-    @Test
-    func compileStoryboard() {
+    func testcompileStoryboard() {
         let formatted = logFormatted("CompileStoryboard /Users/admin/MyApp/MyApp/Main.storyboard (in target: MyApp)")
-        #expect(formatted == "[MyApp] Compiling Main.storyboard")
+        XCTAssertEqual(formatted, "[MyApp] Compiling Main.storyboard")
     }
 
-    @Test
-    func compileWarning() {
+    func testcompileWarning() {
         let input = "/path/file.swift:64:69: warning: 'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value"
-        let output = "###vso[task.logissue type=warning;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value\n\n"
-        #expect(logFormatted(input) == output)
+        let output = "##vso[task.logissue type=warning;sourcepath=/path/file.swift;linenumber=64;columnnumber=69]'flatMap' is deprecated: Please use compactMap(_:) for the case where closure returns an optional value\n\n"
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func compileXib() {
+    func testcompileXib() {
         let input = "CompileXIB /path/file.xib (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Compiling file.xib"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func copyHeader() {
+    func testcopyHeader() {
         let input = "CpHeader /path/to/destination/file.h /path/file.h (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Copying file.h"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func copyPlist() {
+    func testcopyPlist() {
         let input = "CopyPlistFile /path/to/destination/file.plist /path/file.plist (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Copying file.plist"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func copyStrings() {
+    func testcopyStrings() {
         let input = "CopyStringsFile /path/to/destination/file.strings /path/file.strings (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Copying file.strings"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func cpResource() {
+    func testcpResource() {
         let input = "CpResource /path/to/destination/file.ttf /path/file.ttf (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Copying file.ttf"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func copyMatchingSourceAndDestinationFiles() {
+    func testcopyMatchingSourceAndDestinationFiles() {
         let input = "Copy /path/to/some/file.swift /path/to/some/other/file.swift (in target 'Target' from project 'Project')"
         let output = "[Target] Copy file.swift -> file.swift"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func copyDifferentSourceAndDestinationFiles() {
+    func testcopyDifferentSourceAndDestinationFiles() {
         let input = #"Copy /Backyard-Birds/Build/Products/Debug/Backyard_Birds.swiftmodule/x86_64-apple-macos.abi.json /Backyard-Birds/Build/Intermediates.noindex/Backyard\ Birds.build/Debug/Backyard\ Birds.build/Objects-normal/x86_64/Backyard_Birds.abi.json (in target 'Backyard Birds' from project 'Backyard Birds')"#
         let output = "[Backyard Birds] Copy x86_64-apple-macos.abi.json -> Backyard_Birds.abi.json"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func cursor() { }
+    func testcursor() { }
 
-    @Test
-    func executed() throws {
+    func testexecuted() throws {
         let input1 = "Test Suite 'All tests' failed at 2022-01-15 21:31:49.073."
         let formatted1 = logFormatted(input1)
-        #expect(input1 == formatted1)
+        XCTAssertEqual(input1, formatted1)
 
         let input2 = "Executed 3 tests, with 2 failures (1 unexpected) in 0.112 (0.112) seconds"
         let formatted2 = logFormatted(input2)
-        #expect(input2 == formatted2)
+        XCTAssertEqual(input2, formatted2)
 
         let input3 = "Test Suite 'All tests' passed at 2022-01-15 21:33:49.073."
         let formatted3 = logFormatted(input3)
-        #expect(input3 == formatted3)
+        XCTAssertEqual(input3, formatted3)
 
         let input4 = "Executed 1 test, with 1 failure (1 unexpected) in 0.200 (0.200) seconds"
         let formatted4 = logFormatted(input4)
-        #expect(input4 == formatted4)
+        XCTAssertEqual(input4, formatted4)
     }
 
     #if os(macOS)
-    @Test
-    func executedWithSkipped() {
+    func testexecutedWithSkipped() {
         let input1 = "Test Suite 'All tests' failed at 2022-01-15 21:31:49.073."
         let formatted1 = logFormatted(input1)
-        #expect(input1 == formatted1)
+        XCTAssertEqual(input1, formatted1)
 
         let input2 = "Executed 56 tests, with 3 test skipped and 2 failures (1 unexpected) in 1.029 (1.029) seconds"
         let formatted2 = logFormatted(input2)
-        #expect(input2 == formatted2)
+        XCTAssertEqual(input2, formatted2)
 
         let input3 = "Test Suite 'All tests' passed at 2022-01-15 21:33:49.073."
         let formatted3 = logFormatted(input3)
-        #expect(input3 == formatted3)
+        XCTAssertEqual(input3, formatted3)
 
         let input4 = "Executed 1 test, with 1 test skipped and 1 failure (1 unexpected) in 3.000 (3.000) seconds"
         let formatted4 = logFormatted(input4)
-        #expect(input4 == formatted4)
+        XCTAssertEqual(input4, formatted4)
     }
     #endif
 
-    @Test
-    func failingTest() { }
+    func testfailingTest() { }
 
-    @Test
-    func fatalError() {
+    func testfatalError() {
         let input = "fatal error: malformed or corrupted AST file: 'could not find file '/path/file.h' referenced by AST file' note: after modifying system headers, please delete the module cache at '/path/DerivedData/ModuleCache/M5WJ0FYE7N06'"
-        let output = "###vso[task.logissue type=error]fatal error: malformed or corrupted AST file: 'could not find file '/path/file.h' referenced by AST file' note: after modifying system headers, please delete the module cache at '/path/DerivedData/ModuleCache/M5WJ0FYE7N06'"
-        #expect(logFormatted(input) == output)
+        let output = "##vso[task.logissue type=error]fatal error: malformed or corrupted AST file: 'could not find file '/path/file.h' referenced by AST file' note: after modifying system headers, please delete the module cache at '/path/DerivedData/ModuleCache/M5WJ0FYE7N06'"
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func fileMissingError() {
+    func testfileMissingError() {
         let input = "<unknown>:0: error: no such file or directory: '/path/file.swift'"
-        let output = "###vso[task.logissue type=error;sourcepath=/path/file.swift]error: no such file or directory:"
-        #expect(logFormatted(input) == output)
+        let output = "##vso[task.logissue type=error;sourcepath=/path/file.swift]error: no such file or directory:"
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func generateCoverageData() {
+    func testgenerateCoverageData() {
         let formatted = logFormatted("Generating coverage data...")
-        #expect(formatted == "Generating code coverage data...")
+        XCTAssertEqual(formatted, "Generating code coverage data...")
     }
 
-    @Test
-    func generatedCoverageReport() {
+    func testgeneratedCoverageReport() {
         let formatted = logFormatted("Generated coverage report: /path/to/code coverage.xccovreport")
-        #expect(formatted == "Generated code coverage report: /path/to/code coverage.xccovreport")
+        XCTAssertEqual(formatted, "Generated code coverage report: /path/to/code coverage.xccovreport")
     }
 
-    @Test
-    func generateDsym() {
+    func testgenerateDsym() {
         let input = "GenerateDSYMFile /path/file.dSYM /path/to/file (in target 'MyApp' from project 'MyProject')"
         let output = "[MyApp] Generating file.dSYM"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func genericWarning() {
+    func testgenericWarning() {
         let input = "warning: some warning here 123"
-        let output = "###vso[task.logissue type=warning]some warning here 123"
-        #expect(logFormatted(input) == output)
+        let output = "##vso[task.logissue type=warning]some warning here 123"
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func ldError() {
+    func testldError() {
         let inputLdLibraryError = "ld: library not found for -lPods-Yammer"
-        #expect(logFormatted(inputLdLibraryError) == "###vso[task.logissue type=error]ld: library not found for -lPods-Yammer")
+        XCTAssertEqual(logFormatted(inputLdLibraryError), "##vso[task.logissue type=error]ld: library not found for -lPods-Yammer")
 
         let inputLdSymbolsError = "ld: symbol(s) not found for architecture x86_64"
-        #expect(logFormatted(inputLdSymbolsError) == "###vso[task.logissue type=error]ld: symbol(s) not found for architecture x86_64")
+        XCTAssertEqual(logFormatted(inputLdSymbolsError), "##vso[task.logissue type=error]ld: symbol(s) not found for architecture x86_64")
     }
 
-    @Test
-    func ldWarning() {
+    func testldWarning() {
         let input = "ld: warning: embedded dylibs/frameworks only run on iOS 8 or later"
-        let output = "###vso[task.logissue type=warning]ld: embedded dylibs/frameworks only run on iOS 8 or later"
-        #expect(logFormatted(input) == output)
+        let output = "##vso[task.logissue type=warning]ld: embedded dylibs/frameworks only run on iOS 8 or later"
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func libtool() { }
+    func testlibtool() { }
 
-    @Test
-    func linkerDuplicateSymbolsLocation() { }
+    func testlinkerDuplicateSymbolsLocation() { }
 
-    @Test
-    func linkerDuplicateSymbols() { }
+    func testlinkerDuplicateSymbols() { }
 
-    @Test
-    func linkerUndefinedSymbolLocation() { }
+    func testlinkerUndefinedSymbolLocation() { }
 
-    @Test
-    func linkerUndefinedSymbols() { }
+    func testlinkerUndefinedSymbols() { }
 
-    @Test
-    func linking() {
+    func testlinking() {
         #if os(macOS)
         let formatted = logFormatted("Ld /Users/admin/Library/Developer/Xcode/DerivedData/xcbeautify-abcd/Build/Products/Debug/xcbeautify normal x86_64 (in target: xcbeautify)")
-        #expect(formatted == "[xcbeautify] Linking xcbeautify")
+        XCTAssertEqual(formatted, "[xcbeautify] Linking xcbeautify")
 
         let formatted2 = logFormatted("Ld /Users/admin/Library/Developer/Xcode/DerivedData/MyApp-abcd/Build/Intermediates.noindex/ArchiveIntermediates/MyApp/IntermediateBuildFilesPath/MyApp.build/Release-iphoneos/MyApp.build/Objects-normal/armv7/My\\ App normal armv7 (in target: MyApp)")
-        #expect(formatted2 == "[MyApp] Linking My\\ App")
+        XCTAssertEqual(formatted2, "[MyApp] Linking My\\ App")
         #endif
     }
 
-    @Test
-    func moduleIncludesError() { }
+    func testmoduleIncludesError() { }
 
-    @Test
-    func noCertificate() { }
+    func testnoCertificate() { }
 
-    @Test
-    func parallelTestCaseFailed() {
+    func testparallelTestCaseFailed() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'xctest (49438)' (0.131 seconds)")
-        #expect(formatted == "###vso[task.logissue type=error]    testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, "##vso[task.logissue type=error]    testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
-    @Test
-    func parallelTestCasePassed() {
+    func testparallelTestCasePassed() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'xctest (49438)' (0.131 seconds)")
-        #expect(formatted == "    ✔ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
-    @Test
-    func parallelTestCaseSkipped() {
+    func testparallelTestCaseSkipped() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' skipped on 'xctest (49438)' (0.131 seconds)")
-        #expect(formatted == "    ⊘ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
+        XCTAssertEqual(formatted, "    ⊘ [XcbeautifyLibTests] testBuildTarget on 'xctest (49438)' (0.131 seconds)")
     }
 
-    @Test
-    func concurrentDestinationTestSuiteStarted() {
+    func testconcurrentDestinationTestSuiteStarted() {
         let formatted = logFormatted("Test suite 'XcbeautifyLibTests (iOS).xctest' started on 'iPhone X'")
-        #expect(formatted == "Test Suite XcbeautifyLibTests (iOS).xctest started on 'iPhone X'")
+        XCTAssertEqual(formatted, "Test Suite XcbeautifyLibTests (iOS).xctest started on 'iPhone X'")
     }
 
-    @Test
-    func concurrentDestinationTestCaseFailed() {
+    func testconcurrentDestinationTestCaseFailed() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' failed on 'iPhone X' (77.158 seconds)")
-        #expect(formatted == "###vso[task.logissue type=error]    testBuildTarget on 'iPhone X' (77.158 seconds)")
+        XCTAssertEqual(formatted, "##vso[task.logissue type=error]    testBuildTarget on 'iPhone X' (77.158 seconds)")
     }
 
-    @Test
-    func concurrentDestinationTestCasePassed() {
+    func testconcurrentDestinationTestCasePassed() {
         let formatted = logFormatted("Test case 'XcbeautifyLibTests.testBuildTarget()' passed on 'iPhone X' (77.158 seconds)")
-        #expect(formatted == "    ✔ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests] testBuildTarget on 'iPhone X' (77.158 seconds)")
     }
 
-    @Test
-    func parallelTestCaseAppKitPassed() {
+    func testparallelTestCaseAppKitPassed() {
         let formatted = logFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed on 'xctest (49438)' (0.131 seconds).")
-        #expect(formatted == "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
+        XCTAssertEqual(formatted, "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
     }
 
-    @Test
-    func parallelTestingStarted() {
+    func testparallelTestingStarted() {
         let formatted = logFormatted("Testing started on 'iPhone X'")
-        #expect(formatted == "Testing started on 'iPhone X'")
+        XCTAssertEqual(formatted, "Testing started on 'iPhone X'")
     }
 
-    @Test
-    func parallelTestingPassed() {
+    func testparallelTestingPassed() {
         let formatted = logFormatted("Testing passed on 'iPhone X'")
-        #expect(formatted == "Testing passed on 'iPhone X'")
+        XCTAssertEqual(formatted, "Testing passed on 'iPhone X'")
     }
 
-    @Test
-    func parallelTestingFailed() {
+    func testparallelTestingFailed() {
         let formatted = logFormatted("Testing failed on 'iPhone X'")
-        #expect(formatted == "###vso[task.logissue type=error]Testing failed on 'iPhone X'")
+        XCTAssertEqual(formatted, "##vso[task.logissue type=error]Testing failed on 'iPhone X'")
     }
 
-    @Test
-    func pbxCp() {
+    func testpbxCp() {
         let formatted = logFormatted("PBXCp /Users/admin/CocoaLumberjack/Classes/Extensions/DDDispatchQueueLogFormatter.h /Users/admin/Library/Developer/Xcode/DerivedData/Lumberjack-abcd/Build/Products/Release/include/CocoaLumberjack/DDDispatchQueueLogFormatter.h (in target: CocoaLumberjack-Static)")
-        #expect(formatted == "[CocoaLumberjack-Static] Copying DDDispatchQueueLogFormatter.h")
+        XCTAssertEqual(formatted, "[CocoaLumberjack-Static] Copying DDDispatchQueueLogFormatter.h")
     }
 
-    @Test
-    func phaseScriptExecution() {
+    func testphaseScriptExecution() {
         let input1 = "PhaseScriptExecution [CP]\\ Check\\ Pods\\ Manifest.lock /Users/admin/Library/Developer/Xcode/DerivedData/App-abcd/Build/Intermediates.noindex/ArchiveIntermediates/App/IntermediateBuildFilesPath/App.build/Release-iphoneos/App.build/Script-53BECF2B2F2E203E928C31AE.sh (in target: App)"
         let input2 = "PhaseScriptExecution [CP]\\ Check\\ Pods\\ Manifest.lock /Users/admin/Library/Developer/Xcode/DerivedData/App-abcd/Build/Intermediates.noindex/ArchiveIntermediates/App/IntermediateBuildFilesPath/App.build/Release-iphoneos/App.build/Script-53BECF2B2F2E203E928C31AE.sh (in target 'App' from project 'App')"
-        #expect(logFormatted(input1) == "[App] Running script [CP] Check Pods Manifest.lock")
-        #expect(logFormatted(input2) == "[App] Running script [CP] Check Pods Manifest.lock")
+        XCTAssertEqual(logFormatted(input1), "[App] Running script [CP] Check Pods Manifest.lock")
+        XCTAssertEqual(logFormatted(input2), "[App] Running script [CP] Check Pods Manifest.lock")
     }
 
-    @Test
-    func phaseSuccess() {
+    func testphaseSuccess() {
         let formatted = logFormatted("** CLEAN SUCCEEDED ** [0.085 sec]")
-        #expect(formatted == "Clean Succeeded")
+        XCTAssertEqual(formatted, "Clean Succeeded")
     }
 
-    @Test
-    func podsError() {
+    func testpodsError() {
         let input = "error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation."
-        let output = "###vso[task.logissue type=error]error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation."
-        #expect(logFormatted(input) == output)
+        let output = "##vso[task.logissue type=error]error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation."
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func preprocess() {
+    func testpreprocess() {
         let input = "Preprocess /Example/Example/Something.m normal arm64 (in target 'SomeTarget' from project 'SomeProject')"
         let output = "[SomeTarget] Preprocess Something.m"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func processInfoPlist() {
+    func testprocessInfoPlist() {
         let formatted = logFormatted("ProcessInfoPlistFile /Users/admin/Library/Developer/Xcode/DerivedData/xcbeautify-abcd/Build/Products/Debug/Guaka.framework/Versions/A/Resources/Info.plist /Users/admin/xcbeautify/xcbeautify.xcodeproj/Guaka_Info.plist")
-        #expect(formatted == "Processing Guaka_Info.plist")
+        XCTAssertEqual(formatted, "Processing Guaka_Info.plist")
     }
 
-    @Test
-    func processPchCommand() {
+    func testprocessPchCommand() {
         let formatted = logFormatted("/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++-header -target x86_64-apple-macos10.13 -c /path/to/my.pch -o /path/to/output/AcVDiff_Prefix.pch.gch")
-        #expect(formatted == "Preprocessing /path/to/my.pch")
+        XCTAssertEqual(formatted, "Preprocessing /path/to/my.pch")
     }
 
-    @Test
-    func processPchCommandArbitraryExtension() {
+    func testprocessPchCommandArbitraryExtension() {
         let formatted = logFormatted(#"/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x c++-header -target x86_64-apple-macos12.3 -c /path/with\ space/cmake_pch.hxx -o /path/with\ space/build/SharedPrecompiledHeaders/SharedPrecompiledHeaders/2304651503107189736/cmake_pch.hxx.gch --serialize-diagnostics /path/with\ space/build/SharedPrecompiledHeaders/SharedPrecompiledHeaders/2304651503107189736/cmake_pch.hxx.dia"#)
-        #expect(formatted == #"Preprocessing /path/with\ space/cmake_pch.hxx"#)
+        XCTAssertEqual(formatted, #"Preprocessing /path/with\ space/cmake_pch.hxx"#)
     }
 
-    @Test
-    func processPch() {
+    func testprocessPch() {
         let formatted = logFormatted("ProcessPCH /Users/admin/Library/Developer/Xcode/DerivedData/Lumberjack-abcd/Build/Intermediates.noindex/PrecompiledHeaders/SharedPrecompiledHeaders/5872309797734264511/CocoaLumberjack-Prefix.pch.gch /Users/admin/CocoaLumberjack/Framework/Lumberjack/CocoaLumberjack-Prefix.pch normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.analyzer (in target: CocoaLumberjack)")
-        #expect(formatted == "[CocoaLumberjack] Processing CocoaLumberjack-Prefix.pch")
+        XCTAssertEqual(formatted, "[CocoaLumberjack] Processing CocoaLumberjack-Prefix.pch")
     }
 
-    @Test
-    func processPchArbitraryExtension() {
+    func testprocessPchArbitraryExtension() {
         let formatted = logFormatted(#"ProcessPCH++ /Users/admin/src/Test\ Folder/_builds/SharedPrecompiledHeaders/SharedPrecompiledHeaders/2304651503107189736/cmake_pch.hxx.gch /Users/admin/src/Test\ Folder/_builds/CMakeFiles/foo.dir/Debug/cmake_pch.hxx normal x86_64 c++ com.apple.compilers.llvm.clang.1_0.compiler (in target 'foo' from project 'foo')"#)
-        #expect(formatted == "[foo] Processing cmake_pch.hxx")
+        XCTAssertEqual(formatted, "[foo] Processing cmake_pch.hxx")
     }
 
-    @Test
-    func processPchPlusPlus() {
+    func testprocessPchPlusPlus() {
         let formatted = logFormatted("ProcessPCH++ /Users/admin/Library/Developer/Xcode/DerivedData/Lumberjack-abcd/Build/Intermediates.noindex/PrecompiledHeaders/SharedPrecompiledHeaders/5872309797734264511/CocoaLumberjack-Prefix.pch.gch /Users/admin/CocoaLumberjack/Framework/Lumberjack/CocoaLumberjack-Prefix.pch normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.analyzer (in target: CocoaLumberjack)")
-        #expect(formatted == "[CocoaLumberjack] Processing CocoaLumberjack-Prefix.pch")
+        XCTAssertEqual(formatted, "[CocoaLumberjack] Processing CocoaLumberjack-Prefix.pch")
     }
 
-    @Test
-    func provisioningProfileRequired() {
+    func testprovisioningProfileRequired() {
         let input = #"MyProject requires a provisioning profile. Select a provisioning profile for the "Debug" build configuration in the project editor."#
-        let output = #"###vso[task.logissue type=error]MyProject requires a provisioning profile. Select a provisioning profile for the "Debug" build configuration in the project editor."#
-        #expect(logFormatted(input) == output)
+        let output = #"##vso[task.logissue type=error]MyProject requires a provisioning profile. Select a provisioning profile for the "Debug" build configuration in the project editor."#
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func restartingTests() {
+    func testrestartingTests() {
         let formatted = logFormatted("Restarting after unexpected exit, crash, or test timeout in HomePresenterTest.testIsCellPresented(); summary will include totals from previous launches.")
-        #expect(formatted == "###vso[task.logissue type=error]    Restarting after unexpected exit, crash, or test timeout in HomePresenterTest.testIsCellPresented(); summary will include totals from previous launches.")
+        XCTAssertEqual(formatted, "##vso[task.logissue type=error]    Restarting after unexpected exit, crash, or test timeout in HomePresenterTest.testIsCellPresented(); summary will include totals from previous launches.")
     }
 
-    @Test
-    func shellCommand() {
+    func testshellCommand() {
         let formatted = logFormatted("    cd /foo/bar/baz")
-        #expect(formatted == nil)
+        XCTAssertNil(formatted)
     }
 
-    @Test
-    func symbolReferencedFrom() {
+    func testsymbolReferencedFrom() {
         let formatted = logFormatted("  \"NetworkBusiness.ImageDownloadManager.saveImage(image: __C.UIImage, needWatermark: Swift.Bool, params: [Swift.String : Any], downloadHandler: (Swift.Bool) -> ()?) -> ()\", referenced from:")
-        #expect(formatted == "###vso[task.logissue type=error]  \"NetworkBusiness.ImageDownloadManager.saveImage(image: __C.UIImage, needWatermark: Swift.Bool, params: [Swift.String : Any], downloadHandler: (Swift.Bool) -> ()?) -> ()\", referenced from:")
+        XCTAssertEqual(formatted, "##vso[task.logissue type=error]  \"NetworkBusiness.ImageDownloadManager.saveImage(image: __C.UIImage, needWatermark: Swift.Bool, params: [Swift.String : Any], downloadHandler: (Swift.Bool) -> ()?) -> ()\", referenced from:")
     }
 
-    @Test
-    func undefinedSymbolLocation() {
+    func testundefinedSymbolLocation() {
         let formatted = logFormatted("      MediaBrowser.ChatGalleryViewController.downloadImage() -> () in MediaBrowser(ChatGalleryViewController.o)")
-        #expect(formatted == "###vso[task.logissue type=warning]      MediaBrowser.ChatGalleryViewController.downloadImage() -> () in MediaBrowser(ChatGalleryViewController.o)")
+        XCTAssertEqual(formatted, "##vso[task.logissue type=warning]      MediaBrowser.ChatGalleryViewController.downloadImage() -> () in MediaBrowser(ChatGalleryViewController.o)")
     }
 
-    @Test
-    func testCaseMeasured() {
+    func testtestCaseMeasured() {
         #if os(macOS)
         let formatted = logFormatted(#"/Users/cyberbeni/Desktop/framework/TypedNotificationCenter/<compiler-generated>:54: Test Case '-[TypedNotificationCenterPerformanceTests.BridgedNotificationTests test_subscribing_2senders_notificationName]' measured [High Water Mark For Heap Allocations, KB] average: 5407.634, relative standard deviation: 45.772%, values: [9341.718750, 3779.468750, 3779.468750, 9630.344727, 3779.468750, 3779.468750, 3895.093750, 3779.468750, 8532.372070, 3779.468750], performanceMetricID:com.apple.XCTPerformanceMetric_HighWaterMarkForHeapAllocations, baselineName: "", baselineAverage: , polarity: prefers smaller, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 1.000, maxStandardDeviation: 1.000"#)
-        #expect(formatted == #"    ◷ test_subscribing_2senders_notificationName measured (5407.634 KB ±45.772% -- High Water Mark For Heap Allocations)"#)
+        XCTAssertEqual(formatted, #"    ◷ test_subscribing_2senders_notificationName measured (5407.634 KB ±45.772% -- High Water Mark For Heap Allocations)"#)
         #endif
     }
 
-    @Test
-    func testCasePassed() {
+    func testtestCasePassed() {
         #if os(macOS)
         let formatted = logFormatted("Test Case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' passed (0.131 seconds).")
-        #expect(formatted == "    ✔ testBuildTarget (0.131 seconds)")
+        XCTAssertEqual(formatted, "    ✔ testBuildTarget (0.131 seconds)")
         #endif
     }
 
-    @Test
-    func testCaseSkipped() {
+    func testtestCaseSkipped() {
         #if os(macOS)
         let formatted = logFormatted("Test Case '-[SomeTests testName]' skipped (0.004 seconds).")
-        #expect(formatted == "    ⊘ testName (0.004 seconds)")
+        XCTAssertEqual(formatted, "    ⊘ testName (0.004 seconds)")
         #endif
     }
 
-    @Test
-    func testCasePending() { }
+    func testtestCasePending() { }
 
-    @Test
-    func testCaseStarted() { }
+    func testtestCaseStarted() { }
 
-    @Test
-    func testSuiteStart() { }
+    func testtestSuiteStart() { }
 
-    @Test
-    func testSuiteStarted() { }
+    func testtestSuiteStarted() { }
 
     #if os(macOS)
-    @Test
-    func testSuiteAllTestsPassed() {
+    func testtestSuiteAllTestsPassed() {
         let input = "Test Suite 'All tests' passed at 2022-01-15 21:31:49.073."
         let formatted = logFormatted(input)
-        #expect(input == formatted)
+        XCTAssertEqual(input, formatted)
     }
     #endif
 
     #if os(macOS)
-    @Test
-    func testSuiteAllTestsFailed() {
+    func testtestSuiteAllTestsFailed() {
         let input = "Test Suite 'All tests' failed at 2022-01-15 21:31:49.073."
         let formatted = logFormatted(input)
-        #expect(input == formatted)
+        XCTAssertEqual(input, formatted)
     }
     #endif
 
-    @Test
-    func testsRunCompletion() { }
+    func testtestsRunCompletion() { }
 
-    @Test
-    func tiffutil() {
+    func testtiffutil() {
         let input = "TiffUtil file.tiff"
-        #expect(logFormatted(input) == nil)
+        XCTAssertEqual(logFormatted(input), nil)
     }
 
-    @Test
-    func touch() {
+    func testtouch() {
         let formatted = logFormatted("Touch /Users/admin/Library/Developer/Xcode/DerivedData/xcbeautify-dgnqmpfertotpceazwfhtfwtuuwt/Build/Products/Debug/XcbeautifyLib.framework (in target: XcbeautifyLib)")
-        #expect(formatted == "[XcbeautifyLib] Touching XcbeautifyLib.framework")
+        XCTAssertEqual(formatted, "[XcbeautifyLib] Touching XcbeautifyLib.framework")
     }
 
-    @Test
-    func uiFailingTest() {
+    func testuiFailingTest() {
         let formatted = logFormatted("    t =    10.13s Assertion Failure: <unknown>:0: App crashed in <external symbol>")
-        #expect(formatted == "###vso[task.logissue type=error;sourcepath=<unknown>;linenumber=0]    App crashed in <external symbol>")
+        XCTAssertEqual(formatted, "##vso[task.logissue type=error;sourcepath=<unknown>;linenumber=0]    App crashed in <external symbol>")
     }
 
-    @Test
-    func willNotBeCodeSigned() {
+    func testwillNotBeCodeSigned() {
         let input = "FrameworkName will not be code signed because its settings don't specify a development team."
-        let output = "###vso[task.logissue type=warning]FrameworkName will not be code signed because its settings don't specify a development team."
-        #expect(logFormatted(input) == output)
+        let output = "##vso[task.logissue type=warning]FrameworkName will not be code signed because its settings don't specify a development team."
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func writeAuxiliaryFileGeneric() {
+    func testwriteAuxiliaryFileGeneric() {
         let input = #"WriteAuxiliaryFile /path/to/some/auxiliary/file.extension (in target 'Target' from project 'Project')"#
         let output = "[Target] Write Auxiliary File file.extension"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func writeAuxiliaryFileBackyardBirds() {
+    func testwriteAuxiliaryFileBackyardBirds() {
         let input = #"WriteAuxiliaryFile /Backyard-Birds/Build/Intermediates.noindex/LayeredArtworkLibrary.build/Debug/LayeredArtworkLibrary_LayeredArtworkLibrary.build/empty-LayeredArtworkLibrary_LayeredArtworkLibrary.plist (in target 'LayeredArtworkLibrary_LayeredArtworkLibrary' from project 'LayeredArtworkLibrary')"#
         let output = "[LayeredArtworkLibrary_LayeredArtworkLibrary] Write Auxiliary File empty-LayeredArtworkLibrary_LayeredArtworkLibrary.plist"
-        #expect(logFormatted(input) == output)
+        XCTAssertEqual(logFormatted(input), output)
     }
 
-    @Test
-    func writeFile() {
+    func testwriteFile() {
         let input = "write-file /path/file.SwiftFileList"
-        #expect(logFormatted(input) == nil)
+        XCTAssertNil(logFormatted(input))
     }
 
-    @Test
-    func packageFetching() {
+    func testpackageFetching() {
         let input1 = "Fetching from https://github.com/cpisciotta/xcbeautify"
         let output1 = "Fetching https://github.com/cpisciotta/xcbeautify"
         let formatted1 = logFormatted(input1)
-        #expect(formatted1 == output1)
+        XCTAssertEqual(formatted1, output1)
 
         let input2 = "Fetching from https://github.com/cpisciotta/xcbeautify (cached)"
         let output2 = "Fetching https://github.com/cpisciotta/xcbeautify (cached)"
         let formatted2 = logFormatted(input2)
-        #expect(formatted2 == output2)
+        XCTAssertEqual(formatted2, output2)
 
         let input3 = "Fetching from https://github.com/cpisciotta/xcbeautify.git"
         let output3 = "Fetching https://github.com/cpisciotta/xcbeautify.git"
         let formatted3 = logFormatted(input3)
-        #expect(formatted3 == output3)
+        XCTAssertEqual(formatted3, output3)
     }
 
-    @Test
-    func packageUpdating() {
+    func testPackageUpdating() {
         let input1 = "Updating from https://github.com/cpisciotta/xcbeautify"
         let output1 = "Updating https://github.com/cpisciotta/xcbeautify"
         let formatted1 = logFormatted(input1)
-        #expect(formatted1 == output1)
+        XCTAssertEqual(formatted1, output1)
 
         let input2 = "Updating from https://github.com/cpisciotta/xcbeautify (cached)"
         let output2 = "Updating https://github.com/cpisciotta/xcbeautify (cached)"
         let formatted2 = logFormatted(input2)
-        #expect(formatted2 == output2)
+        XCTAssertEqual(formatted2, output2)
 
         let input3 = "Updating from https://github.com/cpisciotta/xcbeautify.git"
         let output3 = "Updating https://github.com/cpisciotta/xcbeautify.git"
         let formatted3 = logFormatted(input3)
-        #expect(formatted3 == output3)
+        XCTAssertEqual(formatted3, output3)
     }
 
-    @Test
-    func packageCheckingOut() {
+    func testPackageCheckingOut() {
         let input1 = "Cloning local copy of package 'xcbeautify'"
         let formatted1 = logFormatted(input1)
-        #expect(formatted1 == nil)
+        XCTAssertNil(formatted1)
 
         let input2 = "Checking out x.y.z of package 'xcbeautify'"
         let output2 = "Checking out 'xcbeautify' @ x.y.z"
         let formatted2 = logFormatted(input2)
-        #expect(formatted2 == output2)
+        XCTAssertEqual(formatted2, output2)
     }
 
-    @Test
-    func packageGraphResolved() {
+    func testPackageGraphResolved() {
         // Start
         let start = logFormatted("Resolve Package Graph")
-        #expect(start == "Resolving Package Graph")
+        XCTAssertEqual(start, "Resolving Package Graph")
 
         // Ended
         let ended = logFormatted("Resolved source packages:")
-        #expect(ended == "Resolved source packages")
+        XCTAssertEqual(ended, "Resolved source packages")
 
         // Package
         let package = logFormatted("  StrasbourgParkAPI: https://github.com/yageek/StrasbourgParkAPI.git @ 3.0.2")
-        #expect(package == "StrasbourgParkAPI - https://github.com/yageek/StrasbourgParkAPI.git @ 3.0.2")
+        XCTAssertEqual(package, "StrasbourgParkAPI - https://github.com/yageek/StrasbourgParkAPI.git @ 3.0.2")
     }
 
-    @Test
-    func xcodebuildError() {
+    func testXcodebuildError() {
         let formatted = logFormatted("xcodebuild: error: Existing file at -resultBundlePath \"/output/file.xcresult\"")
-        #expect(formatted == "###vso[task.logissue type=error]xcodebuild: error: Existing file at -resultBundlePath \"/output/file.xcresult\"")
+        XCTAssertEqual(formatted, "##vso[task.logissue type=error]xcodebuild: error: Existing file at -resultBundlePath \"/output/file.xcresult\"")
     }
 
-    @Test
-    func xcodeprojError() {
+    func testXcodeprojError() {
         // Given
         let errorText = #"/path/to/project.xcodeproj: error: No signing certificate "iOS Distribution" found: No "iOS Distribution" signing certificate matching team ID "xxxxx" with a private key was found. (in target 'target' from project 'project')"#
-        let expectedFormatted = "###vso[task.logissue type=error;sourcepath=/path/to/project.xcodeproj]No signing certificate \"iOS Distribution\" found: No \"iOS Distribution\" signing certificate matching team ID \"xxxxx\" with a private key was found. (in target 'target' from project 'project')\n\n"
+        let expectedFormatted = "##vso[task.logissue type=error;sourcepath=/path/to/project.xcodeproj]No signing certificate \"iOS Distribution\" found: No \"iOS Distribution\" signing certificate matching team ID \"xxxxx\" with a private key was found. (in target 'target' from project 'project')\n\n"
 
         // When
         let actualFormatted = logFormatted(errorText)
 
         // Then
-        #expect(actualFormatted == expectedFormatted)
+        XCTAssertEqual(actualFormatted, expectedFormatted)
     }
 
-    @Test
-    func xcodeprojWarning() {
+    func testXcodeprojWarning() {
         // Given
         let errorText = "/Users/xxxxx/Example/Pods/Pods.xcodeproj: warning: The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.0.99. (in target 'XXPay' from project 'Pods')"
-        let expectedFormatted = "###vso[task.logissue type=warning;sourcepath=/Users/xxxxx/Example/Pods/Pods.xcodeproj]The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.0.99. (in target 'XXPay' from project 'Pods')\n\n"
+        let expectedFormatted = "##vso[task.logissue type=warning;sourcepath=/Users/xxxxx/Example/Pods/Pods.xcodeproj]The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 9.0, but the range of supported deployment target versions is 11.0 to 16.0.99. (in target 'XXPay' from project 'Pods')\n\n"
 
         // When
         let actualFormatted = logFormatted(errorText)
 
         // Then
-        #expect(actualFormatted == expectedFormatted)
+        XCTAssertEqual(actualFormatted, expectedFormatted)
     }
 
-    @Test
-    func duplicateLocalizedStringKey() {
+    func testDuplicateLocalizedStringKey() {
         let formatted = logFormatted(#"2022-12-07 16:26:40 --- WARNING: Key "duplicate" used with multiple values. Value "First" kept. Value "Second" ignored."#)
-        #expect(formatted == #"###vso[task.logissue type=warning]Key "duplicate" used with multiple values. Value "First" kept. Value "Second" ignored."#)
+        XCTAssertEqual(formatted, #"##vso[task.logissue type=warning]Key "duplicate" used with multiple values. Value "First" kept. Value "Second" ignored."#)
     }
 
-    @Test
-    func testingStarted() {
+    func testTestingStarted() {
         let formatted = logFormatted(#"Testing started"#)
-        #expect(formatted == #"Testing started"#)
+        XCTAssertEqual(formatted, #"Testing started"#)
     }
 
-    @Test
-    func swiftTestingRunCompletion() {
+    func testSwiftTestingRunCompletion() {
         let input = #"􁁛 Test run with 5 tests passed after 12.345 seconds."#
         let formatted = logFormatted(input)
         let expectedOutput = "Test run with 5 tests passed after 12.345 seconds"
-        #expect(formatted == expectedOutput)
+        XCTAssertEqual(formatted, expectedOutput)
     }
 
-    @Test
-    func swiftTestingRunFailed() {
+    func testSwiftTestingRunFailed() {
         let input = #"􀢄 Test run with 10 tests failed after 15.678 seconds with 3 issues."#
         let formatted = logFormatted(input)
-        let expectedOutput = "###vso[task.logissue type=error]Test run with 10 tests failed after 15.678 seconds with 3 issue(s)"
-        #expect(formatted == expectedOutput)
+        let expectedOutput = "##vso[task.logissue type=error]Test run with 10 tests failed after 15.678 seconds with 3 issue(s)"
+        XCTAssertEqual(formatted, expectedOutput)
     }
 
-    @Test
-    func swiftTestingSuiteFailed() {
+    func testSwiftTestingSuiteFailed() {
         let input = #"􀢄 Suite "MyTestSuite" failed after 8.456 seconds with 2 issues."#
         let formatted = logFormatted(input)
-        let expectedOutput = "###vso[task.logissue type=error]Suite \"MyTestSuite\" failed after 8.456 seconds with 2 issue(s)"
-        #expect(formatted == expectedOutput)
+        let expectedOutput = "##vso[task.logissue type=error]Suite \"MyTestSuite\" failed after 8.456 seconds with 2 issue(s)"
+        XCTAssertEqual(formatted, expectedOutput)
     }
 
-    @Test
-    func swiftTestingTestFailed() {
+    func testSwiftTestingTestFailed() {
         let input = #"􀢄 Test "myTest" failed after 1.234 seconds with 1 issue."#
         let formatted = logFormatted(input)
-        let expectedOutput = "###vso[task.logissue type=error]\"myTest\" (1.234 seconds) 1 issue(s)"
-        #expect(formatted == expectedOutput)
+        let expectedOutput = "##vso[task.logissue type=error]\"myTest\" (1.234 seconds) 1 issue(s)"
+        XCTAssertEqual(formatted, expectedOutput)
     }
 
-    @Test
-    func swiftTestingTestSkipped() {
+    func testSwiftTestingTestSkipped() {
         let input = #"􀙟 Test myTest() skipped."#
         let formatted = logFormatted(input)
         let expectedOutput = "    ⊘ myTest() skipped"
-        #expect(formatted == expectedOutput)
+        XCTAssertEqual(formatted, expectedOutput)
     }
 
-    @Test
-    func swiftTestingTestSkippedReason() {
+    func testSwiftTestingTestSkippedReason() {
         let input = #"􀙟 Test myTest() skipped: "Reason for skipping""#
         let formatted = logFormatted(input)
         let expectedOutput = "    ⊘ myTest() skipped (Reason for skipping)"
-        #expect(formatted == expectedOutput)
+        XCTAssertEqual(formatted, expectedOutput)
     }
 
-    @Test
-    func swiftTestingIssue() {
+    func testSwiftTestingIssue() {
         let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
         let formatted = logFormatted(input)
-        let expectedOutput = "###vso[task.logissue type=error]Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
-        #expect(formatted == expectedOutput)
+        let expectedOutput = "##vso[task.logissue type=error]Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
+        XCTAssertEqual(formatted, expectedOutput)
     }
 
-    @Test
-    func swiftTestingIssueArguments() {
+    func testSwiftTestingIssueArguments() {
         let input = #"􀢄 Test "myTest" recorded an issue with 2 arguments."#
         let formatted = logFormatted(input)
-        let expectedOutput = "###vso[task.logissue type=error]Recorded an issue (2) argument(s)"
-        #expect(formatted == expectedOutput)
+        let expectedOutput = "##vso[task.logissue type=error]Recorded an issue (2) argument(s)"
+        XCTAssertEqual(formatted, expectedOutput)
     }
 
-    @Test
-    func swiftTestingIssueDetails() {
+    func testSwiftTestingIssueDetails() {
         let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
         let formatted = logFormatted(input)
-        let expectedOutput = "###vso[task.logissue type=error]Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
-        #expect(formatted == expectedOutput)
+        let expectedOutput = "##vso[task.logissue type=error]Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
+        XCTAssertEqual(formatted, expectedOutput)
     }
 }

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -216,7 +216,16 @@ final class GitHubActionsRendererTests: XCTestCase {
     }
     #endif
 
-    func testFailingTest() { }
+    func testFailingTest() {
+        #if os(Linux)
+        let input = "/path/to/Tests.swift:123: error: Suite.testCase : XCTAssertEqual failed: (\"1\") is not equal to (\"2\") -"
+        let output = "::error file=/path/to/Tests.swift,line=123::    testCase, XCTAssertEqual failed: (\"1\") is not equal to (\"2\") -"
+        #else
+        let input = "/path/to/Tests.swift:123: error: -[Tests.Suite testCase] : XCTAssertEqual failed: (\"1\") is not equal to (\"2\")"
+        let output = "::error file=/path/to/Tests.swift,line=123::    testCase, XCTAssertEqual failed: (\"1\") is not equal to (\"2\")"
+        #endif
+        XCTAssertEqual(logFormatted(input), output)
+    }
 
     func testFatalError() {
         let input = "fatal error: malformed or corrupted AST file: 'could not find file '/path/file.h' referenced by AST file' note: after modifying system headers, please delete the module cache at '/path/DerivedData/ModuleCache/M5WJ0FYE7N06'"


### PR DESCRIPTION
### Description

This PR adds a renderer to annotate build logs for Azure DevOps pipelines. The new `AzureDevOpsPipelinesRenderer` shares most formatting logic with `GitHubActionsRenderer`.

E.g.
```Shell
xcodebuild [Flags] 2>&1 | xcbeautify --renderer azure-devops-pipelines
```
Or
```Shell
swift test 2>&1 | xcbeautify --renderer azure-devops-pipelines
```

## References

Azure DevOps - [Task Commands](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#task-commands)