### PR TITLE
Fix GitHubActionsRenderer Annotation Values

### DIFF
--- a/Sources/XcbeautifyLib/Renderers/GitHubActionsRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/GitHubActionsRenderer.swift
@@ -264,7 +264,7 @@ struct GitHubActionsRenderer: OutputRendering {
     func formatSwiftTestingIssue(group: SwiftTestingIssueCaptureGroup) -> String {
         let message = "Recorded an issue" + (group.issueDetails.map { " (\($0))" } ?? "")
         return outputGitHubActionsLog(
-            annotationType: .notice,
+            annotationType: .error,
             message: message
         )
     }
@@ -272,7 +272,7 @@ struct GitHubActionsRenderer: OutputRendering {
     func formatSwiftTestingIssueArguments(group: SwiftTestingIssueArgumentCaptureGroup) -> String {
         let message = "Recorded an issue" + (group.numberOfArguments.map { " (\($0)) argument(s)" } ?? "")
         return outputGitHubActionsLog(
-            annotationType: .notice,
+            annotationType: .error,
             message: message
         )
     }

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -653,21 +653,21 @@ final class GitHubActionsRendererTests: XCTestCase {
     func testSwiftTestingIssue() {
         let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
         let formatted = logFormatted(input)
-        let expectedOutput = "::notice ::Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
+        let expectedOutput = "::error ::Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
         XCTAssertEqual(formatted, expectedOutput)
     }
 
     func testSwiftTestingIssueArguments() {
         let input = #"􀢄 Test "myTest" recorded an issue with 2 arguments."#
         let formatted = logFormatted(input)
-        let expectedOutput = "::notice ::Recorded an issue (2) argument(s)"
+        let expectedOutput = "::error ::Recorded an issue (2) argument(s)"
         XCTAssertEqual(formatted, expectedOutput)
     }
 
     func testSwiftTestingIssueDetails() {
         let input = #"􀢄  Test "myTest" recorded an issue at PlanTests.swift:43:5: Expectation failed"#
         let formatted = logFormatted(input)
-        let expectedOutput = "::notice ::Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
+        let expectedOutput = "::error ::Recorded an issue (PlanTests.swift:43:5: Expectation failed)"
         XCTAssertEqual(formatted, expectedOutput)
     }
 }


### PR DESCRIPTION
## Description

This PR updates the annotation type for Swift Testing issue recording (`.notice` -> `.error`), aligning with both Xcode and `swift test` output.

## References

See discussion in https://github.com/cpisciotta/xcbeautify/pull/338#discussion_r1875324998