### PR TITLE
Add Objective-C parallel test failure capture group (#486)

### DIFF
--- a/Sources/XcbeautifyLib/CaptureGroups.swift
+++ b/Sources/XcbeautifyLib/CaptureGroups.swift
@@ -1248,6 +1248,34 @@ struct PackageUpdatingCaptureGroup: CaptureGroup {
     }
 }
 
+struct ParallelTestCaseAppKitFailedCaptureGroup: TestCaseCaptureGroup, JUnitParallelReportable {
+    static let outputType: OutputType = .testCaseFailure
+
+    /// Regular expression captured groups:
+    /// $1 = suite
+    /// $2 = test case
+    /// $3 = time
+    static let regex = XCRegex(pattern: #"^\s*Test case\s'-\[(.*?)\s(.*)\]'\sfailed\son\s'.*'\s\((\d*\.\d{3})\sseconds\)"#)
+
+    let suite: String
+    let testCase: String
+    let time: String
+
+    init?(groups: [String]) {
+        assert(groups.count >= 3)
+        guard let suite = groups[safe: 0], let testCase = groups[safe: 1], let time = groups[safe: 2] else { return nil }
+        self.suite = suite
+        self.testCase = testCase
+        self.time = time
+    }
+
+    func junitComponent() -> JUnitComponent {
+        // Parallel tests do not provide meaningful failure messages
+        let testCase = TestCase(classname: suite, name: testCase, time: nil, failure: .init(message: "Parallel test failed"))
+        return .failingTest(testCase)
+    }
+}
+
 struct ParallelTestCaseAppKitPassedCaptureGroup: TestCaseCaptureGroup {
     static let outputType: OutputType = .testCasePass
 

--- a/Sources/XcbeautifyLib/Formatter.swift
+++ b/Sources/XcbeautifyLib/Formatter.swift
@@ -161,6 +161,8 @@ package struct Formatter {
             return renderer.formatPackageStart()
         case let group as PackageUpdatingCaptureGroup:
             return renderer.formatPackageUpdating(group: group)
+        case let group as ParallelTestCaseAppKitFailedCaptureGroup:
+            return renderer.formatParallelTestCaseAppKitFailed(group: group)
         case let group as ParallelTestCaseAppKitPassedCaptureGroup:
             return renderer.formatParallelTestCaseAppKitPassed(group: group)
         case let group as ParallelTestCaseFailedCaptureGroup:

--- a/Sources/XcbeautifyLib/Parser.swift
+++ b/Sources/XcbeautifyLib/Parser.swift
@@ -76,6 +76,7 @@ package final class Parser {
         PackageGraphResolvingEndedCaptureGroup.self,
         PackageGraphResolvingStartCaptureGroup.self,
         PackageUpdatingCaptureGroup.self,
+        ParallelTestCaseAppKitFailedCaptureGroup.self,
         ParallelTestCaseAppKitPassedCaptureGroup.self,
         ParallelTestCaseFailedCaptureGroup.self,
         ParallelTestCasePassedCaptureGroup.self,

--- a/Sources/XcbeautifyLib/Renderers/Microsoft/MicrosoftOutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/Microsoft/MicrosoftOutputRendering.swift
@@ -169,6 +169,16 @@ extension MicrosoftOutputRendering {
         )
     }
 
+    func formatParallelTestCaseAppKitFailed(group: ParallelTestCaseAppKitFailedCaptureGroup) -> String {
+        let testCase = group.testCase
+        let time = group.time
+        let message = "    \(testCase) (\(time) seconds)"
+        return makeOutputLog(
+            annotation: .error,
+            message: message
+        )
+    }
+
     func formatParallelTestingFailed(group: ParallelTestingFailedCaptureGroup) -> String {
         makeOutputLog(
             annotation: .error,

--- a/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
+++ b/Sources/XcbeautifyLib/Renderers/OutputRendering.swift
@@ -65,6 +65,7 @@ protocol OutputRendering {
     func formatPackageItem(group: PackageGraphResolvedItemCaptureGroup) -> String
     func formatPackageStart() -> String
     func formatPackageUpdating(group: PackageUpdatingCaptureGroup) -> String
+    func formatParallelTestCaseAppKitFailed(group: ParallelTestCaseAppKitFailedCaptureGroup) -> String
     func formatParallelTestCaseAppKitPassed(group: ParallelTestCaseAppKitPassedCaptureGroup) -> String
     func formatParallelTestCaseFailed(group: ParallelTestCaseFailedCaptureGroup) -> String
     func formatParallelTestCasePassed(group: ParallelTestCasePassedCaptureGroup) -> String
@@ -528,6 +529,14 @@ extension OutputRendering {
         let time = group.time
 
         return formatParallelTestCase(result: TestStatus.pass, suite: suite, testCase: testCase, device: nil, time: time)
+    }
+
+    func formatParallelTestCaseAppKitFailed(group: ParallelTestCaseAppKitFailedCaptureGroup) -> String {
+        let suite = group.suite
+        let testCase = group.testCase
+        let time = group.time
+
+        return formatParallelTestCase(result: TestStatus.fail, suite: suite, testCase: testCase, device: nil, time: time)
     }
 
     func formatParallelTestCaseFailed(group: ParallelTestCaseFailedCaptureGroup) -> String {

--- a/Tests/XcbeautifyLibTests/FormattedStringTests.swift
+++ b/Tests/XcbeautifyLibTests/FormattedStringTests.swift
@@ -455,6 +455,14 @@ struct FormattedStringTests {
         #expect(colored == expected)
     }
 
+    @Test func parallelTestCaseAppKitFailedWithRedStatus() {
+        let input = "Test case '-[MyTests testFailure]' failed on 'My Mac - xctest (99082)' (0.010 seconds)"
+        let colored = coloredFormatted(input)
+
+        let expected = "\(Format.indent)\(redStart)✖\(reset) [\(cyanStart)MyTests\(reset)] testFailure (0.010 seconds)"
+        #expect(colored == expected)
+    }
+
     @Test func parallelTestCaseSkippedWithYellowStatus() {
         let input = "Test case 'MyTests.testSkipped()' skipped on 'iPhone 15 Simulator' (0.001 seconds)"
         let colored = coloredFormatted(input)

--- a/Tests/XcbeautifyLibTests/JUnitReporterTests.swift
+++ b/Tests/XcbeautifyLibTests/JUnitReporterTests.swift
@@ -845,4 +845,18 @@ struct JUnitReporterTests {
         #expect(testCase.skipped != nil)
         #expect(testCase.failure == nil)
     }
+
+    @Test func parallelTestCaseAppKitFailedJUnitComponent() throws {
+        let group = try #require(ParallelTestCaseAppKitFailedCaptureGroup(groups: ["MySuite", "testMyFailure", "0.001"]))
+        let component = group.junitComponent()
+        guard case let .failingTest(testCase) = component else {
+            Issue.record("Expected .failingTest but got \(component)")
+            return
+        }
+        #expect(testCase.classname == "MySuite")
+        #expect(testCase.name == "testMyFailure")
+        #expect(testCase.time == nil)
+        #expect(testCase.skipped == nil)
+        #expect(testCase.failure?.message == "Parallel test failed")
+    }
 }

--- a/Tests/XcbeautifyLibTests/ParserTests.swift
+++ b/Tests/XcbeautifyLibTests/ParserTests.swift
@@ -342,6 +342,13 @@ struct ParserTests {
         #expect(resultFailed.testCase == "exampleFalse")
     }
 
+    @Test func parseObjectiveCParallelTestOutputFailed() throws {
+        let resultFailed = try #require(parser.parse(line: "Test case '-[LPSceneLayerMoveGestureRecognizerTests testOptionDragDuplicationCopiesAndReplacesDraggingLayersWithPastedLayers]' failed on 'My Mac - xctest (99082)' (0.974 seconds)") as? ParallelTestCaseAppKitFailedCaptureGroup)
+        #expect(resultFailed.suite == "LPSceneLayerMoveGestureRecognizerTests")
+        #expect(resultFailed.time == "0.974")
+        #expect(resultFailed.testCase == "testOptionDragDuplicationCopiesAndReplacesDraggingLayersWithPastedLayers")
+    }
+
     @Test func precompileModule() throws {
         let input = try #require(parser.parse(line: "PrecompileModule /Users/Some/Random-Path/_To/A/Build/Intermediates.noindex/ExplicitPrecompileModules/file-ABC123.scan") as? PrecompileModuleCaptureGroup)
         #expect(input.path == "/Users/Some/Random-Path/_To/A/Build/Intermediates.noindex/ExplicitPrecompileModules/file-ABC123.scan")

--- a/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/AzureDevOpsPipelinesRendererTests.swift
@@ -384,6 +384,11 @@ struct AzureDevOpsPipelinesRendererTests {
         #expect(formatted == "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
     }
 
+    @Test func parallelTestCaseAppKitFailed() {
+        let formatted = logFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' failed on 'xctest (49438)' (0.131 seconds)")
+        #expect(formatted == "##vso[task.logissue type=error]    testBuildTarget (0.131 seconds)")
+    }
+
     @Test func parallelTestingStarted() {
         let formatted = logFormatted("Testing started on 'iPhone X'")
         #expect(formatted == "Testing started on 'iPhone X'")

--- a/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/GitHubActionsRendererTests.swift
@@ -393,6 +393,11 @@ struct GitHubActionsRendererTests {
         #expect(formatted == "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
     }
 
+    @Test func parallelTestCaseAppKitFailed() {
+        let formatted = logFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' failed on 'xctest (49438)' (0.131 seconds)")
+        #expect(formatted == "::error ::    testBuildTarget (0.131 seconds)")
+    }
+
     @Test func parallelTestingStarted() {
         let formatted = logFormatted("Testing started on 'iPhone X'")
         #expect(formatted == "Testing started on 'iPhone X'")

--- a/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TeamCityRendererTests.swift
@@ -382,6 +382,11 @@ struct TeamCityRendererTests {
         #expect(formatted == "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
     }
 
+    @Test func parallelTestCaseAppKitFailed() {
+        let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' failed on 'xctest (49438)' (0.131 seconds)")
+        #expect(formatted == "    ✖ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
+    }
+
     @Test func parallelTestCaseAppKitWithSpacesPassed() {
         let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests test build target]' passed on 'xctest (49438)' (0.131 seconds).")
         #expect(formatted == "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] test build target (0.131 seconds)")

--- a/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
+++ b/Tests/XcbeautifyLibTests/RendererTests/TerminalRendererTests.swift
@@ -387,6 +387,11 @@ struct TerminalRendererTests {
         #expect(formatted == "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
     }
 
+    @Test func parallelTestCaseAppKitFailed() {
+        let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests testBuildTarget]' failed on 'xctest (49438)' (0.131 seconds)")
+        #expect(formatted == "    ✖ [XcbeautifyLibTests.XcbeautifyLibTests] testBuildTarget (0.131 seconds)")
+    }
+
     @Test func parallelTestCaseAppKitWithSpacesPassed() {
         let formatted = noColoredFormatted("Test case '-[XcbeautifyLibTests.XcbeautifyLibTests test build target]' passed on 'xctest (49438)' (0.131 seconds).")
         #expect(formatted == "    ✔ [XcbeautifyLibTests.XcbeautifyLibTests] test build target (0.131 seconds)")


### PR DESCRIPTION
## Summary

Fixes a gap in parallel XCTest parsing where Objective-C AppKit-style failure lines were not captured or rendered.

Before this change, lines like:

```text
Test case '-[LPSceneLayerMoveGestureRecognizerTests testOptionDragDuplicationCopiesAndReplacesDraggingLayersWithPastedLayers]' failed on 'My Mac - xctest (99082)' (0.974 seconds)
```

were dropped, even though the matching `passed on` form was already supported.

This is a fairly critical failure mode because it hides failing tests from formatted output, effectively creating a silent failure. In my own setup, this caused me to miss a number of failing tests before I tracked the issue down to xcbeautify.

Closes #486.

## What Changed

- Added `ParallelTestCaseAppKitFailedCaptureGroup`
- Registered the new capture group in `Parser.captureGroupTypes`
- Wired the new capture group through `Formatter`
- Added default renderer formatting for the AppKit-style parallel failure case
- Added Microsoft renderer overrides so GitHub Actions and Azure DevOps continue to emit annotated failure output
- Added focused test coverage for:
  - parser recognition
  - terminal rendering
  - TeamCity rendering
  - GitHub Actions rendering
  - Azure DevOps rendering
  - colored formatted output
  - JUnit component generation

## Why

`xcbeautify` already handled AppKit-style parallel Objective-C `passed on` lines, but not the corresponding `failed on` lines. When parallelization is enabled, that meant real test failures could disappear from formatted output.

Because the failure is omission rather than malformed output, it is easy to miss in practice: the formatter simply hides the failing test line. That makes this more severe than a cosmetic formatting bug.

## Validation

Ran:

```text
./tools/check-sorted
swift test --filter RendererTests
swift test --filter JUnitReporterTests
swift test
```

All passed.
