### PR TITLE
Delete LinkerDuplicateSymbolsLocationCaptureGroup

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -1691,22 +1691,6 @@ struct LDErrorCaptureGroup: ErrorCaptureGroup {
     }
 }
 
-struct LinkerDuplicateSymbolsLocationCaptureGroup: CaptureGroup {
-    static let outputType: OutputType = .error
-
-    /// Regular expression captured groups:
-    /// $1 = file path
-    static let regex = XCRegex(pattern: #"^\s+(\/.*\.o[\)]?)$"#)
-
-    let wholeError: String
-
-    init?(groups: [String]) {
-        assert(groups.count >= 1)
-        guard let wholeError = groups[safe: 0] else { return nil }
-        self.wholeError = wholeError
-    }
-}
-
 struct LinkerDuplicateSymbolsCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .error
 

--- a/Sources/XcbeautifyLib/Formatter.swift
+++ b/Sources/XcbeautifyLib/Formatter.swift
@@ -118,8 +118,6 @@ package struct Formatter {
             return renderer.formatLibtool(group: group)
         case let group as LinkerDuplicateSymbolsCaptureGroup:
             return renderer.formatLinkerDuplicateSymbolsError(group: group)
-        case let group as LinkerDuplicateSymbolsLocationCaptureGroup:
-            return renderer.formatLinkerDuplicateSymbolsLocation(group: group)
         case let group as LinkerUndefinedSymbolLocationCaptureGroup:
             return renderer.formatLinkerUndefinedSymbolLocation(group: group)
         case let group as LinkerUndefinedSymbolsCaptureGroup:

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -77,7 +77,6 @@ package final class Parser {
         CursorCaptureGroup.self,
         FatalErrorCaptureGroup.self,
         LDErrorCaptureGroup.self,
-        LinkerDuplicateSymbolsLocationCaptureGroup.self,
         LinkerDuplicateSymbolsCaptureGroup.self,
         LinkerUndefinedSymbolLocationCaptureGroup.self,
         LinkerUndefinedSymbolsCaptureGroup.self,

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -40,7 +40,6 @@ protocol OutputRendering {
     func formatLdWarning(group: LDWarningCaptureGroup) -> String
     func formatLibtool(group: LibtoolCaptureGroup) -> String
     func formatLinkerDuplicateSymbolsError(group: LinkerDuplicateSymbolsCaptureGroup) -> String
-    func formatLinkerDuplicateSymbolsLocation(group: LinkerDuplicateSymbolsLocationCaptureGroup) -> String?
     func formatLinkerUndefinedSymbolLocation(group: LinkerUndefinedSymbolLocationCaptureGroup) -> String?
     func formatLinkerUndefinedSymbolsError(group: LinkerUndefinedSymbolsCaptureGroup) -> String
     func formatLinking(group: LinkingCaptureGroup) -> String
@@ -228,10 +227,6 @@ extension OutputRendering {
         let filename = group.filename
         let target = group.target
         return colored ? "[\(target.f.Cyan)] \("Building library".s.Bold) \(filename)" : "[\(target)] Building library \(filename)"
-    }
-
-    func formatLinkerDuplicateSymbolsLocation(group: LinkerDuplicateSymbolsLocationCaptureGroup) -> String? {
-        nil
     }
 
     func formatLinkerUndefinedSymbolLocation(group: LinkerUndefinedSymbolLocationCaptureGroup) -> String? {


### PR DESCRIPTION
As a prerequisite to #365, delete this overly-generic definition that conflicts with `ShellCommandCaptureGroup`. Given there aren't tests against this regular expression, it's unclear what output it actually expects and how it differs from `LinkerDuplicateSymbolsCaptureGroup`. Given this definition is formatted as `nil` output, we can safely delete this type; deleting this type won't impact user-facing logs, so the only known trade-off is a potential time regression.