### PR TITLE
Refactor JUnitReporter

### DIFF
--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -22,28 +22,28 @@ package final class JunitReporter {
     package func add(captureGroup: any CaptureGroup) {
         switch captureGroup {
         case let group as FailingTestCaptureGroup:
-            guard let testCase = generateFailingTest(group: group) else { return }
+            let testCase = generateFailingTest(group: group)
             components.append(.failingTest(testCase))
         case let group as RestartingTestCaptureGroup:
-            guard let testCase = generateRestartingTest(group: group) else { return }
+            let testCase = generateRestartingTest(group: group)
             components.append(.failingTest(testCase))
         case let group as TestCasePassedCaptureGroup:
-            guard let testCase = generatePassingTest(group: group) else { return }
+            let testCase = generatePassingTest(group: group)
             components.append(.testCasePassed(testCase))
         case let group as TestCaseSkippedCaptureGroup:
-            guard let testCase = generateSkippedTest(group: group) else { return }
+            let testCase = generateSkippedTest(group: group)
             components.append(.skippedTest(testCase))
         case let group as TestSuiteStartedCaptureGroup:
-            guard let testStart = generateSuiteStart(group: group) else { return }
+            let testStart = generateSuiteStart(group: group)
             components.append(.testSuiteStart(testStart))
         case let group as ParallelTestCaseFailedCaptureGroup:
-            guard let testCase = generateParallelFailingTest(group: group) else { return }
+            let testCase = generateParallelFailingTest(group: group)
             parallelComponents.append(.failingTest(testCase))
         case let group as ParallelTestCasePassedCaptureGroup:
-            guard let testCase = generatePassingParallelTest(group: group) else { return }
+            let testCase = generatePassingParallelTest(group: group)
             parallelComponents.append(.testCasePassed(testCase))
         case let group as ParallelTestCaseSkippedCaptureGroup:
-            guard let testCase = generateSkippedParallelTest(group: group) else { return }
+            let testCase = generateSkippedParallelTest(group: group)
             parallelComponents.append(.testCasePassed(testCase))
         default:
             // Not needed for generating a junit report
@@ -51,36 +51,36 @@ package final class JunitReporter {
         }
     }
 
-    private func generateFailingTest(group: FailingTestCaptureGroup) -> TestCase? {
+    private func generateFailingTest(group: FailingTestCaptureGroup) -> TestCase {
         TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: "\(group.file) - \(group.reason)"))
     }
 
-    private func generateRestartingTest(group: RestartingTestCaptureGroup) -> TestCase? {
+    private func generateRestartingTest(group: RestartingTestCaptureGroup) -> TestCase {
         TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: group.wholeMessage))
     }
 
