### PR TITLE
Test for Unique Capture Group Parsing

### DIFF
--- a/Tests/XcbeautifyLibTests/UniqueCaptureGroupTests.swift
+++ b/Tests/XcbeautifyLibTests/UniqueCaptureGroupTests.swift
@@ -31,4 +31,112 @@ final class UniqueCaptureGroupTests: XCTestCase {
         )
     }
     #endif
+
+    // TODO: Drop this macOS platform gating
+    #if os(macOS)
+    func testUniqueCaptureGroups() throws {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: "clean_build_xcode_15_1", withExtension: "txt"))
+
+        var buildLog: [String] = try String(contentsOf: url)
+            .components(separatedBy: .newlines)
+
+        while !buildLog.isEmpty {
+            let line = buildLog.removeFirst()
+
+            let capturedTypes = captureGroupTypes.filter { type in
+                guard let groups = type.regex.captureGroups(for: line) else { return false }
+                XCTAssertNotNil(type.init(groups: groups))
+                return true
+            }
+
+            XCTAssertLessThanOrEqual(
+                capturedTypes.count,
+                1,
+                """
+                Failed to uniquely parse xcodebuild output.
+                Line: \(line)
+                Captured Types: \(ListFormatter.localizedString(byJoining: capturedTypes.map(String.init(describing:))))
+                """
+            )
+        }
+    }
+
+    func testUniqueTestCaptureGroups() throws {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: "TestLog", withExtension: "txt"))
+        var buildLog: [String] = try String(contentsOf: url)
+            .components(separatedBy: .newlines)
+
+        while !buildLog.isEmpty {
+            let line = buildLog.removeFirst()
+
+            let capturedTypes = captureGroupTypes.filter { type in
+                guard let groups = type.regex.captureGroups(for: line) else { return false }
+                XCTAssertNotNil(type.init(groups: groups))
+                return true
+            }
+
+            XCTAssertLessThanOrEqual(
+                capturedTypes.count,
+                1,
+                """
+                Failed to uniquely parse xcodebuild output.
+                Line: \(line)
+                Captured Types: \(ListFormatter.localizedString(byJoining: capturedTypes.map(String.init(describing:))))
+                """
+            )
+        }
+    }
+
+    func testUniqueSwiftTestingCaptureGroups() throws {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: "swift_test_log", withExtension: "txt"))
+        var buildLog: [String] = try String(contentsOf: url)
+            .components(separatedBy: .newlines)
+
+        while !buildLog.isEmpty {
+            let line = buildLog.removeFirst()
+
+            let capturedTypes = captureGroupTypes.filter { type in
+                guard let groups = type.regex.captureGroups(for: line) else { return false }
+                XCTAssertNotNil(type.init(groups: groups))
+                return true
+            }
+
+            XCTAssertLessThanOrEqual(
+                capturedTypes.count,
+                1,
+                """
+                Failed to uniquely parse xcodebuild output.
+                Line: \(line)
+                Captured Types: \(ListFormatter.localizedString(byJoining: capturedTypes.map(String.init(describing:))))
+                """
+            )
+        }
+    }
+
+    func testUniqueParallelTestCaptureGroups() throws {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: "ParallelTestLog", withExtension: "txt"))
+        var buildLog: [String] = try String(contentsOf: url)
+            .components(separatedBy: .newlines)
+
+        while !buildLog.isEmpty {
+            let line = buildLog.removeFirst()
+
+            let capturedTypes = captureGroupTypes.filter { type in
+                guard let groups = type.regex.captureGroups(for: line) else { return false }
+                XCTAssertNotNil(type.init(groups: groups))
+                return true
+            }
+
+            XCTAssertLessThanOrEqual(
+                capturedTypes.count,
+                1,
+                """
+                Failed to uniquely parse xcodebuild output.
+                Line: \(line)
+                Captured Types: \(ListFormatter.localizedString(byJoining: capturedTypes.map(String.init(describing:))))
+                """
+            )
+        }
+    }
+    #endif
 }


### PR DESCRIPTION
## Changes

Add a unit test that checks if each line of xcodebuild output is captured by at most 1 type.