### PR TITLE
Update CI Matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           - platform: ubuntu-22.04
             swift_version: "5.9"
             xcode_version: "15.2"
-          - platform: macos-15
+          - platform: macos-14
             swift_version: "5.10"
             xcode_version: "15.4"
           - platform: ubuntu-22.04
@@ -69,7 +69,7 @@ jobs:
           - platform: ubuntu-22.04
             swift_version: "5.9"
             xcode_version: "15.2"
-          - platform: macos-15
+          - platform: macos-14
             swift_version: "5.10"
             xcode_version: "15.4"
           - platform: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
           - platform: ubuntu-22.04
             swift_version: "6.0"
             xcode_version: "16.0"
+          - platform: macos-15
+            swift_version: "6.1"
+            xcode_version: "16.3"
+          - platform: ubuntu-22.04
+            swift_version: "6.1"
+            xcode_version: "16.3"
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer
     steps:
@@ -81,6 +87,12 @@ jobs:
           - platform: ubuntu-22.04
             swift_version: "6.0"
             xcode_version: "16.0"
+          - platform: macos-15
+            swift_version: "6.1"
+            xcode_version: "16.3"
+          - platform: ubuntu-22.04
+            swift_version: "6.1"
+            xcode_version: "16.3"
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer
     steps:


### PR DESCRIPTION
## Changes

- Resolve Swift 5.10 / macOS 15 CI errors from deprecated Xcode version
- Add Swift 6.1 jobs