### PR TITLE
Use NORMAL instead of INFO for TeamCity service messages

### DIFF
--- a/Sources/XcbeautifyLib/Renderers/TeamCityRenderer.swift
+++ b/Sources/XcbeautifyLib/Renderers/TeamCityRenderer.swift
@@ -19,9 +19,9 @@ struct TeamCityRenderer: OutputRendering {
         self.additionalLines = additionalLines
     }
 
-    private func outputTeamCityInfo(text: String, details: String) -> String {
+    private func outputTeamCityNormal(text: String, details: String) -> String {
         """
-        ##teamcity[message text='\(text)' errorDetails='\(details.teamCityEscaped())' status='INFO']
+        ##teamcity[message text='\(text)' errorDetails='\(details.teamCityEscaped())' status='NORMAL']
         \(text)
         """
     }
@@ -168,7 +168,7 @@ struct TeamCityRenderer: OutputRendering {
 
     func formatSwiftTestingRunCompletion(group: SwiftTestingRunCompletionCaptureGroup) -> String {
         let outputString = "Test run with \(group.numberOfTests) tests passed after \(group.totalTime) seconds"
-        return outputTeamCityInfo(text: "Test run succeeded", details: outputString)
+        return outputTeamCityNormal(text: "Test run succeeded", details: outputString)
     }
 
     func formatSwiftTestingRunFailed(group: SwiftTestingRunFailedCaptureGroup) -> String {

--- a/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
@@ -719,7 +719,7 @@ final class TeamCityRendererTests: XCTestCase {
 
     func testSwiftTestingRunCompletion() {
         let input = #"􁁛 Test run with 5 tests passed after 12.345 seconds."#
-        let output = "##teamcity[message text=\'Test run succeeded\' errorDetails=\'Test run with 5 tests passed after 12.345 seconds\' status=\'INFO\']\nTest run succeeded"
+        let output = "##teamcity[message text=\'Test run succeeded\' errorDetails=\'Test run with 5 tests passed after 12.345 seconds\' status=\'NORMAL\']\nTest run succeeded"
         XCTAssertEqual(noColoredFormatted(input), output)
     }
 


### PR DESCRIPTION
TeamCity does not support the `INFO` status in service messages. Example:

```
  ##teamcity[message text='Test run succeeded' errorDetails='Test run with 7 tests passed after 0.004 seconds' status='INFO']
18:37:29   Error processing service message: Failed to parse status attribute "INFO", supported statuses: [UNKNOWN, NORMAL, WARNING, FAILURE, ERROR]
```

Documentation: https://www.jetbrains.com/help/teamcity/service-messages.html#Reporting+Messages+to+Build+Log

I noticed other formatting errors where strings are not escaped correctly and/or included newlines. I don't have time to fix those ATM unfortunately. Example:

```
18:48:06   ##teamcity[buildProblem description='[Service]
18:48:10   Error while parsing TeamCity service message: Value should end with "'". Valid service message has a form of "##teamcity[messageName name1='escaped_value' name2='escaped_value']" where escaped_value uses substitutions: '->|', [->|[, ]->|], |->||, newline->|n
18:48:06    failed find template']
18:48:06   ❌ [Service] failed find template: Not Found: the item Missing default template: 4ECCCA78-3984-526E-8B2D-E2498B3611A9 cannot be found, documentID: 797985F0-7A9B-4D90-9683-7754240A3148, templateLibraryDocumentID: 4ECCCA78-3984-526E-8B2D-E2498B3611A9
```