-    private func generateParallelFailingTest(group: ParallelTestCaseFailedCaptureGroup) -> TestCase? {
+    private func generateParallelFailingTest(group: ParallelTestCaseFailedCaptureGroup) -> TestCase {
         // Parallel tests do not provide meaningful failure messages
         TestCase(classname: group.suite, name: group.testCase, time: nil, failure: .init(message: "Parallel test failed"))
     }
 
-    private func generatePassingTest(group: TestCasePassedCaptureGroup) -> TestCase? {
+    private func generatePassingTest(group: TestCasePassedCaptureGroup) -> TestCase {
         TestCase(classname: group.suite, name: group.testCase, time: group.time)
     }
 
-    private func generateSkippedTest(group: TestCaseSkippedCaptureGroup) -> TestCase? {
+    private func generateSkippedTest(group: TestCaseSkippedCaptureGroup) -> TestCase {
         TestCase(classname: group.suite, name: group.testCase, time: group.time, skipped: .init(message: nil))
     }
 
-    private func generatePassingParallelTest(group: ParallelTestCasePassedCaptureGroup) -> TestCase? {
+    private func generatePassingParallelTest(group: ParallelTestCasePassedCaptureGroup) -> TestCase {
         TestCase(classname: group.suite, name: group.testCase, time: group.time)
     }
 
-    private func generateSkippedParallelTest(group: ParallelTestCaseSkippedCaptureGroup) -> TestCase? {
+    private func generateSkippedParallelTest(group: ParallelTestCaseSkippedCaptureGroup) -> TestCase {
         TestCase(classname: group.suite, name: group.testCase, time: group.time, skipped: .init(message: nil))
     }
 
-    private func generateSuiteStart(group: TestSuiteStartedCaptureGroup) -> String? {
+    private func generateSuiteStart(group: TestSuiteStartedCaptureGroup) -> String {
         group.suiteName
     }
 

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -22,66 +22,34 @@ package final class JunitReporter {
     package func add(captureGroup: any CaptureGroup) {
         switch captureGroup {
         case let group as FailingTestCaptureGroup:
-            let testCase = generateFailingTest(group: group)
+            let testCase = TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: "\(group.file) - \(group.reason)"))
             components.append(.failingTest(testCase))
         case let group as RestartingTestCaptureGroup:
-            let testCase = generateRestartingTest(group: group)
+            let testCase = TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: group.wholeMessage))
             components.append(.failingTest(testCase))
         case let group as TestCasePassedCaptureGroup:
-            let testCase = generatePassingTest(group: group)
+            let testCase = TestCase(classname: group.suite, name: group.testCase, time: group.time)
             components.append(.testCasePassed(testCase))
         case let group as TestCaseSkippedCaptureGroup:
-            let testCase = generateSkippedTest(group: group)
+            let testCase = TestCase(classname: group.suite, name: group.testCase, time: group.time, skipped: .init(message: nil))
             components.append(.skippedTest(testCase))
         case let group as TestSuiteStartedCaptureGroup:
-            let testStart = generateSuiteStart(group: group)
+            let testStart = group.suiteName
             components.append(.testSuiteStart(testStart))
         case let group as ParallelTestCaseFailedCaptureGroup:
-            let testCase = generateParallelFailingTest(group: group)
+            // Parallel tests do not provide meaningful failure messages
+            let testCase = TestCase(classname: group.suite, name: group.testCase, time: nil, failure: .init(message: "Parallel test failed"))
             parallelComponents.append(.failingTest(testCase))
         case let group as ParallelTestCasePassedCaptureGroup:
-            let testCase = generatePassingParallelTest(group: group)
+            let testCase = TestCase(classname: group.suite, name: group.testCase, time: group.time)
             parallelComponents.append(.testCasePassed(testCase))
         case let group as ParallelTestCaseSkippedCaptureGroup:
-            let testCase = generateSkippedParallelTest(group: group)
+            let testCase = TestCase(classname: group.suite, name: group.testCase, time: group.time, skipped: .init(message: nil))
             parallelComponents.append(.testCasePassed(testCase))
         default:
             // Not needed for generating a junit report
             return
         }
-    }
-
-    private func generateFailingTest(group: FailingTestCaptureGroup) -> TestCase {
-        TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: "\(group.file) - \(group.reason)"))
-    }
-
-    private func generateRestartingTest(group: RestartingTestCaptureGroup) -> TestCase {
-        TestCase(classname: group.testSuite, name: group.testCase, time: nil, failure: .init(message: group.wholeMessage))
-    }
-
-    private func generateParallelFailingTest(group: ParallelTestCaseFailedCaptureGroup) -> TestCase {
-        // Parallel tests do not provide meaningful failure messages
-        TestCase(classname: group.suite, name: group.testCase, time: nil, failure: .init(message: "Parallel test failed"))
-    }
-
-    private func generatePassingTest(group: TestCasePassedCaptureGroup) -> TestCase {
-        TestCase(classname: group.suite, name: group.testCase, time: group.time)
-    }
-
-    private func generateSkippedTest(group: TestCaseSkippedCaptureGroup) -> TestCase {
-        TestCase(classname: group.suite, name: group.testCase, time: group.time, skipped: .init(message: nil))
-    }
-
-    private func generatePassingParallelTest(group: ParallelTestCasePassedCaptureGroup) -> TestCase {
-        TestCase(classname: group.suite, name: group.testCase, time: group.time)
-    }
-
-    private func generateSkippedParallelTest(group: ParallelTestCaseSkippedCaptureGroup) -> TestCase {
-        TestCase(classname: group.suite, name: group.testCase, time: group.time, skipped: .init(message: nil))
-    }
-
-    private func generateSuiteStart(group: TestSuiteStartedCaptureGroup) -> String {
-        group.suiteName
     }
 
     package func generateReport() throws -> Data {

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -83,16 +83,6 @@ struct Xcbeautify: ParsableCommand {
         let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCI) { print($0) }
         let junitReporter = JunitReporter()
 
-        func readLine() -> String? {
-            let line = Swift.readLine()
-            if let line {
-                if report.contains(.junit) {
-                    junitReporter.add(line: line)
-                }
-            }
-            return line
-        }
-
         let parser = Parser()
 
         let formatter = XcbeautifyLib.Formatter(
@@ -114,6 +104,11 @@ struct Xcbeautify: ParsableCommand {
 
                 continue
             }
+
+            if report.contains(.junit) {
+                junitReporter.add(captureGroup: captureGroup)
+            }
+
             guard let formatted = formatter.format(captureGroup: captureGroup) else { continue }
             output.write(captureGroup.outputType, formatted)
         }

--- a/Tests/XcbeautifyLibTests/JunitReporterTests.swift
+++ b/Tests/XcbeautifyLibTests/JunitReporterTests.swift
@@ -215,10 +215,13 @@ class JunitReporterTests: XCTestCase {
 
     func testJunitReport() throws {
         let url = try XCTUnwrap(Bundle.module.url(forResource: "TestLog", withExtension: "txt"))
+        let parser = Parser()
         let reporter = JunitReporter()
 
-        for component in try String(contentsOf: url).components(separatedBy: .newlines) {
-            reporter.add(line: component)
+        for line in try String(contentsOf: url).components(separatedBy: .newlines) {
+            if let captureGroup = parser.parse(line: line) {
+                reporter.add(captureGroup: captureGroup)
+            }
         }
         let data = try reporter.generateReport()
         let xml = String(data: data, encoding: .utf8)!
@@ -276,9 +279,13 @@ class JunitReporterTests: XCTestCase {
 
     func testParallelJunitReport() throws {
         let url = try XCTUnwrap(Bundle.module.url(forResource: "ParallelTestLog", withExtension: "txt"))
+        let parser = Parser()
         let reporter = JunitReporter()
-        for component in try String(contentsOf: url).components(separatedBy: .newlines) {
-            reporter.add(line: component)
+
+        for line in try String(contentsOf: url).components(separatedBy: .newlines) {
+            if let captureGroup = parser.parse(line: line) {
+                reporter.add(captureGroup: captureGroup)
+            }
         }
         let data = try reporter.generateReport()
         let xml = String(data: data, encoding: .utf8)!


### PR DESCRIPTION
## Changes

- Pass parsed `CaptureGroup` instead of raw xcodebuild output. This avoids duplicate parsing and better leverages type safety.
- Consolidate `JUnitComponent` parsing, avoiding the need for duplicate instantiation and optionals.
- Fix typos.

## Testing

Validated that sample XCTest input parsed as a JUnit report using the debug executable.