### PR TITLE
Update Swift Installation Steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,37 +17,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: macos-14
-            version:
-              swift_version: "5.9"
-              xcode_version: "15.2"
-          - platform: macos-14
-            version:
-              swift_version: "5.10"
-              xcode_version: "15.4"
-          - platform: macos-15
-            version:
-              swift_version: "6.0"
-              xcode_version: "16.0"
-          # Add Swift 6.0 to ubuntu-latest when its available via swift-actions/setup-swift
-          - platform: ubuntu-latest
-            version:
-              swift_version: "5.9"
-              xcode_version: "15.2"
-          - platform: ubuntu-latest
-            version:
-              swift_version: "5.10"
-              xcode_version: "15.4"
+        platform: [macos-14, ubuntu-22.04]
+        version:
+          - swift_version: "5.9"
+            xcode_version: "15.2"
+          - swift_version: "5.10"
+            xcode_version: "15.4"
+          - swift_version: "6.0"
+            xcode_version: "16.0"
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.version.xcode_version }}.app/Contents/Developer
     steps:
       - uses: actions/checkout@v4
-      - name: Install Swift and Tools
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
-        uses: swift-actions/setup-swift@3aed395c5397f62deb91d8fe7af1418a9ae4d16f
-        with:
-          swift-version: ${{ matrix.version.swift_version }}
+
+      - name: Download Swift ${{ matrix.version.swift_version }}
+        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        run: wget https://download.swift.org/swift-${{ matrix.version.swift_version }}-release/ubuntu2204/swift-${{ matrix.version.swift_version }}-RELEASE/swift-${{ matrix.version.swift_version }}-RELEASE-ubuntu22.04.tar.gz
+
+      - name: Extract Swift ${{ matrix.version.swift_version }}
+        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        run: tar xzf swift-${{ matrix.version.swift_version }}-RELEASE-ubuntu22.04.tar.gz
+
+      - name: Add Swift toolchain to PATH
+        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        run: echo "$GITHUB_WORKSPACE/swift-${{ matrix.version.swift_version }}-RELEASE-ubuntu22.04/usr/bin" >> $GITHUB_PATH
+
       - run: swift --version
       - run: swift build --disable-sandbox --configuration release -Xswiftc -warnings-as-errors
 
@@ -57,39 +51,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: macos-14
-            version:
-              swift_version: "5.9"
-              xcode_version: "15.2"
-          - platform: macos-14
-            version:
-              swift_version: "5.10"
-              xcode_version: "15.4"
-          - platform: macos-15
-            version:
-              swift_version: "6.0"
-              xcode_version: "16.0"
-          # Add Swift 6.0 to ubuntu-latest when its available via swift-actions/setup-swift
-          - platform: ubuntu-latest
-            version:
-              swift_version: "5.9"
-              xcode_version: "15.2"
-          - platform: ubuntu-latest
-            version:
-              swift_version: "5.10"
-              xcode_version: "15.4"
+        platform: [macos-14, ubuntu-22.04]
+        version:
+          - swift_version: "5.9"
+            xcode_version: "15.2"
+          - swift_version: "5.10"
+            xcode_version: "15.4"
+          - swift_version: "6.0"
+            xcode_version: "16.0"
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.version.xcode_version }}.app/Contents/Developer
     steps:
       - uses: actions/checkout@v4
       - name: Load Swift Version
         run: echo "SWIFT_VERSION=$(<.swift-version)" >> $GITHUB_ENV
-      - name: Install Swift and Tools
-        if: ${{ matrix.platform == 'ubuntu-latest' }}
-        uses: swift-actions/setup-swift@3aed395c5397f62deb91d8fe7af1418a9ae4d16f
-        with:
-          swift-version: ${{ matrix.version.swift_version }}
+
+      - name: Download Swift ${{ matrix.version.swift_version }}
+        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        run: wget https://download.swift.org/swift-${{ matrix.version.swift_version }}-release/ubuntu2204/swift-${{ matrix.version.swift_version }}-RELEASE/swift-${{ matrix.version.swift_version }}-RELEASE-ubuntu22.04.tar.gz
+      - name: Extract Swift ${{ matrix.version.swift_version }}
+        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        run: tar xzf swift-${{ matrix.version.swift_version }}-RELEASE-ubuntu22.04.tar.gz
+      - name: Add Swift toolchain to PATH
+        if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        run: echo "$GITHUB_WORKSPACE/swift-${{ matrix.version.swift_version }}-RELEASE-ubuntu22.04/usr/bin" >> $GITHUB_PATH
+
       - run: swift --version
       - run: swift test --enable-code-coverage
       - name: Prepare Code Coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
 name: Release
 
 env:
+  # TODO: Load from `.swift-version` file
   SWIFT_VERSION: 5.9
 
 jobs:
@@ -68,14 +69,17 @@ jobs:
 
   ubuntu_x86_64:
     name: Release Linux x86_64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: create_release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: ${{ env.SWIFT_VERSION }}
+      - name: Download Swift ${{ env.SWIFT_VERSION }}
+        run: wget https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/ubuntu2204/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04.tar.gz
+      - name: Extract Swift ${{ env.SWIFT_VERSION }}
+        run: tar xzf swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04.tar.gz
+      - name: Add Swift toolchain to PATH
+        run: echo "$GITHUB_WORKSPACE/swift-${{ env.SWIFT_VERSION }}-RELEASE-ubuntu22.04/usr/bin" >> $GITHUB_PATH
       - name: Package Linux x86_64
         run: make package-linux-x86_64
       - name: Upload Release Asset for Linux x86_64


### PR DESCRIPTION
- Drop `swift-actions/setup-swift` dependency
- Specify macOS and Ubuntu runners
- Add Ubuntu Swift 6.0 jobs