### PR TITLE
impr: use enum definitions to explain options in usage

### DIFF
--- a/Sources/XcbeautifyLib/Constants.swift
+++ b/Sources/XcbeautifyLib/Constants.swift
@@ -56,7 +56,6 @@ UsageOptionsDescribable where Self: CaseIterable & RawRepresentable<String> {
 
 /// Maps to an `OutputRendering` type that formats raw `xcodebuild` output.
 public enum Renderer: String, CaseIterable, UsageOptionsDescribable {
-    
     /// The default `OutputRendering` type for local and general use. Maps to `TerminalRenderer`.
     case terminal
 

--- a/Sources/XcbeautifyLib/Constants.swift
+++ b/Sources/XcbeautifyLib/Constants.swift
@@ -41,8 +41,20 @@ package enum OutputType {
     case issue
 }
 
+public protocol UsageOptionsDescribable {
+    static var optionsDescription: String { get }
+}
+
+public extension
+UsageOptionsDescribable where Self: CaseIterable, Self: RawRepresentable, Self.RawValue: StringProtocol {
+    static var optionsDescription: String {
+        allCases.map(\.rawValue).joined(separator: " | ")
+    }
+}
+
 /// Maps to an `OutputRendering` type that formats raw `xcodebuild` output.
-public enum Renderer: String {
+public enum Renderer: String, CaseIterable, UsageOptionsDescribable {
+    
     /// The default `OutputRendering` type for local and general use. Maps to `TerminalRenderer`.
     case terminal
 

--- a/Sources/XcbeautifyLib/Constants.swift
+++ b/Sources/XcbeautifyLib/Constants.swift
@@ -41,12 +41,14 @@ package enum OutputType {
     case issue
 }
 
-public protocol UsageOptionsDescribable {
+// TODO: ArgumentParser will eventually obviate this, once a release is made that includes ExpressibleByArgument.allValueDescriptions.
+/// A protocol to prepare a string description of all of an option's valid settings, based on the option's CaseIterable enum String rawValues.
+package protocol UsageOptionsDescribable {
     static var optionsDescription: String { get }
 }
 
-public extension
-UsageOptionsDescribable where Self: CaseIterable, Self: RawRepresentable, Self.RawValue: StringProtocol {
+package extension
+UsageOptionsDescribable where Self: CaseIterable & RawRepresentable<String> {
     static var optionsDescription: String {
         allCases.map(\.rawValue).joined(separator: " | ")
     }

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -35,7 +35,7 @@ struct Xcbeautify: ParsableCommand {
 
     // swiftformat:disable redundantReturn
 
-    @Option(help: "Specify a renderer to format raw xcodebuild output. (Options: \(Renderer.optionsDescription)). (Default: terminal).")
+    @Option(help: "Specify a renderer to format raw xcodebuild output. (Options: \(Renderer.optionsDescription)).")
     var renderer: Renderer = {
         if ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true" {
             return .gitHubActions
@@ -50,7 +50,7 @@ struct Xcbeautify: ParsableCommand {
 
     // swiftformat:enable redundantReturn
 
-    @Option(help: "Generate the specified reports. (Options: \(Report.optionsDescription) (Default: none).")
+    @Option(help: "Generate the specified reports. (Options: \(Report.optionsDescription).")
     var report: [Report] = []
 
     @Option(help: "The path to use when generating reports")

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -49,7 +49,7 @@ struct Xcbeautify: ParsableCommand {
 
     // swiftformat:enable redundantReturn
 
-    @Option(help: "Generate the specified reports. (Options: \(Report.optionsDescription).")
+    @Option(help: "Generate the specified reports. (Options: \(Report.optionsDescription)).")
     var report: [Report] = []
 
     @Option(help: "The path to use when generating reports")

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -9,8 +9,9 @@ struct Xcbeautify: ParsableCommand {
         discussion: "EXAMPLE: xcodebuild test ... | xcbeautify",
         version: version
     )
-
-    enum Report: String, ExpressibleByArgument {
+    
+    enum Report: String, ExpressibleByArgument, CaseIterable, UsageOptionsDescribable {
+        
         case junit
     }
 
@@ -34,7 +35,7 @@ struct Xcbeautify: ParsableCommand {
 
     // swiftformat:disable redundantReturn
 
-    @Option(help: "Specify a renderer to format raw xcodebuild output ( options: terminal | github-actions | teamcity | azure-devops-pipelines).")
+    @Option(help: "Specify a renderer to format raw xcodebuild output. (Options: \(Renderer.optionsDescription)). (Default: terminal).")
     var renderer: Renderer = {
         if ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true" {
             return .gitHubActions
@@ -49,7 +50,7 @@ struct Xcbeautify: ParsableCommand {
 
     // swiftformat:enable redundantReturn
 
-    @Option(help: "Generate the specified reports")
+    @Option(help: "Generate the specified reports. (Options: \(Report.optionsDescription) (Default: none).")
     var report: [Report] = []
 
     @Option(help: "The path to use when generating reports")

--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -9,9 +9,8 @@ struct Xcbeautify: ParsableCommand {
         discussion: "EXAMPLE: xcodebuild test ... | xcbeautify",
         version: version
     )
-    
+
     enum Report: String, ExpressibleByArgument, CaseIterable, UsageOptionsDescribable {
-        
         case junit
     }
 


### PR DESCRIPTION
Hi, first contribution here, thanks for making this tool available 👋🏻 

I hadn't noticed what the options were for `--report` by only reading the usage help (`xcbeautify -h`), and saw what it was when reading the source. I figured it'd be nice to add that to the usage.

Then, I figured it'd be more maintainable if we used the enums themselves to describe to the help strings what the possible options are.

Thanks!