### PR TITLE
[junit] Mark test as failed when finding a fatal error when xctest is used directly

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -1751,7 +1751,7 @@ struct FatalErrorCaptureGroup: ErrorCaptureGroup {
     /// Regular expression captured groups:
     /// $1 = whole error.
     /// it varies a lot, not sure if it makes sense to catch everything separately
-    static let regex = XCRegex(pattern: #"^(fatal error:.*)$"#)
+    static let regex = XCRegex(pattern: #"^((?:.* )?[fF]atal error:.*)$"#)
 
     let wholeError: String
 

--- a/Sources/XcbeautifyLib/JunitReporter.swift
+++ b/Sources/XcbeautifyLib/JunitReporter.swift
@@ -55,6 +55,17 @@ package final class JunitReporter {
         case let group as ParallelTestCaseSkippedCaptureGroup:
             let testCase = TestCase(classname: group.suite, name: group.testCase, time: group.time, skipped: .init(message: nil))
             parallelComponents.append(.testCasePassed(testCase))
+        case let group as TestCaseStartedCaptureGroup:
+            components.append(.testCaseStart(suite: group.suite, testName: group.testCase))
+        case let group as FatalErrorCaptureGroup:
+            switch components.last {
+            case let .testCaseStart(suite, testName):
+                let testCase = TestCase(classname: suite, name: testName, time: nil, failure: .init(message: group.wholeError))
+                components.append(.failingTest(testCase))
+            default:
+                break
+            }
+
         default:
             // Not needed for generating a junit report
             return
@@ -95,6 +106,9 @@ private final class JunitComponentParser {
              let .testCasePassed(testCase),
              let .skippedTest(testCase):
             testCases.append(testCase)
+
+        case .testCaseStart:
+            break
         }
     }
 
@@ -120,6 +134,7 @@ private final class JunitComponentParser {
 
 private enum JunitComponent {
     case testSuiteStart(String)
+    case testCaseStart(suite: String, testName: String)
     case failingTest(TestCase)
     case testCasePassed(TestCase)
     case skippedTest(TestCase)

--- a/Tests/XcbeautifyLibTests/JunitReporterTests.swift
+++ b/Tests/XcbeautifyLibTests/JunitReporterTests.swift
@@ -286,6 +286,22 @@ class JunitReporterTests: XCTestCase {
     </testsuites>
     """
 
+    private let expectedXCTestCrashXml = """
+    <testsuites name="All tests" tests="7" failures="1">
+        <testsuite name="DateTests.CalendarDay__Tests" tests="7" failures="1">
+            <testcase classname="DateTests.CalendarDay__Tests" name="testCalendarDayRawValue" time="0.006" />
+            <testcase classname="DateTests.CalendarDay__Tests" name="testCreatingCalendarDay" time="0.000" />
+            <testcase classname="DateTests.CalendarDay__Tests" name="testDateConversion" time="0.000" />
+            <testcase classname="DateTests.CalendarDay__Tests" name="testDateWithTimeConversion" time="0.000" />
+            <testcase classname="DateTests.CalendarDay__Tests" name="testDaysSince" time="0.000" />
+            <testcase classname="DateTests.CalendarDay__Tests" name="testDaysSinceWithDaylightSavings" time="0.000" />
+            <testcase classname="DateTests.CalendarDay__Tests" name="testToday">
+                <failure message="DateTests/CalendarDayTests.swift:63: Fatal error: This test is not implemented yet." />
+            </testcase>
+        </testsuite>
+    </testsuites>
+    """
+
     func testParallelJunitReport() throws {
         let url = try XCTUnwrap(Bundle.module.url(forResource: "ParallelTestLog", withExtension: "txt"))
         let parser = Parser()
@@ -299,6 +315,22 @@ class JunitReporterTests: XCTestCase {
         let data = try reporter.generateReport()
         let xml = String(data: data, encoding: .utf8)!
         let expectedXml = expectedParallelXml
+        XCTAssertEqual(xml, expectedXml)
+    }
+
+    func testXCTestCrashJunitReport() throws {
+        let url = try XCTUnwrap(Bundle.module.url(forResource: "xctest_crash_log", withExtension: "txt"))
+        let parser = Parser()
+        let reporter = JunitReporter()
+
+        for line in try String(contentsOf: url).components(separatedBy: .newlines) {
+            if let captureGroup = parser.parse(line: line) {
+                reporter.add(captureGroup: captureGroup)
+            }
+        }
+        let data = try reporter.generateReport()
+        let xml = String(data: data, encoding: .utf8)!
+        let expectedXml = expectedXCTestCrashXml
         XCTAssertEqual(xml, expectedXml)
     }
 }

--- a/Tests/XcbeautifyLibTests/TestData/xctest_crash_log.txt
+++ b/Tests/XcbeautifyLibTests/TestData/xctest_crash_log.txt
@@ -1,0 +1,23 @@
+exec ${PAGER:-/usr/bin/less} "$0" || exit 1
+Executing tests from //Libs/Date:DateTests
+-----------------------------------------------------------------------------
+Existing simulator 'BAZEL_TEST_iPhone 11_18.4' (A75DA946-4A16-48A5-95F2-5E3AC12DF582) state is: booted
+Test Suite 'All tests' started at 2025-05-19 18:43:25.150.
+Test Suite 'DateTests.xctest' started at 2025-05-19 18:43:25.151.
+Test Suite 'CalendarDay__Tests' started at 2025-05-19 18:43:25.151.
+Test Case '-[DateTests.CalendarDay__Tests testCalendarDayRawValue]' started.
+Test Case '-[DateTests.CalendarDay__Tests testCalendarDayRawValue]' passed (0.006 seconds).
+Test Case '-[DateTests.CalendarDay__Tests testCreatingCalendarDay]' started.
+Test Case '-[DateTests.CalendarDay__Tests testCreatingCalendarDay]' passed (0.000 seconds).
+Test Case '-[DateTests.CalendarDay__Tests testDateConversion]' started.
+Test Case '-[DateTests.CalendarDay__Tests testDateConversion]' passed (0.000 seconds).
+Test Case '-[DateTests.CalendarDay__Tests testDateWithTimeConversion]' started.
+Test Case '-[DateTests.CalendarDay__Tests testDateWithTimeConversion]' passed (0.000 seconds).
+Test Case '-[DateTests.CalendarDay__Tests testDaysSince]' started.
+Test Case '-[DateTests.CalendarDay__Tests testDaysSince]' passed (0.000 seconds).
+Test Case '-[DateTests.CalendarDay__Tests testDaysSinceWithDaylightSavings]' started.
+Test Case '-[DateTests.CalendarDay__Tests testDaysSinceWithDaylightSavings]' passed (0.000 seconds).
+Test Case '-[DateTests.CalendarDay__Tests testToday]' started.
+DateTests/CalendarDayTests.swift:63: Fatal error: This test is not implemented yet.
+Child process terminated with signal 5: Trace/BPT trap
+error: tests exited with '133'


### PR DESCRIPTION
In the bazel world, it's common to run tests with the `xctest` binary directly instead of calling `xcodebuild` ([reference](https://github.com/bazelbuild/rules_apple/blob/281186e426f197b67cf3b225095478a5c23e8572/apple/testing/default_runner/ios_xctestrun_runner.template.sh#L527-L528)) for performance reasons.

However, `xctest` doesn't handle crashes very well: it abruptly stops the execution, without marking the test case as failed. Because of that, `xcbeautify` doesn't mark the test as failed in the JUnit XML (in fact it's not even added).

This PR handles that. 