### PR TITLE
Delete TestCasePendingCaptureGroup

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -865,25 +865,6 @@ struct TestCaseStartedCaptureGroup: CaptureGroup {
     }
 }
 
-struct TestCasePendingCaptureGroup: CaptureGroup {
-    static let outputType: OutputType = .testCase
-
-    /// Regular expression captured groups:
-    /// $1 = suite
-    /// $2 = test case
-    static let regex = XCRegex(pattern: #"^Test Case\s'-\[(.*?)\s(.*)PENDING\]'\spassed"#)
-
-    let suite: String
-    let testCase: String
-
-    init?(groups: [String]) {
-        assert(groups.count >= 2)
-        guard let suite = groups[safe: 0], let testCase = groups[safe: 1] else { return nil }
-        self.suite = suite
-        self.testCase = testCase
-    }
-}
-
 struct TestCaseMeasuredCaptureGroup: CaptureGroup {
     static let outputType: OutputType = .testCase
 

--- a/Sources/XcbeautifyLib/Formatter.swift
+++ b/Sources/XcbeautifyLib/Formatter.swift
@@ -194,8 +194,6 @@ package struct Formatter {
             return renderer.formatTestCasePassed(group: group)
         case let group as TestCaseSkippedCaptureGroup:
             return renderer.formatTestCaseSkipped(group: group)
-        case let group as TestCasePendingCaptureGroup:
-            return renderer.formatTestCasePending(group: group)
         case let group as TestCaseStartedCaptureGroup:
             return renderer.formatTestCasesStarted(group: group)
         case let group as TestsRunCompletionCaptureGroup:

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -40,7 +40,6 @@ package final class Parser {
         TestCasePassedCaptureGroup.self,
         TestCaseSkippedCaptureGroup.self,
         TestCaseStartedCaptureGroup.self,
-        TestCasePendingCaptureGroup.self,
         TestCaseMeasuredCaptureGroup.self,
         PhaseSuccessCaptureGroup.self,
         PhaseScriptExecutionCaptureGroup.self,

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -75,7 +75,6 @@ protocol OutputRendering {
     func formatTestCaseMeasured(group: TestCaseMeasuredCaptureGroup) -> String
     func formatTestCasePassed(group: TestCasePassedCaptureGroup) -> String
     func formatTestCaseSkipped(group: TestCaseSkippedCaptureGroup) -> String
-    func formatTestCasePending(group: TestCasePendingCaptureGroup) -> String
     func formatTestCasesStarted(group: TestCaseStartedCaptureGroup) -> String?
     func formatTestsRunCompletion(group: TestsRunCompletionCaptureGroup) -> String
     func formatTestSuiteAllTestsFailed(group: TestSuiteAllTestsFailedCaptureGroup) -> String
@@ -363,11 +362,6 @@ extension OutputRendering {
         let project = group.project
         let configuration = group.configuration
         return colored ? "\(command) target \(target) of project \(project) with configuration \(configuration)".s.Bold.f.Cyan : "\(command) target \(target) of project \(project) with configuration \(configuration)"
-    }
-
-    func formatTestCasePending(group: TestCasePendingCaptureGroup) -> String {
-        let testCase = group.testCase
-        return colored ? Format.indent + TestStatus.pending.foreground.Yellow + " " + testCase + " [PENDING]" : Format.indent + TestStatus.pending + " " + testCase + " [PENDING]"
     }
 
     func formatTestCasesStarted(group: TestCaseStartedCaptureGroup) -> String? {

--- a/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
@@ -487,8 +487,6 @@ final class AzureDevOpsPipelinesRendererTests: XCTestCase {
         #endif
     }
 
-    func testTestCasePending() { }
-
     func testTestCaseStarted() { }
 
     func testTestSuiteStarted() {

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -484,8 +484,6 @@ final class GitHubActionsRendererTests: XCTestCase {
         #endif
     }
 
-    func testTestCasePending() { }
-
     func testTestCaseStarted() { }
 
     func testTestSuiteStarted() {

--- a/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
@@ -505,8 +505,6 @@ final class TeamCityRendererTests: XCTestCase {
         #endif
     }
 
-    func testTestCasePending() { }
-
     func testTestCaseStarted() { }
 
     func testTestSuiteStarted() {

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -484,8 +484,6 @@ final class TerminalRendererTests: XCTestCase {
         #endif
     }
 
-    func testTestCasePending() { }
-
     func testTestCaseStarted() { }
 
     func testTestSuiteStarted() {


### PR DESCRIPTION
It's unclear what this regular expression captures. I'm deleting this instance, since there aren't any tests against it, there is no example output, and this causes conflicts with at least one other regular expression.