### PR TITLE
Add --quieter-after-error flag

### DIFF
--- a/Sources/xcbeautify/Xcbeautify.swift
+++ b/Sources/xcbeautify/Xcbeautify.swift
@@ -29,6 +29,9 @@ struct Xcbeautify: ParsableCommand {
     @Flag(name: [.long, .customLong("qq", withSingleDash: true)], help: "Only print tasks that have errors.")
     var quieter = false
 
+    @Flag(name: [.customShort("Q"), .long], help: "Switch to quieter mode after the first error is encountered.")
+    var quieterAfterError = false
+
     @Flag(name: [.long], help: "Preserves unbeautified output lines.")
     var preserveUnbeautified = false
 
@@ -89,7 +92,7 @@ struct Xcbeautify: ParsableCommand {
             )
         }
 
-        let output = OutputHandler(quiet: quiet, quieter: quieter, isCI: isCI) { print($0) }
+        let output = OutputHandler(quiet: quiet, quieter: quieter, quieterAfterError: quieterAfterError, isCI: isCI) { print($0) }
         let junitReporter = JUnitReporter()
 
         let parser = Parser()


### PR DESCRIPTION
## Summary
- Implements a new `--quieter-after-error` flag with `-Q` short option
- Switches to quieter mode dynamically after the first error is encountered
- Initially displays all output normally, then suppresses warnings and tasks after errors

## Usage
```bash
xcodebuild test ... | xcbeautify --quieter-after-error
# or
xcodebuild test ... | xcbeautify -Q
```

## Behavior
- **Before first error**: Shows all output (tasks, warnings, errors, results)
- **After first error**: Switches to quieter mode (only errors, results, test outcomes)
- **Maintains context**: Task banners still appear for subsequent errors
- **Backward compatible**: Does not affect existing `--quiet` and `--quieter` modes

## Implementation Details
- Added new CLI flag using ArgumentParser
- Extended `OutputHandler` with error state tracking
- Dynamic mode switching based on error detection
- Comprehensive test coverage for all scenarios

## Test plan
- [x] All existing tests pass
- [x] New tests cover the feature behavior
- [x] Code passes SwiftFormat linting
- [x] Build succeeds without warnings

🤖 Generated with [Claude Code](https://claude.ai/code)